### PR TITLE
First go at an overengineered hosting shortcut

### DIFF
--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -5,8 +5,16 @@ $optionsRepoUrl = 'https://api.github.com/repos/TheEadie/WormsLeague/releases/la
 $installDirPath = 'C:\Program Files (x86)\Steam\steamapps\common\Worms Armageddon\'
 $schemesDirPath = Join-Path $installDirPath '\User\Schemes\'
 
+#Gets the ip that'd actually be used rather than random virtual netadapters.
+function Get-Ip() {
+	$pingResponse = (ping -4 -n 1 $env:computername)[1]
+	$ipStart = $pingResponse.IndexOf("[") + 1 # Hopefully the machine name doesn't contain "[" or "]"
+	$ipLength = $pingResponse.IndexOf("]") - $ipStart
+	return $pingResponse.SubString($ipStart, $ipLength)
+}
+
 function Send-Slack() {
-	$ip = (ipconfig | grep "10.120" -m 1).Substring(39)
+	$ip = Get-Ip
 	$messageText = "Hosting at: $ip"
 	$message = @{token=$yourSecretSlackToken; channel=$channel; text=$messageText; as_user=$true}
 	Invoke-RestMethod -Uri https://slack.com/api/chat.postMessage -Body $message

--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -32,13 +32,7 @@ function Update-Options() {
 }
 
 function Start-Worms() {
-    # See http://worms2d.info/Command-line_options
-    #
-    # The scheme parameter is documented here:
-    # http://worms2d.info/WormNET_(Worms_Armageddon)#Channels
-    #
-    # 'We' means 4 worms per team (don't ask)
-    & $wa wa:host?scheme=We
+    & $wa /host
 }
 
 Send-Slack

--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -15,7 +15,7 @@ function Get-Ip() {
 
 function Send-Slack() {
 	$ip = Get-Ip
-	$messageText = "Hosting at: $ip"
+	$messageText = "@here Hosting at: $ip"
 	$message = @{token=$yourSecretSlackToken; channel=$channel; text=$messageText; as_user=$true}
 	Invoke-RestMethod -Uri https://slack.com/api/chat.postMessage -Body $message
 }

--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -1,11 +1,8 @@
 $yourSecretSlackToken = 'ENTER YOUR SECRET SLACK TOKEN' # Get from https://api.slack.com/web#authentication
+
 $channel = '#games-worms'
-
 $optionsRepoUrl = 'https://api.github.com/repos/TheEadie/WormsLeague/releases/latest'
-
 $installDirPath = (Get-ItemProperty HKCU:\SOFTWARE\Team17SoftwareLTD\WormsArmageddon).PATH
-$wa = Join-Path $installDirPath 'WA.exe'
-$schemesDirPath = Join-Path $installDirPath '\User\Schemes\'
 
 function Get-Ip() {
     return Get-NetAdapter -Physical | 
@@ -22,6 +19,7 @@ function Send-Slack() {
 }
 
 function Update-Options() {
+    $schemesDirPath = Join-Path $installDirPath '\User\Schemes\'
     $latestrelease = Invoke-RestMethod $optionsRepoUrl
     $latestrelease.assets | 
         where {$_.name -like "*.wsc"} |
@@ -32,6 +30,7 @@ function Update-Options() {
 }
 
 function Start-Worms() {
+    $wa = Join-Path $installDirPath 'WA.exe'
     & $wa /host
 }
 

--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -1,0 +1,30 @@
+$yourSecretSlackToken = 'ENTER YOUR SECRET SLACK TOKEN' # Get from https://api.slack.com/web#authentication
+
+$channel = '#games-worms'
+$optionsRepoUrl = 'https://api.github.com/repos/TheEadie/WormsLeague/releases/latest'
+$installDirPath = 'C:\Program Files (x86)\Steam\steamapps\common\Worms Armageddon\'
+$schemesDirPath = Join-Path $installDirPath '\User\Schemes\'
+
+function Send-Slack() {
+	$ip = (ipconfig | grep "10.120" -m 1).Substring(39)
+	$messageText = "Hosting at: $ip"
+	$message = @{token=$yourSecretSlackToken; channel=$channel; text=$messageText; as_user=$true}
+	Invoke-RestMethod -Uri https://slack.com/api/chat.postMessage -Body $message
+}
+
+function Update-Options() {
+	$latestrelease = invoke-restmethod $optionsRepoUrl
+	$optionsFiles = $latestrelease.assets | Where-Object {$_.name -like "*.wsc"}
+	foreach ($file in $optionsFiles) { 
+		Write-Host $file.name
+		curl $file.browser_download_url -OutFile (Join-Path $schemesDirPath $file.name)
+	}
+}
+
+function Start-Worms() {
+	Start-Process (Join-Path $installDirPath "WA.exe") "/host"
+}
+
+Send-Slack
+Update-Options
+Start-Worms


### PR DESCRIPTION
It's a bit annoying to update since the token is directly in the same file as the script, but putting it in a different one would mean someone isn't forced to look at the script before giving away an auth token to it

It's also handy to make powershell scripts [open with powershell by default](http://www.howtogeek.com/204166/how-to-configure-windows-to-work-with-powershell-scripts-more-easily/)

Running the script:
* Posts a slack message to #games-worms with your ip address
* Updates the options from TheEadie's releases
* Starts Worms Armageddon

Works on my machine.