### PR TITLE
Make the editable options params

### DIFF
--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -1,7 +1,9 @@
-$yourSecretSlackToken = 'ENTER YOUR SECRET SLACK TOKEN' # Get from https://api.slack.com/web#authentication
+param(
+	$yourSecretSlackToken = 'ENTER YOUR SECRET SLACK TOKEN', # Get from https://api.slack.com/web#authentication
+	$channel = '#games-worms',
+	$optionsRepoUrl = 'https://api.github.com/repos/TheEadie/WormsLeague/releases/latest'
+)
 
-$channel = '#games-worms'
-$optionsRepoUrl = 'https://api.github.com/repos/TheEadie/WormsLeague/releases/latest'
 $installDirPath = (Get-ItemProperty HKCU:\SOFTWARE\Team17SoftwareLTD\WormsArmageddon).PATH
 
 function Get-Ip() {

--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -1,6 +1,6 @@
 param(
-	$yourSecretSlackToken = 'ENTER YOUR SECRET SLACK TOKEN', # Get from https://api.slack.com/web#authentication
-	$channel = '#games-worms',
+	$yourSecretSlackToken, # Get from https://api.slack.com/web#authentication
+	$channel, #E.g. '#games-worms'
 	$optionsRepoUrl = 'https://api.github.com/repos/TheEadie/WormsLeague/releases/latest'
 )
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # WormsLeague
+
+1. Clone/download the repo
+2. Make a desktop shortcut to 
+`%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe "& 'C:\PathToWormsLeagueRepo\HostWormsGame.ps1' 'Secret slack token' '#games-worms'"`
+3. Replace the path to the repo, and insert your [secret slack token](https://api.slack.com/docs/oauth-test-tokens)
+4. Name it something like host worms and set an icon like `"C:\Program Files (x86)\Steam\steamapps\common\Worms Armageddon\User"`
+
+The shortcut will download the latest options, post your IP in the channel specified in the shortcut and start worms - you just need to click OK when it starts to host a game with no password.


### PR DESCRIPTION
Now you can make a link to  
`%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe "& 'C:\PathToWormsLeagueRepo\HostWormsGame.ps1' 'Secret slack token' '#games-worms' "`

(Replacing the path to the repo on your machine and the token)

This means when the script is updated you can just do a pull on the repo

I previously didn't do this because I don't like passing an API token to a black box - but it's not really a black box, people can always review the script as they please since it's powershell. Since it's not self-updating that seems fine to me.