### PR TITLE
Turn the "Hosting at:" IP into a link

### DIFF
--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -15,7 +15,7 @@ function Get-Ip() {
 
 function Send-Slack() {
     $ip = Get-Ip
-    $messageText = "<!here> Hosting at: $ip"
+    $messageText = "<!here> Hosting at: wa://$ip"
     $message = @{token=$yourSecretSlackToken; channel=$channel; text=$messageText; as_user=$true}
     Invoke-RestMethod -Uri https://slack.com/api/chat.postMessage -Body $message
 }


### PR DESCRIPTION
I've written a URL handler that will make links such as [wa://DEV-SAM](wa://DEV-SAM) clickable.  To install the URL handler, you need to adjust the path as necessary and paste the following into a .reg file:
```
Windows Registry Editor Version 5.00
[HKEY_CLASSES_ROOT\wa]
@="URL: WA Protocol handler"
"URL Protocol"=""
[HKEY_CLASSES_ROOT\wa\DefaultIcon]
@="D:\\SteamLibrary\\steamapps\\common\\Worms Armageddon\\WA.exe"
[HKEY_CLASSES_ROOT\wa\shell]
[HKEY_CLASSES_ROOT\wa\shell\open]
[HKEY_CLASSES_ROOT\wa\shell\open\command]
@="\"D:\\SteamLibrary\\steamapps\\common\\Worms Armageddon\\WA.exe\" %1"
```