### PR TITLE
Support Tls12 when downloading options

### DIFF
--- a/HostWormsGame.ps1
+++ b/HostWormsGame.ps1
@@ -28,6 +28,8 @@ function Update-Options() {
         where {$_.name -like "*.wsc"} |
         foreach {
             Write-Host $_.name
+            $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+            [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
             Invoke-WebRequest $_.browser_download_url -OutFile (Join-Path $schemesDirPath $_.name)
         }
 }


### PR DESCRIPTION
GitHub disabled Tls1.0 support so the download options fails. This allows the download to succeed.

I ran without this and got `Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.`

With the change it could download the files successfully