### PR TITLE
Fix off by one error in Mole Bomb

### DIFF
--- a/Uber Coolest Options.txt
+++ b/Uber Coolest Options.txt
@@ -82,7 +82,7 @@ Holy Hand Grenade             Ammo: [1]    Power: [2]    Delay: [5]    Crate pro
 Old Woman                     Ammo: [0]    Power: [2]    Delay: [5]    Crate probability: [1]
 Sheep Launcher                Ammo: [1]    Power: [2]    Delay: [2]    Crate probability: [1]
 Super Sheep                   Ammo: [0]    Power: [2]    Delay: [5]    Crate probability: [1]
-Mole Bomb                     Ammo: [1]    Power: [15]   Delay: [2]    Crate probability: [1]
+Mole Bomb                     Ammo: [1]    Power: [14]   Delay: [2]    Crate probability: [1]
 Jet Pack                      Ammo: [0]    Power: [0]    Delay: [0]    Crate probability: [0]
 Low Gravity                   Ammo: [1]    Power: [0]    Delay: [0]    Crate probability: [0]
 Laser Sight                   Ammo: [0]    Power: [0]    Delay: [0]    Crate probability: [0]


### PR DESCRIPTION
This makes the mole bomb better by increasing damage and blast radius. This was always the intent but an off by one error exists in the power scale part of the schema converter. http://worms2d.info/Mole_Bomb