### PR TITLE
Nerf cluster bombs slightly

### DIFF
--- a/Uber Coolest Options.txt
+++ b/Uber Coolest Options.txt
@@ -48,7 +48,7 @@ Bazooka                       Ammo: [10]   Power: [2]    Delay: [0]    Crate pro
 Homing Missile                Ammo: [1]    Power: [2]    Delay: [0]    Crate probability: [1]
 Mortar                        Ammo: [10]   Power: [4]    Delay: [0]    Crate probability: [0]
 Grenade                       Ammo: [10]   Power: [2]    Delay: [0]    Crate probability: [0]
-Cluster Bomb                  Ammo: [10]   Power: [4]    Delay: [0]    Crate probability: [0]
+Cluster Bomb                  Ammo: [10]   Power: [3]    Delay: [0]    Crate probability: [0]
 Skunk                         Ammo: [1]    Power: [2]    Delay: [0]    Crate probability: [0]
 Petrol Bomb                   Ammo: [2]    Power: [2]    Delay: [0]    Crate probability: [0]
 Banana Bomb                   Ammo: [1]    Power: [2]    Delay: [5]    Crate probability: [1]


### PR DESCRIPTION
There shouldn't be weapons available on first turn that can kill outright. Power 4 = 5 bomblets, each max 22 damage, vs power 5 = 6 bomblets, each max 24 damage. So at power 4 (ie 3 in the txt file) it could still in theory kill in one go but is very unlikely to.