### PR TITLE
Create and delete Schemes

### DIFF
--- a/CommandLine/GitVersion.yml
+++ b/CommandLine/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.8
+next-version: 0.9
 mode: ContinuousDelivery
 tag-prefix: 'cli/v'
 branches: {}

--- a/CommandLine/src/Commands/ConfigurationException.cs
+++ b/CommandLine/src/Commands/ConfigurationException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Worms.Commands
+{
+    public class ConfigurationException : Exception
+    {
+        public ConfigurationException() {}
+
+        public ConfigurationException(string message)
+            : base(message) {}
+
+        public ConfigurationException(string message, Exception inner)
+            : base(message, inner) {}
+    }
+}

--- a/CommandLine/src/Commands/Create.cs
+++ b/CommandLine/src/Commands/Create.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+// ReSharper disable UnusedMember.Global - CLI library uses magic to call OnExecuteAsync()
+
+namespace Worms.Commands
+{
+    [Command("create", Description = "Create a resource")]
+    [Subcommand(typeof(CreateScheme))]
+    internal class Create : CommandBase
+    {
+        public Task<int> OnExecuteAsync(CommandLineApplication app)
+        {
+            Logger.Error("No resource type specified");
+            Logger.Information("");
+            app.ShowHelp();
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/CommandLine/src/Commands/CreateScheme.cs
+++ b/CommandLine/src/Commands/CreateScheme.cs
@@ -20,7 +20,7 @@ namespace Worms.Commands
         private readonly WscWriter _wscWriter;
         private readonly IWormsLocator _wormsLocator;
 
-        [Option(Description = "Name for the Scheme", ShortName = "n")]
+        [Argument(0, Name = "name", Description = "The name of the Scheme to be created")]
         public string Name { get; }
 
         [Option(Description = "File to load the Scheme definition from", ShortName = "f")]

--- a/CommandLine/src/Commands/CreateScheme.cs
+++ b/CommandLine/src/Commands/CreateScheme.cs
@@ -1,8 +1,10 @@
+using System;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using Worms.Resources.Schemes;
 using Worms.WormsArmageddon;
+using Worms.WormsArmageddon.Schemes;
 using Worms.WormsArmageddon.Schemes.WscFiles;
 
 // ReSharper disable MemberCanBePrivate.Global - CLI library uses magic to read members
@@ -53,9 +55,19 @@ namespace Worms.Commands
                 return Task.FromResult(1);
             }
 
-            Logger.Verbose($"Reading Scheme definition from {source}");
-            var schemeReader = new SchemeTextReader();
-            var scheme = schemeReader.GetModel(definition);
+            Scheme scheme;
+
+            try
+            {
+                Logger.Verbose($"Reading Scheme definition from {source}");
+                var schemeReader = new SchemeTextReader();
+                scheme = schemeReader.GetModel(definition);
+            }
+            catch (FormatException exception)
+            {
+                Logger.Error("Failed to read Scheme definition: " + exception.Message);
+                return Task.FromResult(1);
+            }
 
             var outputFilePath = _fileSystem.Path.Combine(outputFolder, name + ".wsc");
             Logger.Information($"Writing Scheme to {outputFilePath}");

--- a/CommandLine/src/Commands/CreateScheme.cs
+++ b/CommandLine/src/Commands/CreateScheme.cs
@@ -13,7 +13,7 @@ using Worms.WormsArmageddon.Schemes.WscFiles;
 
 namespace Worms.Commands
 {
-    [Command("scheme", "schemes", Description = "Create Worms Schemes (.wsc files)")]
+    [Command("scheme", "schemes", "wsc", Description = "Create Worms Schemes (.wsc files)")]
     internal class CreateScheme : CommandBase
     {
         private readonly IFileSystem _fileSystem;

--- a/CommandLine/src/Commands/CreateScheme.cs
+++ b/CommandLine/src/Commands/CreateScheme.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Worms.Logging;
+using Worms.Resources.Schemes;
+using Worms.WormsArmageddon;
+using Worms.WormsArmageddon.Schemes.WscFiles;
+
+// ReSharper disable MemberCanBePrivate.Global - CLI library uses magic to read members
+// ReSharper disable UnassignedGetOnlyAutoProperty - CLI library uses magic to set members
+// ReSharper disable UnusedMember.Global - CLI library uses magic to call OnExecuteAsync()
+
+namespace Worms.Commands
+{
+    [Command("scheme", "schemes", Description = "Create Worms Schemes (.wsc files)")]
+    internal class CreateScheme : CommandBase
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly WscWriter _wscWriter;
+        private readonly IWormsLocator _wormsLocator;
+
+        [Argument(0, Description = "", Name = "name")]
+        public string Name { get; }
+
+        [Option(
+            Description = "If set the scheme definition will be loaded from this file",
+            ShortName = "f")]
+        public string FilePath { get; }
+
+        public CreateScheme(IFileSystem fileSystem, WscWriter wscWriter, IWormsLocator wormsLocator)
+        {
+            _fileSystem = fileSystem;
+            _wscWriter = wscWriter;
+            _wormsLocator = wormsLocator;
+        }
+
+        public Task<int> OnExecuteAsync(IConsole console)
+        {
+            var definition = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                Logger.Error("No name provided for the scheme being created.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(FilePath))
+            {
+                definition = _fileSystem.File.ReadAllText(FilePath);
+            }
+            else if (console.IsInputRedirected)
+            {
+                definition = console.In.ReadToEnd();
+            }
+            else
+            {
+                Logger.Error("No scheme definition provided");
+                Task.FromResult(1);
+            }
+
+            var gameInfo = _wormsLocator.Find();
+
+            var schemeReader = new SchemeTextReader();
+            var scheme = schemeReader.GetModel(definition);
+
+            _wscWriter.WriteModel(scheme, _fileSystem.Path.Combine(gameInfo.SchemesFolder , Name + ".wsc"));
+
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/CommandLine/src/Commands/Delete.cs
+++ b/CommandLine/src/Commands/Delete.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+// ReSharper disable UnusedMember.Global - CLI library uses magic to call OnExecuteAsync()
+
+namespace Worms.Commands
+{
+    [Command("delete", "rm", Description = "Delete a resource")]
+    [Subcommand(typeof(DeleteScheme))]
+    internal class Delete : CommandBase
+    {
+        public Task<int> OnExecuteAsync(CommandLineApplication app)
+        {
+            Logger.Error("No resource type specified");
+            Logger.Information("");
+            app.ShowHelp();
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/CommandLine/src/Commands/DeleteScheme.cs
+++ b/CommandLine/src/Commands/DeleteScheme.cs
@@ -10,7 +10,7 @@ using Worms.WormsArmageddon.Schemes.WscFiles;
 
 namespace Worms.Commands
 {
-    [Command("scheme", "schemes", Description = "Delete Worms Schemes (.wsc files)")]
+    [Command("scheme", "schemes", "wsc", Description = "Delete Worms Schemes (.wsc files)")]
     internal class DeleteScheme : CommandBase
     {
         private readonly IFileSystem _fileSystem;

--- a/CommandLine/src/Commands/DeleteScheme.cs
+++ b/CommandLine/src/Commands/DeleteScheme.cs
@@ -1,0 +1,77 @@
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Worms.WormsArmageddon;
+using Worms.WormsArmageddon.Schemes.WscFiles;
+
+// ReSharper disable MemberCanBePrivate.Global - CLI library uses magic to read members
+// ReSharper disable UnassignedGetOnlyAutoProperty - CLI library uses magic to set members
+// ReSharper disable UnusedMember.Global - CLI library uses magic to call OnExecuteAsync()
+
+namespace Worms.Commands
+{
+    [Command("scheme", "schemes", Description = "Delete Worms Schemes (.wsc files)")]
+    internal class DeleteScheme : CommandBase
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly IWormsLocator _wormsLocator;
+
+        [Argument(0, Name = "name", Description = "The name of the Scheme to be deleted")]
+        public string Name { get; }
+
+        public DeleteScheme(IFileSystem fileSystem, WscWriter wscWriter, IWormsLocator wormsLocator)
+        {
+            _fileSystem = fileSystem;
+            _wormsLocator = wormsLocator;
+        }
+
+        public Task<int> OnExecuteAsync(IConsole console)
+        {
+            string filePath;
+
+            try
+            {
+                var name = ValidateName();
+                filePath = GetFilePath(name);
+            }
+            catch (ConfigurationException exception)
+            {
+                Logger.Error(exception.Message);
+                return Task.FromResult(1);
+            }
+
+            _fileSystem.File.Delete(filePath);
+            return Task.FromResult(0);
+        }
+
+        private string GetFilePath(string name)
+        {
+            var gameInfo = _wormsLocator.Find();
+
+            if (!gameInfo.IsInstalled)
+            {
+                throw new ConfigurationException(
+                    "Worms is not installed.");
+            }
+
+            var filePath = _fileSystem.Path.Combine(gameInfo.SchemesFolder, name + ".wsc");
+
+            if (!_fileSystem.File.Exists(filePath))
+            {
+                throw new ConfigurationException($"No Scheme file found with name: {name}");
+            }
+
+            return filePath;
+        }
+
+        private string ValidateName()
+        {
+            if (!string.IsNullOrWhiteSpace(Name))
+            {
+                return Name;
+            }
+
+            throw new ConfigurationException("No name provided for the Scheme to be deleted.");
+        }
+    }
+}

--- a/CommandLine/src/Commands/GetScheme.cs
+++ b/CommandLine/src/Commands/GetScheme.cs
@@ -20,9 +20,9 @@ namespace Worms.Commands
 
         [Argument(
             0,
+            Name = "name",
             Description =
-                "Optional: The name or search pattern for the Scheme to be retrieved. Wildcards (*) are supported",
-            Name = "name")]
+                "Optional: The name or search pattern for the Scheme to be retrieved. Wildcards (*) are supported")]
         public string Name { get; }
 
         public GetScheme(ISchemesRetriever schemesRetriever, IResourcePrinter<SchemeResource> printer)
@@ -37,13 +37,14 @@ namespace Worms.Commands
             {
                 var windowWidth = Console.WindowWidth == 0 ? 80 : Console.WindowWidth;
                 PrintScheme(Name, console.Out, windowWidth);
-                return Task.FromResult(0);
             }
-            catch (ArgumentException exception)
+            catch (ConfigurationException exception)
             {
                 Logger.Error(exception.Message);
                 return Task.FromResult(1);
             }
+
+            return Task.FromResult(0);
         }
 
         private void PrintScheme(string name, TextWriter writer, int outputMaxWidth)
@@ -57,8 +58,7 @@ namespace Worms.Commands
                 switch (matches.Count)
                 {
                     case 0:
-                        Logger.Error($"No Scheme found with name: {name}");
-                        break;
+                        throw new ConfigurationException($"No Scheme found with name: {name}");
                     case 1:
                         _printer.Print(writer, matches.Single(), outputMaxWidth);
                         break;

--- a/CommandLine/src/Commands/GetScheme.cs
+++ b/CommandLine/src/Commands/GetScheme.cs
@@ -12,7 +12,7 @@ using Worms.Resources.Schemes;
 
 namespace Worms.Commands
 {
-    [Command("scheme", "schemes", Description = "Retrieves information for Worms Schemes (.wsc files)")]
+    [Command("scheme", "schemes", "wsc", Description = "Retrieves information for Worms Schemes (.wsc files)")]
     internal class GetScheme : CommandBase
     {
         private readonly ISchemesRetriever _schemesRetriever;

--- a/CommandLine/src/Commands/Root.cs
+++ b/CommandLine/src/Commands/Root.cs
@@ -9,6 +9,7 @@ namespace Worms.Commands
     [Command("worms", Description = "Worms CLI")]
     [Subcommand(typeof(Get))]
     [Subcommand(typeof(Create))]
+    [Subcommand(typeof(Delete))]
     [Subcommand(typeof(Version))]
     [Subcommand(typeof(Update))]
     [Subcommand(typeof(Host))]

--- a/CommandLine/src/Commands/Root.cs
+++ b/CommandLine/src/Commands/Root.cs
@@ -8,6 +8,7 @@ namespace Worms.Commands
 {
     [Command("worms", Description = "Worms CLI")]
     [Subcommand(typeof(Get))]
+    [Subcommand(typeof(Create))]
     [Subcommand(typeof(Version))]
     [Subcommand(typeof(Update))]
     [Subcommand(typeof(Host))]

--- a/CommandLine/src/Container/CliModule.cs
+++ b/CommandLine/src/Container/CliModule.cs
@@ -39,6 +39,7 @@ namespace Worms.Container
             builder.RegisterType<DefaultSchemesPrinter>().As<IResourcePrinter<SchemeResource>>();
             builder.RegisterType<LocalSchemesRetriever>().As<ISchemesRetriever>();
             builder.RegisterType<WscReader>();
+            builder.RegisterType<WscWriter>();
         }
 
         private static void RegisterOsModules(ContainerBuilder builder)

--- a/CommandLine/src/Logging/DefaultSchemesPrinter.cs
+++ b/CommandLine/src/Logging/DefaultSchemesPrinter.cs
@@ -33,9 +33,6 @@ namespace Worms.Logging
         public void Print(TextWriter writer, SchemeResource item, int outputMaxWidth)
         {
             WriteHeader(writer, "GENERAL");
-            WriteItem(writer, "Name", item.Name);
-            WriteItem(writer, "Context", item.Context);
-            writer.WriteLine();
             WriteItem(writer, "Hot seat delay", item.Details.HotSeatDelay);
             WriteItem(writer, "Retreat time", item.Details.RetreatTime, "Seconds");
             WriteItem(writer, "Rope retreat time", item.Details.RopeRetreatTime, "Seconds");

--- a/CommandLine/src/Resources/Schemes/SchemeTextReader.cs
+++ b/CommandLine/src/Resources/Schemes/SchemeTextReader.cs
@@ -1,0 +1,125 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Worms.WormsArmageddon.Schemes;
+
+namespace Worms.Resources.Schemes
+{
+    public class SchemeTextReader
+    {
+        public Scheme GetModel(string definition)
+        {
+            using var b = new StringReader(definition);
+
+            const string signature = "SCHM";
+            const int version = 2;
+
+            // Skip over some heading lines
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+
+            var hotSeatDelay = GetInt(b);
+            var retreatTime = GetInt(b);
+            var ropeRetreatTime = GetInt(b);
+            var displayTotalRoundTime = GetBool(b);
+            var automaticReplays = GetBool(b);
+            var fallDamage = GetInt(b);
+            var artilleryMode = GetBool(b);
+            var stockpilingMode = GetByte(b);
+            var wormSelect = GetByte(b);
+            var suddenDeathEvent = GetByte(b);
+            var waterRiseRate = GetInt(b);
+            var weaponCrateProb = GetInt(b);
+            var healthCrateProb = GetInt(b);
+            var utilityCrateProb = GetInt(b);
+            var healthCrateEnergy = GetInt(b);
+            var donorCards = GetBool(b);
+            var hazardObjects = GetInt(b);
+            var mineDelay = GetInt(b);
+            var dudMines = GetBool(b);
+            var wormPlacement = GetBool(b);
+            var initialWormEnergy = GetInt(b);
+            var turnTime = GetInt(b);
+            var roundTime = GetInt(b);
+            var numberOfRounds = GetInt(b);
+            var blood = GetBool(b);
+            var aquaSheep = GetBool(b);
+            var sheepHeaven = GetBool(b);
+            var godWorms = GetBool(b);
+            var indestructibleLand = GetBool(b);
+            var upgradedGrenade = GetBool(b);
+            var upgradedShotgun = GetBool(b);
+            var upgradedClusters = GetBool(b);
+            var upgradedLongbow = GetBool(b);
+            var teamWeapons = GetBool(b);
+            var superWeapons = GetBool(b);
+
+            // Skip over the middle heading
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+            b.ReadLine();
+
+            var weapons = new List<Weapon>();
+
+            foreach (var weaponName in Weapons.AllWeapons)
+            {
+                var values = GetInts(b);
+                var ammo = values[0];
+                var power = values[1];
+                var delay = values[2];
+                var crateProb = values[3];
+
+                weapons.Add(new Weapon(weaponName, ammo, power, delay, crateProb));
+            }
+
+            return new Scheme(signature, version, hotSeatDelay, retreatTime, ropeRetreatTime,
+                displayTotalRoundTime,
+                automaticReplays, fallDamage, artilleryMode, stockpilingMode, wormSelect, suddenDeathEvent,
+                waterRiseRate, weaponCrateProb, donorCards, healthCrateProb, healthCrateEnergy, utilityCrateProb,
+                hazardObjects, mineDelay, dudMines, wormPlacement, initialWormEnergy, turnTime, roundTime,
+                numberOfRounds, blood, aquaSheep, sheepHeaven, godWorms, indestructibleLand, upgradedGrenade,
+                upgradedShotgun, upgradedClusters, upgradedLongbow, teamWeapons, superWeapons,
+                weapons);
+        }
+
+        private static byte GetByte(TextReader b)
+        {
+            return (byte)GetInt(b);
+        }
+
+        private static bool GetBool(TextReader b)
+        {
+            return bool.Parse(GetValue(b.ReadLine()));
+        }
+
+        private static int GetInt(TextReader b)
+        {
+            return int.Parse(GetValue(b.ReadLine()));
+        }
+
+        private static int[] GetInts(TextReader b)
+        {
+            var values = new int[4];
+            var line = b.ReadLine();
+            values[0] = int.Parse(GetValue(line.Substring(0, 44)));
+            values[1] = int.Parse(GetValue(line.Substring(44, 10)));
+            values[2] = int.Parse(GetValue(line.Substring(55, 20)));
+            values[3] = int.Parse(GetValue(line.Substring(75, line.Length - 75)));
+
+            return values;
+        }
+
+        private static string GetValue(string text)
+        {
+            var startIndex = text.IndexOf('[') + 1;
+            var endIndex = text.IndexOf(']');
+            var substring = text.Substring(startIndex, endIndex - startIndex);
+            return substring;
+        }
+    }
+}


### PR DESCRIPTION
Adds support for creating schemes from a definition provided by stdin or from a file

`worms get scheme test | worms create scheme -n test-copy`
`worms create scheme -n test -f test.txt`

Add support for deleting schemes by name

`worms delete scheme test`
`worms rm scheme test`