### PR TITLE
Work around issue with extnded options

### DIFF
--- a/CommandLine/src/Resources/Schemes/Binary/WscReader.cs
+++ b/CommandLine/src/Resources/Schemes/Binary/WscReader.cs
@@ -6,7 +6,16 @@ namespace Worms.Resources.Schemes.Binary
     {
         public Scheme Read(string path)
         {
-            return new Scheme(path);
+            var scheme = new Scheme(path);
+
+            // This value incorrectly defaults to false in the 3rd party library
+            // when the scheme is Version 1
+            if (scheme.Version == SchemeVersion.Version1)
+            {
+                scheme.Extended.FiringPausesTimer = true;
+            }
+
+            return scheme;
         }
     }
 }

--- a/CommandLine/src/Resources/Schemes/Text/SchemeTextReader.cs
+++ b/CommandLine/src/Resources/Schemes/Text/SchemeTextReader.cs
@@ -77,6 +77,9 @@ namespace Worms.Resources.Schemes.Text
                 scheme.Weapons[weaponName].Prob = prob;
             }
 
+            // This value incorrectly defaults to false in the 3rd party library
+            scheme.Extended.FiringPausesTimer = true;
+
             return scheme;
         }
 


### PR DESCRIPTION
The default value for `FiringPausesTimer` is wrong in the 3rd party library. This works around the issue while I work out how to contribute a fix.