### PR TITLE
Fix null ref when Replay winner is null

### DIFF
--- a/CommandLine/src/Worms.Armageddon.Game/Windows/SteamService.cs
+++ b/CommandLine/src/Worms.Armageddon.Game/Windows/SteamService.cs
@@ -6,9 +6,9 @@ namespace Worms.Armageddon.Game.Windows
 {
     internal class SteamService : ISteamService
     {
-        private const string _processName = "Steam";
+        private const string ProcessName = "Steam";
 
-        private static readonly Regex _launchGamePromptRegex = new Regex(
+        private static readonly Regex LaunchGamePromptRegex = new Regex(
             "Allow game launch\\?",
             RegexOptions.IgnoreCase);
 
@@ -27,8 +27,8 @@ namespace Worms.Armageddon.Game.Windows
 
         private static IntPtr GetSteamPromptWindow()
         {
-            var windows = WindowTools.GetWindowsWithTitleMatching(_launchGamePromptRegex);
-            return Array.Find(windows, w => WindowTools.GetProcessForWindow(w).ProcessName == _processName);
+            var windows = WindowTools.GetWindowsWithTitleMatching(LaunchGamePromptRegex);
+            return Array.Find(windows, w => WindowTools.GetProcessForWindow(w).ProcessName == ProcessName);
         }
     }
 }

--- a/CommandLine/src/Worms.Armageddon.Resources/Replays/ReplayResourceBuilder.cs
+++ b/CommandLine/src/Worms.Armageddon.Resources/Replays/ReplayResourceBuilder.cs
@@ -9,7 +9,7 @@ namespace Worms.Armageddon.Resources.Replays
         private DateTime _start;
         private readonly List<Team> _teams = new();
         private readonly List<Turn> _turns = new();
-        private string _winner = "";
+        private string _winner;
         private string _fullLog;
 
         public TurnBuilder CurrentTurn { get; private set; } = new();

--- a/CommandLine/src/Worms/Commands/Resources/Schemes/GetScheme.cs
+++ b/CommandLine/src/Worms/Commands/Resources/Schemes/GetScheme.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
-using Worms.Armageddon.Resources.Schemes;
 using Worms.Cli.Resources.Local.Schemes;
 using Worms.Resources;
 

--- a/CommandLine/src/Worms/Logging/TableOutput/TableBuilder.cs
+++ b/CommandLine/src/Worms/Logging/TableOutput/TableBuilder.cs
@@ -36,7 +36,9 @@ namespace Worms.Logging.TableOutput
                 // Only add another column if the heading can be rendered
                 var headingLength = column.Heading.Length + ColumnPadding;
                 if (currentWidth >= _outputWidth - headingLength)
+                {
                     break;
+                }
 
                 adjustedColumns.Add(column);
                 currentWidth += column.Width;
@@ -74,7 +76,10 @@ namespace Worms.Logging.TableOutput
             var headerLength = header.Length + ColumnPadding;
             var longest = anyItems ? values.Max(x => x.Length) + ColumnPadding : headerLength;
             if (longest < headerLength)
+            {
                 longest = headerLength;
+            }
+
             return longest;
         }
     }

--- a/CommandLine/src/Worms/Modules/CliModule.cs
+++ b/CommandLine/src/Worms/Modules/CliModule.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 using Autofac;
 using Worms.Armageddon.Game.Modules;
 using Worms.Armageddon.Resources.Modules;
-using Worms.Armageddon.Resources.Schemes;
 using Worms.Cli;
 using Worms.Cli.PackageManagers;
 using Worms.Cli.Resources.Local.Replays;

--- a/CommandLine/src/Worms/Resources/Replays/ReplayTextPrinter.cs
+++ b/CommandLine/src/Worms/Resources/Replays/ReplayTextPrinter.cs
@@ -16,7 +16,7 @@ namespace Worms.Resources.Replays
             tableBuilder.AddColumn("NAME", items.Select(x => x.Details.Date.ToString("yyyy-MM-dd HH.mm.ss")).ToList());
             tableBuilder.AddColumn("CONTEXT", items.Select(x => x.Context).ToList());
             tableBuilder.AddColumn("PROCESSED", items.Select(x => x.Details.Processed.ToString()).ToList());
-            tableBuilder.AddColumn("WINNER", items.Select(x => x.Details.Winner.ToString()).ToList());
+            tableBuilder.AddColumn("WINNER", items.Select(x => x.Details.Winner != null ? x.Details.Winner.ToString() : "").ToList());
             tableBuilder.AddColumn("TEAMS", items.Select(x => string.Join(", ", x.Details.Teams.Select(t => t.Name))).ToList());
 
             var table = tableBuilder.Build();

--- a/CommandLine/src/Worms/Resources/Schemes/SchemeTextPrinter.cs
+++ b/CommandLine/src/Worms/Resources/Schemes/SchemeTextPrinter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Syroot.Worms.Armageddon;
-using Worms.Armageddon.Resources.Schemes;
 using Worms.Armageddon.Resources.Schemes.Text;
 using Worms.Cli.Resources.Local.Schemes;
 using Worms.Logging.TableOutput;


### PR DESCRIPTION
Allows winner to be `null` in the domain model but not throw an exception when rendering the CLI table. This fixes #310 
Using non-nullable reference types would help express this better in the code.
