### PR TITLE
Make .gifs ~ 1/3 smaller

### DIFF
--- a/CommandLine/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
+++ b/CommandLine/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
@@ -31,7 +31,7 @@ namespace Worms.Cli.Resources.Local.Gifs
             var replayName = _fileSystem.Path.GetFileNameWithoutExtension(replayPath);
             var worms = _wormsLocator.Find();
             var framesFolder = _fileSystem.Path.Combine(worms.CaptureFolder, replayName);
-            var outputFileName = _fileSystem.Path.Combine(worms.CaptureFolder, replayName + ".gif");
+            var outputFileName = _fileSystem.Path.Combine(worms.CaptureFolder, replayName + " - " + parameters.Turn + ".gif");
 
             var animationDelay = 100 / parameters.FramesPerSecond / parameters.SpeedMultiplier;
 

--- a/CommandLine/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
+++ b/CommandLine/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
@@ -13,7 +13,10 @@ namespace Worms.Cli.Resources.Local.Gifs
         private readonly IWormsLocator _wormsLocator;
         private readonly IFileSystem _fileSystem;
 
-        public LocalGifCreator(IReplayFrameExtractor replayFrameExtractor, IWormsLocator wormsLocator, IFileSystem fileSystem)
+        public LocalGifCreator(
+            IReplayFrameExtractor replayFrameExtractor,
+            IWormsLocator wormsLocator,
+            IFileSystem fileSystem)
         {
             _replayFrameExtractor = replayFrameExtractor;
             _wormsLocator = wormsLocator;
@@ -23,7 +26,7 @@ namespace Worms.Cli.Resources.Local.Gifs
         public async Task<LocalGif> Create(LocalGifCreateParameters parameters)
         {
             var replayPath = parameters.Replay.Paths.WAgamePath;
-            var turn = parameters.Replay.Details.Turns.ElementAt((int)parameters.Turn - 1);
+            var turn = parameters.Replay.Details.Turns.ElementAt((int) parameters.Turn - 1);
 
             var replayName = _fileSystem.Path.GetFileNameWithoutExtension(replayPath);
             var worms = _wormsLocator.Find();
@@ -33,8 +36,11 @@ namespace Worms.Cli.Resources.Local.Gifs
             var animationDelay = 100 / parameters.FramesPerSecond / parameters.SpeedMultiplier;
 
             DeleteFrames(framesFolder);
-            await _replayFrameExtractor.ExtractReplayFrames(replayPath, parameters.FramesPerSecond,
-                turn.Start + parameters.StartOffset, turn.End - parameters.EndOffset);
+            await _replayFrameExtractor.ExtractReplayFrames(
+                replayPath,
+                parameters.FramesPerSecond,
+                turn.Start + parameters.StartOffset,
+                turn.End - parameters.EndOffset);
             CreateGifFromFiles(framesFolder, outputFileName, animationDelay, 640, 480);
             DeleteFrames(framesFolder);
 
@@ -49,7 +55,12 @@ namespace Worms.Cli.Resources.Local.Gifs
             }
         }
 
-        private void CreateGifFromFiles(string framesFolder, string outputFile, uint animationDelay, int width, int height)
+        private void CreateGifFromFiles(
+            string framesFolder,
+            string outputFile,
+            uint animationDelay,
+            int width,
+            int height)
         {
             var frames = _fileSystem.Directory.GetFiles(framesFolder, "*.png");
 
@@ -58,14 +69,14 @@ namespace Worms.Cli.Resources.Local.Gifs
             {
                 var image = new MagickImage(file);
                 image.Resize(width, height);
-                image.AnimationDelay = (int)animationDelay;
+                image.AnimationDelay = (int) animationDelay;
                 collection.Add(image);
             }
 
-            var settings = new QuantizeSettings {Colors = 256};
+            var settings = new QuantizeSettings { Colors = 256 };
 
             collection.Quantize(settings);
-            collection.Optimize();
+            collection.OptimizeTransparency();
             collection.Write(outputFile);
         }
     }


### PR DESCRIPTION
**Small gifs**
This uses a better optimization method when generating the gif to compress pixels that don't change between frames.

**Unique filenames**
Gif files now include the turn number so that more than 1 gif can be generated for a replay