### PR TITLE
Host games via Hub

### DIFF
--- a/src/cli/makefile
+++ b/src/cli/makefile
@@ -4,7 +4,7 @@ default: all
 OUTPUT_DIR = .artifacts
 IMAGE_NAME = theeadie/wormscli
 
-NEXT_VERSION := 0.18
+NEXT_VERSION := 0.19
 TAG_PREFIX := cli/v
 
 VERSION := $(shell ../../build/version.sh $(NEXT_VERSION) $(TAG_PREFIX))

--- a/src/cli/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/cli/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -14,20 +14,23 @@ namespace Worms.Armageddon.Game.Linux
 
         public Task RunWorms(params string[] wormsArgs)
         {
-            var gameInfo = _wormsLocator.Find();
-
-            var args = string.Join(" ", wormsArgs);
-            var processStartInfo = new ProcessStartInfo
+            return Task.Run(() =>
             {
-                FileName = "wine",
-                Arguments = gameInfo.ExeLocation + " " + args,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            };
+                var gameInfo = _wormsLocator.Find();
 
-            using var process = Process.Start(processStartInfo);
-            process?.WaitForExit();
-            return Task.CompletedTask;
+                var args = string.Join(" ", wormsArgs);
+                var processStartInfo = new ProcessStartInfo
+                {
+                    FileName = "wine",
+                    Arguments = gameInfo.ExeLocation + " " + args,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+
+                using var process = Process.Start(processStartInfo);
+                process?.WaitForExit();
+                return Task.CompletedTask;
+            });
         }
     }
 }

--- a/src/cli/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/cli/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -14,27 +14,20 @@ namespace Worms.Armageddon.Game.Linux
 
         public Task RunWorms(params string[] wormsArgs)
         {
-            return Task.Factory.StartNew(
-                () =>
-                    {
-                        var gameInfo = _wormsLocator.Find();
+            var gameInfo = _wormsLocator.Find();
 
-                        var args = string.Join(" ", wormsArgs);
-                        var processStartInfo = new ProcessStartInfo
-                        {
-                            FileName = "wine",
-                            Arguments = gameInfo.ExeLocation + " " + args,
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true
-                        };
+            var args = string.Join(" ", wormsArgs);
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = "wine",
+                Arguments = gameInfo.ExeLocation + " " + args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
 
-                        using var process = Process.Start(processStartInfo);
-                        if (process == null)
-                        {
-                            return;
-                        }
-                        process.WaitForExit();
-                    });
+            using var process = Process.Start(processStartInfo);
+            process?.WaitForExit();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/cli/src/Worms.Armageddon.Game/Windows/WormsRunner.cs
+++ b/src/cli/src/Worms.Armageddon.Game/Windows/WormsRunner.cs
@@ -17,25 +17,28 @@ namespace Worms.Armageddon.Game.Windows
 
         public Task RunWorms(params string[] wormsArgs)
         {
-            var gameInfo = _wormsLocator.Find();
-
-            var args = string.Join(" ", wormsArgs);
-            using (var process = Process.Start(gameInfo.ExeLocation, args))
+            return Task.Run(() =>
             {
-                if (process == null)
+                var gameInfo = _wormsLocator.Find();
+
+                var args = string.Join(" ", wormsArgs);
+                using (var process = Process.Start(gameInfo.ExeLocation, args))
                 {
-                    return Task.CompletedTask;
+                    if (process == null)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    process.WaitForExit();
                 }
 
-                process.WaitForExit();
-            }
+                _steamService.WaitForSteamPrompt();
 
-            _steamService.WaitForSteamPrompt();
+                var wormsProcess = Process.GetProcessesByName(gameInfo.ProcessName).FirstOrDefault();
+                wormsProcess?.WaitForExit();
 
-            var wormsProcess = Process.GetProcessesByName(gameInfo.ProcessName).FirstOrDefault();
-            wormsProcess?.WaitForExit();
-
-            return Task.CompletedTask;
+                return Task.CompletedTask;
+            });
         }
     }
 }

--- a/src/cli/src/Worms.Armageddon.Game/Windows/WormsRunner.cs
+++ b/src/cli/src/Worms.Armageddon.Game/Windows/WormsRunner.cs
@@ -17,31 +17,25 @@ namespace Worms.Armageddon.Game.Windows
 
         public Task RunWorms(params string[] wormsArgs)
         {
-            return Task.Factory.StartNew(
-                () =>
-                    {
-                        var gameInfo = _wormsLocator.Find();
+            var gameInfo = _wormsLocator.Find();
 
-                        var args = string.Join(" ", wormsArgs);
-                        using (var process = Process.Start(gameInfo.ExeLocation, args))
-                        {
-                            if (process == null)
-                            {
-                                return;
-                            }
+            var args = string.Join(" ", wormsArgs);
+            using (var process = Process.Start(gameInfo.ExeLocation, args))
+            {
+                if (process == null)
+                {
+                    return Task.CompletedTask;
+                }
 
-                            process.WaitForExit();
-                            if (process.ExitCode == 0)
-                            {
-                                return;
-                            }
-                        }
+                process.WaitForExit();
+            }
 
-                        _steamService.WaitForSteamPrompt();
+            _steamService.WaitForSteamPrompt();
 
-                        var wormsProcess = Process.GetProcessesByName(gameInfo.ProcessName).FirstOrDefault();
-                        wormsProcess?.WaitForExit();
-                    });
+            var wormsProcess = Process.GetProcessesByName(gameInfo.ProcessName).FirstOrDefault();
+            wormsProcess?.WaitForExit();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/cli/src/Worms.Cli.Resources/IResourceCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/IResourceCreator.cs
@@ -1,9 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
 
 namespace Worms.Cli.Resources
 {
     public interface IResourceCreator<T, in TParams>
     {
-        Task<T> Create(TParams parameters);
+        Task<T> Create(TParams parameters, ILogger logger, CancellationToken cancellationToken);
     }
 }

--- a/src/cli/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
@@ -1,7 +1,9 @@
 ﻿using System.IO.Abstractions;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ImageMagick;
+using Serilog;
 using Worms.Armageddon.Game;
 using Worms.Armageddon.Game.Replays;
 
@@ -23,7 +25,7 @@ namespace Worms.Cli.Resources.Local.Gifs
             _fileSystem = fileSystem;
         }
 
-        public async Task<LocalGif> Create(LocalGifCreateParameters parameters)
+        public async Task<LocalGif> Create(LocalGifCreateParameters parameters, ILogger logger, CancellationToken cancellationToken)
         {
             var replayPath = parameters.Replay.Paths.WAgamePath;
             var turn = parameters.Replay.Details.Turns.ElementAt((int) parameters.Turn - 1);

--- a/src/cli/src/Worms.Cli.Resources/Local/Schemes/LocalSchemeCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/Local/Schemes/LocalSchemeCreator.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO.Abstractions;
+using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 using Worms.Armageddon.Resources.Schemes.Binary;
 using Worms.Armageddon.Resources.Schemes.Text;
 
@@ -18,7 +20,7 @@ namespace Worms.Cli.Resources.Local.Schemes
             _fileSystem = fileSystem;
         }
 
-        public Task<LocalScheme> Create(LocalSchemeCreateParameters parameters)
+        public Task<LocalScheme> Create(LocalSchemeCreateParameters parameters, ILogger logger, CancellationToken cancellationToken)
         {
             var scheme = _schemeTextReader.GetModel(parameters.Definition);
             var path = _fileSystem.Path.Combine(parameters.Folder, parameters.Name + ".wsc");

--- a/src/cli/src/Worms.Cli.Resources/Local/Schemes/LocalSchemeRandomCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/Local/Schemes/LocalSchemeRandomCreator.cs
@@ -1,5 +1,7 @@
 using System.IO.Abstractions;
+using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 using Worms.Armageddon.Resources.Schemes.Binary;
 using Worms.Armageddon.Resources.Schemes.Random;
 
@@ -18,7 +20,7 @@ namespace Worms.Cli.Resources.Local.Schemes
             _fileSystem = fileSystem;
         }
 
-        public Task<LocalScheme> Create(LocalSchemeCreateRandomParameters parameters)
+        public Task<LocalScheme> Create(LocalSchemeCreateRandomParameters parameters, ILogger logger, CancellationToken cancellationToken)
         {
             var scheme = _randomSchemeGenerator.Generate();
             var path = _fileSystem.Path.Combine(parameters.Folder, parameters.Name + ".wsc");

--- a/src/cli/src/Worms.Cli.Resources/Modules/CliResourcesModule.cs
+++ b/src/cli/src/Worms.Cli.Resources/Modules/CliResourcesModule.cs
@@ -42,7 +42,7 @@ namespace Worms.Cli.Resources.Modules
             
             // Games
             builder.RegisterType<RemoteGameRetriever>().As<IResourceRetriever<RemoteGame>>();
-
+            builder.RegisterType<RemoteGameCreator>().As<IResourceCreator<RemoteGame, string>>();
         }
     }
 }

--- a/src/cli/src/Worms.Cli.Resources/Modules/CliResourcesModule.cs
+++ b/src/cli/src/Worms.Cli.Resources/Modules/CliResourcesModule.cs
@@ -23,7 +23,8 @@ namespace Worms.Cli.Resources.Modules
             // Schemes
             builder.RegisterType<LocalSchemesRetriever>().As<IResourceRetriever<LocalScheme>>();
             builder.RegisterType<LocalSchemeCreator>().As<IResourceCreator<LocalScheme, LocalSchemeCreateParameters>>();
-            builder.RegisterType<LocalSchemeRandomCreator>().As<IResourceCreator<LocalScheme, LocalSchemeCreateRandomParameters>>();
+            builder.RegisterType<LocalSchemeRandomCreator>()
+                .As<IResourceCreator<LocalScheme, LocalSchemeCreateRandomParameters>>();
             builder.RegisterType<LocalSchemeDeleter>().As<IResourceDeleter<LocalScheme>>();
 
             // Replays
@@ -34,15 +35,16 @@ namespace Worms.Cli.Resources.Modules
 
             // Gifs
             builder.RegisterType<LocalGifCreator>().As<IResourceCreator<LocalGif, LocalGifCreateParameters>>();
-            
+
             // API
             builder.RegisterType<AccessTokenRefreshService>().As<IAccessTokenRefreshService>();
             builder.RegisterType<DeviceCodeLoginService>().As<ILoginService>();
             builder.RegisterType<WormsServerApi>().As<IWormsServerApi>();
-            
+
             // Games
             builder.RegisterType<RemoteGameRetriever>().As<IResourceRetriever<RemoteGame>>();
             builder.RegisterType<RemoteGameCreator>().As<IResourceCreator<RemoteGame, string>>();
+            builder.RegisterType<RemoteGameUpdater>().As<IRemoteGameUpdater>();
         }
     }
 }

--- a/src/cli/src/Worms.Cli.Resources/Remote/Auth/AccessTokenRefreshService.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Auth/AccessTokenRefreshService.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using RestSharp;
 
 namespace Worms.Cli.Resources.Remote.Auth;
 
@@ -10,37 +10,40 @@ internal class AccessTokenRefreshService : IAccessTokenRefreshService
 {
     private const string Authority = "https://eadie.eu.auth0.com";
     private const string ClientId = "0dBbKeIKO2UAzWfBh6LuGwWYSWGZPFHB";
-    
+
     public async Task<AccessTokens> RefreshAccessTokens(AccessTokens current)
     {
-        using var httpClient = new HttpClient();
-        httpClient.BaseAddress = new Uri(Authority);
+        var client = new RestClient(Authority);
+        var request = new RestRequest("oauth/token", Method.Post);
+        request.AddHeader("content-type", "application/x-www-form-urlencoded");
+        request.AddParameter("application/x-www-form-urlencoded",
+            $"grant_type=refresh_token&client_id={ClientId}&refresh_token={current.RefreshToken}",
+            ParameterType.RequestBody);
+        var response = await client.ExecuteAsync(request).ConfigureAwait(false);
 
-        var response = await httpClient.PostAsync(new Uri(
-                    "oauth/token?" +
-                    $"client_id={ClientId}&" +
-                    $"refresh_token={current.RefreshToken}&" +
-                    "grant_type=refresh_token",
-                    UriKind.Relative),
-                null)
-            .ConfigureAwait(false);
+        if (!response.IsSuccessful)
+        {
+            throw response.ErrorException ?? throw new Exception(response.ErrorMessage);
+        }
 
-        _ = response.EnsureSuccessStatusCode();
-        var streamAsync = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        await using var stream = streamAsync.ConfigureAwait(false);
-        var result = await JsonSerializer.DeserializeAsync<TokenResponse>(streamAsync).ConfigureAwait(false);
+        var result = JsonSerializer.Deserialize<TokenResponse>(response.Content!);
         if (result is null)
         {
             throw new JsonException("The API returned success but the JSON response was empty");
         }
 
-        return new AccessTokens(result.AccessToken, result.RefreshToken);
+        return current with {AccessToken = result.AccessToken};
     }
-    
+
     private record TokenResponse(
-        [property:JsonPropertyName("access_token")] string AccessToken,
-        [property:JsonPropertyName("refresh_token")] string RefreshToken,
-        [property:JsonPropertyName("id_token")] string IdToken,
-        [property:JsonPropertyName("token_type")] string TokenType,
-        [property:JsonPropertyName("expires_in")] int ExpiresIn); 
+        [property: JsonPropertyName("access_token")]
+        string AccessToken,
+        [property: JsonPropertyName("refresh_token")]
+        string RefreshToken,
+        [property: JsonPropertyName("id_token")]
+        string IdToken,
+        [property: JsonPropertyName("token_type")]
+        string TokenType,
+        [property: JsonPropertyName("expires_in")]
+        int ExpiresIn);
 }

--- a/src/cli/src/Worms.Cli.Resources/Remote/Games/IRemoteGameUpdater.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Games/IRemoteGameUpdater.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Worms.Cli.Resources.Remote.Games;
+
+public interface IRemoteGameUpdater
+{
+    Task SetGameComplete(RemoteGame game, ILogger logger, CancellationToken cancellationToken);
+}

--- a/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
@@ -1,0 +1,33 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Worms.Cli.Resources.Remote.Games;
+
+internal class RemoteGameCreator : IResourceCreator<RemoteGame, string>
+{
+    private readonly IWormsServerApi _api;
+
+    public RemoteGameCreator(IWormsServerApi api)
+    {
+        _api = api;
+    }
+
+    public async Task<RemoteGame> Create(string parameters, ILogger logger, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var apiGame = await _api.CreateGame(parameters);
+            return new RemoteGame(apiGame.Id, apiGame.Status, apiGame.HostMachine);
+        }
+        catch (HttpRequestException e)
+        {
+            if (e.StatusCode == HttpStatusCode.Unauthorized)
+                logger.Warning("You don't have access to the Worms League Server. Please run worms auth or contact an admin");
+
+            return new RemoteGame("", "", "");
+        }
+    }
+}

--- a/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
@@ -19,13 +19,14 @@ internal class RemoteGameCreator : IResourceCreator<RemoteGame, string>
     {
         try
         {
-            var apiGame = await _api.CreateGame(parameters);
+            var apiGame = await _api.CreateGame(new WormsServerApi.CreateGameDtoV1(parameters));
             return new RemoteGame(apiGame.Id, apiGame.Status, apiGame.HostMachine);
         }
         catch (HttpRequestException e)
         {
             if (e.StatusCode == HttpStatusCode.Unauthorized)
-                logger.Warning("You don't have access to the Worms League Server. Please run worms auth or contact an admin");
+                logger.Warning(
+                    "You don't have access to the Worms League Server. Please run worms auth or contact an admin");
 
             return new RemoteGame("", "", "");
         }

--- a/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
@@ -24,9 +24,16 @@ internal class RemoteGameCreator : IResourceCreator<RemoteGame, string>
         }
         catch (HttpRequestException e)
         {
-            if (e.StatusCode == HttpStatusCode.Unauthorized)
-                logger.Warning(
-                    "You don't have access to the Worms League Server. Please run worms auth or contact an admin");
+            switch (e.StatusCode)
+            {
+                case HttpStatusCode.Unauthorized:
+                    logger.Warning(
+                        "You don't have access to the Worms Hub. Please run worms auth or contact an admin");
+                    break;
+                default:
+                    logger.Error(e, "An error occured calling the Worms Hub API");
+                    break;
+            }
 
             return new RemoteGame("", "", "");
         }

--- a/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameRetriever.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameRetriever.cs
@@ -19,18 +19,27 @@ internal class RemoteGameRetriever : IResourceRetriever<RemoteGame>
 
     public async Task<IReadOnlyCollection<RemoteGame>> Get(ILogger logger, CancellationToken cancellationToken)
         => await Get("*", logger, cancellationToken);
-    
-    public async Task<IReadOnlyCollection<RemoteGame>> Get(string pattern, ILogger logger, CancellationToken cancellationToken)
+
+    public async Task<IReadOnlyCollection<RemoteGame>> Get(string pattern, ILogger logger,
+        CancellationToken cancellationToken)
     {
         try
         {
             var apiGames = await _api.GetGames();
-            return apiGames.Select(x=>new RemoteGame(x.Id, x.Status, x.HostMachine)).ToList();
+            return apiGames.Select(x => new RemoteGame(x.Id, x.Status, x.HostMachine)).ToList();
         }
         catch (HttpRequestException e)
         {
-            if (e.StatusCode == HttpStatusCode.Unauthorized)
-                logger.Warning("You don't have access to the Worms League Server. Please run worms auth or contact an admin");
+            switch (e.StatusCode)
+            {
+                case HttpStatusCode.Unauthorized:
+                    logger.Warning(
+                        "You don't have access to the Worms Hub. Please run worms auth or contact an admin");
+                    break;
+                default:
+                    logger.Error(e, "An error occured calling the Worms Hub API");
+                    break;
+            }
 
             return new List<RemoteGame>(0);
         }

--- a/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameUpdater.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/Games/RemoteGameUpdater.cs
@@ -1,0 +1,38 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Worms.Cli.Resources.Remote.Games;
+
+internal class RemoteGameUpdater : IRemoteGameUpdater
+{
+    private readonly IWormsServerApi _api;
+
+    public RemoteGameUpdater(IWormsServerApi api)
+    {
+        _api = api;
+    }
+
+    public async Task SetGameComplete(RemoteGame game, ILogger logger, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _api.UpdateGame(new WormsServerApi.GamesDtoV1(game.Id, "Complete", game.HostMachine));
+        }
+        catch (HttpRequestException e)
+        {
+            switch (e.StatusCode)
+            {
+                case HttpStatusCode.Unauthorized:
+                    logger.Warning(
+                        "You don't have access to the Worms Hub. Please run worms auth or contact an admin");
+                    break;
+                default:
+                    logger.Error(e, "An error occured calling the Worms Hub API");
+                    break;
+            }
+        }
+    }
+}

--- a/src/cli/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
@@ -6,4 +6,6 @@ namespace Worms.Cli.Resources.Remote;
 internal interface IWormsServerApi
 {
     Task<IReadOnlyCollection<WormsServerApi.GamesDtoV1>> GetGames();
+
+    Task<WormsServerApi.GamesDtoV1> CreateGame(string hostMachineName);
 }

--- a/src/cli/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
@@ -8,4 +8,5 @@ internal interface IWormsServerApi
     Task<IReadOnlyCollection<WormsServerApi.GamesDtoV1>> GetGames();
 
     Task<WormsServerApi.GamesDtoV1> CreateGame(WormsServerApi.CreateGameDtoV1 hostMachineName);
+    Task UpdateGame(WormsServerApi.GamesDtoV1 newGameDetails);
 }

--- a/src/cli/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
@@ -7,5 +7,5 @@ internal interface IWormsServerApi
 {
     Task<IReadOnlyCollection<WormsServerApi.GamesDtoV1>> GetGames();
 
-    Task<WormsServerApi.GamesDtoV1> CreateGame(string hostMachineName);
+    Task<WormsServerApi.GamesDtoV1> CreateGame(WormsServerApi.CreateGameDtoV1 hostMachineName);
 }

--- a/src/cli/src/Worms.Cli.Resources/Remote/WormsServerApi.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/WormsServerApi.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -31,22 +32,24 @@ internal class WormsServerApi : IWormsServerApi
     public async Task<IReadOnlyCollection<GamesDtoV1>> GetGames() =>
         await Get<IReadOnlyCollection<GamesDtoV1>>(new Uri("api/v1/games", UriKind.Relative));
 
-    public async Task<GamesDtoV1> CreateGame(string hostMachineName)
+    public async Task<GamesDtoV1> CreateGame(CreateGameDtoV1 createParams)
     {
         const string path = "api/v1/games";
-        
-        var accessTokens = _tokenStore.GetAccessTokens();
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
 
-        var response = await _httpClient.PostAsync(path, new StringContent(hostMachineName)).ConfigureAwait(false);
+        var accessTokens = _tokenStore.GetAccessTokens();
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
+
+        var response = await _httpClient.PostAsJsonAsync(path, createParams).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.Unauthorized)
         {
             // Retry with newer access token
             accessTokens = await _accessTokenRefreshService.RefreshAccessTokens(accessTokens).ConfigureAwait(false);
             _tokenStore.StoreAccessTokens(accessTokens);
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
-            response = await _httpClient.PostAsync(path, new StringContent(hostMachineName)).ConfigureAwait(false);
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
+            response = await _httpClient.PostAsJsonAsync(path, createParams).ConfigureAwait(false);
         }
 
         _ = response.EnsureSuccessStatusCode();
@@ -54,18 +57,26 @@ internal class WormsServerApi : IWormsServerApi
         var streamAsync = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         await using var stream = streamAsync.ConfigureAwait(false);
         var result = await JsonSerializer.DeserializeAsync<GamesDtoV1>(streamAsync).ConfigureAwait(false);
-        return result is null ? throw new JsonException("The API returned success but the JSON response was empty") : (GamesDtoV1) result;
+        return result is null
+            ? throw new JsonException("The API returned success but the JSON response was empty")
+            : (GamesDtoV1) result;
     }
 
     public record GamesDtoV1(
-        [property:JsonPropertyName("id")] string Id,
-        [property:JsonPropertyName("status")] string Status,
-        [property:JsonPropertyName("hostMachine")]string HostMachine);
-    
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("hostMachine")]
+        string HostMachine);
+
+    public record CreateGameDtoV1(
+        [property: JsonPropertyName("hostMachine")]
+        string HostMachine);
+
     private async Task<T> Get<T>(Uri path)
     {
         var accessTokens = _tokenStore.GetAccessTokens();
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
 
         var response = await _httpClient.GetAsync(path).ConfigureAwait(false);
 
@@ -74,7 +85,8 @@ internal class WormsServerApi : IWormsServerApi
             // Retry with newer access token
             accessTokens = await _accessTokenRefreshService.RefreshAccessTokens(accessTokens).ConfigureAwait(false);
             _tokenStore.StoreAccessTokens(accessTokens);
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
             response = await _httpClient.GetAsync(path).ConfigureAwait(false);
         }
 
@@ -83,6 +95,8 @@ internal class WormsServerApi : IWormsServerApi
         var streamAsync = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         await using var stream = streamAsync.ConfigureAwait(false);
         var result = await JsonSerializer.DeserializeAsync<T>(streamAsync).ConfigureAwait(false);
-        return result is null ? throw new JsonException("The API returned success but the JSON response was empty") : (T) result;
+        return result is null
+            ? throw new JsonException("The API returned success but the JSON response was empty")
+            : (T) result;
     }
 }

--- a/src/cli/src/Worms.Cli.Resources/Remote/WormsServerApi.cs
+++ b/src/cli/src/Worms.Cli.Resources/Remote/WormsServerApi.cs
@@ -29,37 +29,18 @@ internal class WormsServerApi : IWormsServerApi
 #endif
     }
 
-    public async Task<IReadOnlyCollection<GamesDtoV1>> GetGames() =>
-        await Get<IReadOnlyCollection<GamesDtoV1>>(new Uri("api/v1/games", UriKind.Relative));
+    public async Task<IReadOnlyCollection<GamesDtoV1>> GetGames()
+    {
+        var path = new Uri("api/v1/games", UriKind.Relative);
+        return await CallApiRefreshAccessTokenIfInvalid<IReadOnlyCollection<GamesDtoV1>>(async () =>
+            await _httpClient.GetAsync(path));
+    }
 
     public async Task<GamesDtoV1> CreateGame(CreateGameDtoV1 createParams)
     {
-        const string path = "api/v1/games";
-
-        var accessTokens = _tokenStore.GetAccessTokens();
-        _httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
-
-        var response = await _httpClient.PostAsJsonAsync(path, createParams).ConfigureAwait(false);
-
-        if (response.StatusCode == HttpStatusCode.Unauthorized)
-        {
-            // Retry with newer access token
-            accessTokens = await _accessTokenRefreshService.RefreshAccessTokens(accessTokens).ConfigureAwait(false);
-            _tokenStore.StoreAccessTokens(accessTokens);
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
-            response = await _httpClient.PostAsJsonAsync(path, createParams).ConfigureAwait(false);
-        }
-
-        _ = response.EnsureSuccessStatusCode();
-
-        var streamAsync = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        await using var stream = streamAsync.ConfigureAwait(false);
-        var result = await JsonSerializer.DeserializeAsync<GamesDtoV1>(streamAsync).ConfigureAwait(false);
-        return result is null
-            ? throw new JsonException("The API returned success but the JSON response was empty")
-            : (GamesDtoV1) result;
+        var path = new Uri("api/v1/games", UriKind.Relative);
+        return await CallApiRefreshAccessTokenIfInvalid<GamesDtoV1>(async () =>
+            await _httpClient.PostAsJsonAsync(path, createParams));
     }
 
     public record GamesDtoV1(
@@ -72,13 +53,13 @@ internal class WormsServerApi : IWormsServerApi
         [property: JsonPropertyName("hostMachine")]
         string HostMachine);
 
-    private async Task<T> Get<T>(Uri path)
+    private async Task<T> CallApiRefreshAccessTokenIfInvalid<T>(Func<Task<HttpResponseMessage>> apiCall)
     {
         var accessTokens = _tokenStore.GetAccessTokens();
         _httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
 
-        var response = await _httpClient.GetAsync(path).ConfigureAwait(false);
+        var response = await apiCall().ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.Unauthorized)
         {
@@ -87,7 +68,7 @@ internal class WormsServerApi : IWormsServerApi
             _tokenStore.StoreAccessTokens(accessTokens);
             _httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", accessTokens.AccessToken);
-            response = await _httpClient.GetAsync(path).ConfigureAwait(false);
+            response = await apiCall().ConfigureAwait(false);
         }
 
         _ = response.EnsureSuccessStatusCode();

--- a/src/cli/src/Worms/Commands/Resources/Gifs/CreateGif.cs
+++ b/src/cli/src/Worms/Commands/Resources/Gifs/CreateGif.cs
@@ -63,7 +63,7 @@ namespace Worms.Commands.Resources.Gifs
                 Logger.Information($"Creating gif for {Replay}, turn {Turn} ...");
                 var gif = await _gifCreator.Create(new LocalGifCreateParameters(replay, Turn,
                     TimeSpan.FromSeconds(StartOffset), TimeSpan.FromSeconds(EndOffset),
-                    FramesPerSecond, Speed));
+                    FramesPerSecond, Speed), Logger, cancellationToken);
                 await console.Out.WriteLineAsync(gif.Path);
             }
             catch (FormatException exception)

--- a/src/cli/src/Worms/Commands/Resources/Schemes/CreateScheme.cs
+++ b/src/cli/src/Worms/Commands/Resources/Schemes/CreateScheme.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO.Abstractions;
+using System.Threading;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using Worms.Armageddon.Game;
@@ -40,7 +41,7 @@ namespace Worms.Commands.Resources.Schemes
             _wormsLocator = wormsLocator;
         }
 
-        public async Task<int> OnExecuteAsync(IConsole console)
+        public async Task<int> OnExecuteAsync(IConsole console, CancellationToken cancellationToken)
         {
             string name;
             var outputFolder = ResourceFolder;
@@ -54,13 +55,13 @@ namespace Worms.Commands.Resources.Schemes
                 {
                     var (definition, source) = ValidateSchemeDefinition(console);
                     creator = () =>
-                        _schemeCreator.Create(new LocalSchemeCreateParameters(name, outputFolder, definition));
+                        _schemeCreator.Create(new LocalSchemeCreateParameters(name, outputFolder, definition), Logger, cancellationToken);
                     Logger.Verbose($"Scheme definition being read from {source}");
                 }
                 else
                 {
                     creator = () =>
-                        _randomSchemeCreator.Create(new LocalSchemeCreateRandomParameters(name, outputFolder));
+                        _randomSchemeCreator.Create(new LocalSchemeCreateRandomParameters(name, outputFolder), Logger, cancellationToken);
                 }
             }
             catch (ConfigurationException exception)

--- a/src/cli/src/Worms/worms.csproj
+++ b/src/cli/src/Worms/worms.csproj
@@ -28,8 +28,4 @@
     <ProjectReference Include="..\Worms.Cli.Resources\Worms.Cli.Resources.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Server" />
-  </ItemGroup>
-
 </Project>

--- a/src/hub/makefile
+++ b/src/hub/makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME := theeadie/worms-server-gateway
-NEXT_VERSION := 0.1
+NEXT_VERSION := 0.2
 TAG_PREFIX := hub/v
 
 GITHUB_REPO := theeadie/WormsLeague

--- a/src/hub/src/Worms.Gateway/Announcers/IAnnouncer.cs
+++ b/src/hub/src/Worms.Gateway/Announcers/IAnnouncer.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Worms.Gateway.Announcers
+{
+    public interface ISlackAnnouncer
+    {
+        Task AnnounceGameStarting(string hostName, ILogger log);
+    }
+}

--- a/src/hub/src/Worms.Gateway/Announcers/Slack/SlackAnnouncer.cs
+++ b/src/hub/src/Worms.Gateway/Announcers/Slack/SlackAnnouncer.cs
@@ -1,0 +1,43 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Worms.Gateway.Announcers.Slack
+{
+    internal class SlackAnnouncer : ISlackAnnouncer
+    {
+        private readonly string _webHookUrl;
+        
+        public SlackAnnouncer(IConfiguration configuration)
+        {
+            _webHookUrl = configuration.GetValue<string>("SlackWebHookURL");
+        }
+        
+        public async Task AnnounceGameStarting(string hostName, ILogger log)
+        {
+            if (string.IsNullOrWhiteSpace(_webHookUrl))
+            {
+                log.LogWarning("A Slack web hook must be configured to announce a game");
+                return;
+            }
+
+#if DEBUG
+            var slackMessage = new SlackMessage
+                {Text = $"Debug: This is a test run from local dev. Hosting at wa://{hostName}"};
+#else
+            var slackMessage = new SlackMessage { Text = $"<!here> Hosting at: wa://{hostName}" };
+#endif
+
+            using var client = new HttpClient();
+            var slackUrl = new System.Uri(_webHookUrl);
+            var body = JsonSerializer.Serialize(slackMessage);
+            var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+            var response = await client.PostAsync(slackUrl, content).ConfigureAwait(false);
+            await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/hub/src/Worms.Gateway/Announcers/Slack/SlackMessage.cs
+++ b/src/hub/src/Worms.Gateway/Announcers/Slack/SlackMessage.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Worms.Gateway.Announcers.Slack
+{
+    public sealed class SlackMessage
+    {
+        [JsonPropertyName("text")]
+        public string Text { get; set; }
+    }
+}

--- a/src/hub/src/Worms.Gateway/Controllers/GamesController.cs
+++ b/src/hub/src/Worms.Gateway/Controllers/GamesController.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Worms.Gateway.Announcers;
 using Worms.Gateway.Database;
 using Worms.Gateway.Dtos;
 
@@ -9,10 +11,14 @@ namespace Worms.Gateway.Controllers
     public class GamesController : V1ApiController
     {
         private readonly IRepository<GameDto> _repository;
+        private readonly ISlackAnnouncer _slackAnnouncer;
+        private readonly ILogger _logger;
 
-        public GamesController(IRepository<GameDto> repository)
+        public GamesController(IRepository<GameDto> repository, ISlackAnnouncer slackAnnouncer, ILogger logger)
         {
             _repository = repository;
+            _slackAnnouncer = slackAnnouncer;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -31,6 +37,7 @@ namespace Worms.Gateway.Controllers
         [HttpPost]
         public ActionResult<GameDto> Post(CreateGameDto parameters)
         {
+            _slackAnnouncer.AnnounceGameStarting(parameters.HostMachine, _logger);
             return _repository.Create(new GameDto("0", "Pending", parameters.HostMachine));
         }
     }

--- a/src/hub/src/Worms.Gateway/Controllers/GamesController.cs
+++ b/src/hub/src/Worms.Gateway/Controllers/GamesController.cs
@@ -27,5 +27,12 @@ namespace Worms.Gateway.Controllers
             var found = _repository.Get().SingleOrDefault(x => x.Id == id);
             return new GameDto(found.Id, found.Status, found.HostMachine);
         }
+        
+        [HttpPost]
+        public ActionResult<GameDto> Post(string hostMachine)
+        {
+            return _repository.Create(new GameDto("0", "Pending", hostMachine));
+            
+        }
     }
 }

--- a/src/hub/src/Worms.Gateway/Controllers/GamesController.cs
+++ b/src/hub/src/Worms.Gateway/Controllers/GamesController.cs
@@ -29,10 +29,9 @@ namespace Worms.Gateway.Controllers
         }
         
         [HttpPost]
-        public ActionResult<GameDto> Post(string hostMachine)
+        public ActionResult<GameDto> Post(CreateGameDto parameters)
         {
-            return _repository.Create(new GameDto("0", "Pending", hostMachine));
-            
+            return _repository.Create(new GameDto("0", "Pending", parameters.HostMachine));
         }
     }
 }

--- a/src/hub/src/Worms.Gateway/Database/GamesRepository.cs
+++ b/src/hub/src/Worms.Gateway/Database/GamesRepository.cs
@@ -24,19 +24,34 @@ public class GamesRepository : IRepository<GameDto>
         return dbObjects.Select(x => new GameDto(x.Id.ToString(), x.Status, x.HostMachine)).ToList();
     }
 
-    public GameDto Create(GameDto game)
+    public GameDto Create(GameDto item)
     {
         using var connection = new NpgsqlConnection(_connectionString);
         const string sql = "INSERT INTO games (status, hostmachine) VALUES (@status, @hostmachine) RETURNING id";
 
         var parameters = new
         {
-            status = game.Status,
-            hostmachine = game.HostMachine
+            status = item.Status,
+            hostmachine = item.HostMachine
         };
 
         var created = connection.QuerySingle<string>(sql, parameters);
-        return game with {Id = created};
+        return item with {Id = created};
+    }
+
+    public void Update(GameDto item)
+    {
+        using var connection = new NpgsqlConnection(_connectionString);
+        const string sql = "UPDATE games SET status = @status, hostmachine = @hostmachine WHERE id = @id";
+
+        var parameters = new
+        {
+            id = int.Parse(item.Id),
+            status = item.Status,
+            hostmachine = item.HostMachine
+        };
+
+        connection.Execute(sql, parameters);
     }
 }
 

--- a/src/hub/src/Worms.Gateway/Database/GamesRepository.cs
+++ b/src/hub/src/Worms.Gateway/Database/GamesRepository.cs
@@ -23,6 +23,16 @@ public class GamesRepository : IRepository<GameDto>
         var dbObjects = connection.Query<GamesDb>("SELECT id, status, hostmachine FROM games");
         return dbObjects.Select(x => new GameDto(x.Id.ToString(), x.Status, x.HostMachine)).ToList();
     }
+
+    public GameDto Create(GameDto game)
+    {
+        using var connection = new NpgsqlConnection(_connectionString);
+        
+        var parameters = new { Staus = game.Status, Host = game.HostMachine };
+        const string sql = "INSERT INTO games (status, hostmachine) VALUES (@Status, @Host) RETURNING id";
+        var created = connection.QuerySingle<string>(sql, parameters);
+        return new GameDto(created, game.Status, game.HostMachine);
+    }
 }
 
 public record GamesDb (int Id, string Status, string HostMachine);

--- a/src/hub/src/Worms.Gateway/Database/GamesRepository.cs
+++ b/src/hub/src/Worms.Gateway/Database/GamesRepository.cs
@@ -27,11 +27,16 @@ public class GamesRepository : IRepository<GameDto>
     public GameDto Create(GameDto game)
     {
         using var connection = new NpgsqlConnection(_connectionString);
-        
-        var parameters = new { Staus = game.Status, Host = game.HostMachine };
-        const string sql = "INSERT INTO games (status, hostmachine) VALUES (@Status, @Host) RETURNING id";
+        const string sql = "INSERT INTO games (status, hostmachine) VALUES (@status, @hostmachine) RETURNING id";
+
+        var parameters = new
+        {
+            status = game.Status,
+            hostmachine = game.HostMachine
+        };
+
         var created = connection.QuerySingle<string>(sql, parameters);
-        return new GameDto(created, game.Status, game.HostMachine);
+        return game with {Id = created};
     }
 }
 

--- a/src/hub/src/Worms.Gateway/Database/IRepository.cs
+++ b/src/hub/src/Worms.Gateway/Database/IRepository.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using Worms.Gateway.Dtos;
 
 namespace Worms.Gateway.Database;
 
 public interface IRepository<T>
 {
     IReadOnlyCollection<T> Get();
-    T Create(T game);
+    T Create(T item);
+    void Update(T item);
 }

--- a/src/hub/src/Worms.Gateway/Database/IRepository.cs
+++ b/src/hub/src/Worms.Gateway/Database/IRepository.cs
@@ -2,7 +2,8 @@
 
 namespace Worms.Gateway.Database;
 
-public interface IRepository<out T>
+public interface IRepository<T>
 {
     IReadOnlyCollection<T> Get();
+    T Create(T game);
 }

--- a/src/hub/src/Worms.Gateway/Dtos/GameDto.cs
+++ b/src/hub/src/Worms.Gateway/Dtos/GameDto.cs
@@ -1,16 +1,5 @@
 namespace Worms.Gateway.Dtos
 {
-    public class GameDto
-    {
-        public string Id { get; }
-        public string Status { get; }
-        public string HostMachine { get; }
-
-        public GameDto(string id, string status, string hostMachine)
-        {
-            Id = id;
-            Status = status;
-            HostMachine = hostMachine;
-        }
-    }
+    public record GameDto(string Id, string Status, string HostMachine);
+    public record CreateGameDto(string HostMachine);
 }

--- a/src/hub/src/Worms.Gateway/Program.cs
+++ b/src/hub/src/Worms.Gateway/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Worms.Gateway
 {
@@ -13,8 +14,10 @@ namespace Worms.Gateway
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((ctx, config) => 
+                .ConfigureLogging((_, builder) => builder.AddConsole())
+                .ConfigureAppConfiguration((_, config) => 
                     config.AddEnvironmentVariables(prefix: "WORMS_"))
+                
                 .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
     }
 }

--- a/src/hub/src/Worms.Gateway/Startup.cs
+++ b/src/hub/src/Worms.Gateway/Startup.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
+using Worms.Gateway.Announcers;
+using Worms.Gateway.Announcers.Slack;
 using Worms.Gateway.Auth;
 using Worms.Gateway.Database;
 using Worms.Gateway.Dtos;
@@ -48,6 +50,7 @@ namespace Worms.Gateway
 
             services.AddAuthorization();
             services.AddSingleton<IRepository<GameDto>, GamesRepository>();
+            services.AddSingleton<ISlackAnnouncer, SlackAnnouncer>();
 
             if (_env.IsDevelopment())
             {


### PR DESCRIPTION
This PR notifies hub when `worms host` is run with the details needed for someone else to connect to the game.
Hub then annouces the game to Slack, meaning that each player doesn't need to know the Slack hook url.
When the game finishes the record in Hub is updated to mark the game as complete.