### PR TITLE
Fix processing replays when the steam overlay doesn't appear

### DIFF
--- a/src/Worms.Armageddon.Game/Win/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner.cs
@@ -34,7 +34,7 @@ internal sealed class WormsRunner : IWormsRunner
                     _steamService.WaitForSteamPrompt();
 
                     var wormsProcess = FindWormsProcess(gameInfo);
-                    wormsProcess.WaitForExit();
+                    wormsProcess?.WaitForExit();
 
                     return Task.CompletedTask;
                 });
@@ -51,6 +51,6 @@ internal sealed class WormsRunner : IWormsRunner
             retryCount++;
         }
 
-        return wormsProcess ?? throw new InvalidOperationException("Unable to find worms process");
+        return wormsProcess;
     }
 }


### PR DESCRIPTION
Its valid for the process to not be found at this point if the steam overlay doesn't appear.