### PR TITLE
Remove RestSharp and System.CommandLine.Hosting

### DIFF
--- a/src/Worms.Armageddon.Files/Schemes/Random/RandomSchemeGenerator.cs
+++ b/src/Worms.Armageddon.Files/Schemes/Random/RandomSchemeGenerator.cs
@@ -628,9 +628,11 @@ public class RandomSchemeGenerator : IRandomSchemeGenerator
         }
     }
 
-    private IEnumerable<Weapon> DecideGuaranteedStartingWeapons(Weapon[] configWeapons) => configWeapons.Shuffle(_rng).Distinct().Take(4);
+    private IEnumerable<Weapon> DecideGuaranteedStartingWeapons(Weapon[] configWeapons) =>
+        configWeapons.Shuffle(_rng).Distinct().Take(4);
 
-    private IEnumerable<Weapon> DecideGuaranteedPowerfulWeapons(IEnumerable<Weapon> startingWeapons) => Powers.Where(x => x.Value.Length > 1).Select(x => x.Key).Except(startingWeapons).Shuffle(_rng).Take(5);
+    private IEnumerable<Weapon> DecideGuaranteedPowerfulWeapons(IEnumerable<Weapon> startingWeapons) =>
+        Powers.Where(x => x.Value.Length > 1).Select(x => x.Key).Except(startingWeapons).Shuffle(_rng).Take(5);
 
     private sbyte DecideWeaponDelay(byte powerValue, byte[] powerValues)
     {
@@ -713,7 +715,7 @@ public class RandomSchemeGenerator : IRandomSchemeGenerator
             SuperWeapons = true
         };
 
-        foreach (var weaponName in (Weapon[]) Enum.GetValues(typeof(Weapon)))
+        foreach (var weaponName in Enum.GetValues<Weapon>())
         {
             (sbyte ammo, byte power, sbyte delay, sbyte prob) = (0, 1, 0, 0);
             scheme.Weapons[weaponName].Ammo = ammo;

--- a/src/Worms.Armageddon.Files/Schemes/Text/SchemeTextReader.cs
+++ b/src/Worms.Armageddon.Files/Schemes/Text/SchemeTextReader.cs
@@ -67,7 +67,7 @@ internal class SchemeTextReader : ISchemeTextReader
         _ = ReadNextLine(b);
         _ = ReadNextLine(b);
 
-        foreach (var weaponName in (Weapon[]) Enum.GetValues(typeof(Weapon)))
+        foreach (var weaponName in Enum.GetValues<Weapon>())
         {
             var (ammo, power, delay, prob) = GetWeaponDetails(b);
             scheme.Weapons[weaponName].Ammo = ammo;

--- a/src/Worms.Armageddon.Files/Schemes/Text/SchemeTextWriter.cs
+++ b/src/Worms.Armageddon.Files/Schemes/Text/SchemeTextWriter.cs
@@ -80,7 +80,7 @@ internal class SchemeTextWriter : ISchemeTextWriter
         textWriter.WriteLine("(See http://worms2d.info/Weapons for what various power settings will do)");
         textWriter.WriteLine();
 
-        foreach (var weaponName in (Weapon[]) Enum.GetValues(typeof(Weapon)))
+        foreach (var weaponName in Enum.GetValues<Weapon>())
         {
             var weapon = definition.Weapons[weaponName];
             var ammoPadding = weapon.Ammo > 9 ? "   " : "    ";

--- a/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
+++ b/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimAnalyzers>true</TrimAnalyzers>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Autofac" Version="7.1.0"/>
     <PackageReference Include="Syroot.Worms.Armageddon" Version="4.0.3"/>

--- a/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
+++ b/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimAnalyzers>true</TrimAnalyzers>
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
+++ b/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTrimmable>true</IsTrimmable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
+++ b/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimAnalyzers>true</TrimAnalyzers>
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
+++ b/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimAnalyzers>true</TrimAnalyzers>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Autofac" Version="7.1.0"/>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0"/>

--- a/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
+++ b/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTrimmable>true</IsTrimmable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli.Resources/JsonContext.cs
+++ b/src/Worms.Cli.Resources/JsonContext.cs
@@ -11,6 +11,7 @@ namespace Worms.Cli.Resources;
 [JsonSerializable(typeof(LatestCliDtoV1))]
 [JsonSerializable(typeof(CreateGameDtoV1))]
 [JsonSerializable(typeof(GamesDtoV1))]
+[JsonSerializable(typeof(IReadOnlyCollection<GamesDtoV1>))]
 [JsonSerializable(typeof(CreateReplayDtoV1))]
 [JsonSerializable(typeof(ReplayDtoV1))]
 internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/Worms.Cli.Resources/JsonContext.cs
+++ b/src/Worms.Cli.Resources/JsonContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+using Worms.Cli.Resources.Remote;
+using Worms.Cli.Resources.Remote.Auth;
+using Worms.Cli.Resources.Remote.Auth.Responses;
+
+namespace Worms.Cli.Resources;
+
+[JsonSerializable(typeof(DeviceAuthorizationResponse))]
+[JsonSerializable(typeof(TokenResponse))]
+[JsonSerializable(typeof(AccessTokens))]
+[JsonSerializable(typeof(LatestCliDtoV1))]
+[JsonSerializable(typeof(CreateGameDtoV1))]
+[JsonSerializable(typeof(GamesDtoV1))]
+[JsonSerializable(typeof(CreateReplayDtoV1))]
+[JsonSerializable(typeof(ReplayDtoV1))]
+internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/Worms.Cli.Resources/Remote/Auth/AccessTokenRefreshService.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/AccessTokenRefreshService.cs
@@ -1,30 +1,39 @@
 using System.Text.Json;
-using RestSharp;
 
 namespace Worms.Cli.Resources.Remote.Auth;
 
-internal sealed class AccessTokenRefreshService : IAccessTokenRefreshService
+internal sealed class AccessTokenRefreshService(IHttpClientFactory httpClientFactory) : IAccessTokenRefreshService
 {
     private const string Authority = "https://eadie.eu.auth0.com";
     private const string ClientId = "0dBbKeIKO2UAzWfBh6LuGwWYSWGZPFHB";
 
     public async Task<AccessTokens> RefreshAccessTokens(AccessTokens current)
     {
-        using var client = new RestClient(Authority);
-        var request = new RestRequest("oauth/token", Method.Post);
-        _ = request.AddHeader("content-type", "application/x-www-form-urlencoded");
-        _ = request.AddParameter(
-            "application/x-www-form-urlencoded",
-            $"grant_type=refresh_token&client_id={ClientId}&refresh_token={current.RefreshToken}",
-            ParameterType.RequestBody);
-        var response = await client.ExecuteAsync(request).ConfigureAwait(false);
-
-        if (!response.IsSuccessful)
+        if (current.RefreshToken is null)
         {
-            throw response.ErrorException ?? throw new HttpRequestException(response.ErrorMessage);
+            throw new InvalidOperationException("Cannot refresh access tokens without a refresh token");
         }
 
-        var result = JsonSerializer.Deserialize(response.Content!, JsonContext.Default.TokenResponse)
+        using var httpClient = httpClientFactory.CreateClient();
+        httpClient.BaseAddress = new Uri(Authority);
+
+        using var content = new FormUrlEncodedContent(
+            new Dictionary<string, string>
+            {
+                { "grant_type", "refresh_token" },
+                { "client_id", ClientId },
+                { "refresh_token", current.RefreshToken }
+            });
+
+        var response = await httpClient.PostAsync(new Uri("oauth/token", UriKind.Relative), content)
+            .ConfigureAwait(false);
+
+        _ = response.EnsureSuccessStatusCode();
+
+        var streamAsync = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        await using var stream = streamAsync.ConfigureAwait(false);
+        var result =
+            await JsonSerializer.DeserializeAsync(streamAsync, JsonContext.Default.TokenResponse).ConfigureAwait(false)
             ?? throw new JsonException("The API returned success but the JSON response was empty");
 
         return current with { AccessToken = result.AccessToken };

--- a/src/Worms.Cli.Resources/Remote/Auth/AccessTokenRefreshService.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/AccessTokenRefreshService.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using RestSharp;
 
 namespace Worms.Cli.Resources.Remote.Auth;
@@ -25,21 +24,9 @@ internal sealed class AccessTokenRefreshService : IAccessTokenRefreshService
             throw response.ErrorException ?? throw new HttpRequestException(response.ErrorMessage);
         }
 
-        var result = JsonSerializer.Deserialize<TokenResponse>(response.Content!)
+        var result = JsonSerializer.Deserialize(response.Content!, JsonContext.Default.TokenResponse)
             ?? throw new JsonException("The API returned success but the JSON response was empty");
 
         return current with { AccessToken = result.AccessToken };
     }
-
-    private sealed record TokenResponse(
-        [property: JsonPropertyName("access_token")]
-        string AccessToken,
-        [property: JsonPropertyName("refresh_token")]
-        string RefreshToken,
-        [property: JsonPropertyName("id_token")]
-        string IdToken,
-        [property: JsonPropertyName("token_type")]
-        string TokenType,
-        [property: JsonPropertyName("expires_in")]
-        int ExpiresIn);
 }

--- a/src/Worms.Cli.Resources/Remote/Auth/Responses/DeviceAuthorizationResponse.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/Responses/DeviceAuthorizationResponse.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Worms.Cli.Resources.Remote.Auth.Responses;
+
+internal sealed record DeviceAuthorizationResponse(
+    [property: JsonPropertyName("device_code")]
+    string DeviceCode,
+    [property: JsonPropertyName("user_code")]
+    string UserCode,
+    [property: JsonPropertyName("verification_uri")]
+    Uri VerificationUri,
+    [property: JsonPropertyName("expires_in")]
+    int ExpiresIn,
+    [property: JsonPropertyName("interval")]
+    int Interval,
+    [property: JsonPropertyName("verification_uri_complete")]
+    Uri VerificationUriComplete);

--- a/src/Worms.Cli.Resources/Remote/Auth/Responses/TokenResponse.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/Responses/TokenResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Worms.Cli.Resources.Remote.Auth.Responses;
+
+internal sealed record TokenResponse(
+    [property: JsonPropertyName("access_token")]
+    string AccessToken,
+    [property: JsonPropertyName("refresh_token")]
+    string RefreshToken,
+    [property: JsonPropertyName("id_token")]
+    string IdToken,
+    [property: JsonPropertyName("token_type")]
+    string TokenType,
+    [property: JsonPropertyName("expires_in")]
+    int ExpiresIn);

--- a/src/Worms.Cli.Resources/Remote/Auth/TokenStore.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/TokenStore.cs
@@ -29,7 +29,7 @@ internal sealed class TokenStore : ITokenStore
         if (_fileSystem.File.Exists(_tokenStorePath))
         {
             var fileContent = _fileSystem.File.ReadAllText(_tokenStorePath);
-            var protectedTokens = JsonSerializer.Deserialize<AccessTokens>(fileContent);
+            var protectedTokens = JsonSerializer.Deserialize(fileContent, JsonContext.Default.AccessTokens);
 
             if (protectedTokens is null)
             {
@@ -65,6 +65,8 @@ internal sealed class TokenStore : ITokenStore
             _ = _fileSystem.Directory.CreateDirectory(_tokenStoreFolder);
         }
 
-        _fileSystem.File.WriteAllText(_tokenStorePath, JsonSerializer.Serialize(protectedTokens));
+        _fileSystem.File.WriteAllText(
+            _tokenStorePath,
+            JsonSerializer.Serialize(protectedTokens, JsonContext.Default.AccessTokens));
     }
 }

--- a/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
+++ b/src/Worms.Cli.Resources/Remote/Games/RemoteGameCreator.cs
@@ -9,7 +9,7 @@ internal sealed class RemoteGameCreator(IWormsServerApi api) : IResourceCreator<
     {
         try
         {
-            var apiGame = await api.CreateGame(new WormsServerApi.CreateGameDtoV1(parameters));
+            var apiGame = await api.CreateGame(new CreateGameDtoV1(parameters));
             return new RemoteGame(apiGame.Id, apiGame.Status, apiGame.HostMachine);
         }
         catch (HttpRequestException e)

--- a/src/Worms.Cli.Resources/Remote/Games/RemoteGameUpdater.cs
+++ b/src/Worms.Cli.Resources/Remote/Games/RemoteGameUpdater.cs
@@ -9,7 +9,7 @@ internal sealed class RemoteGameUpdater(IWormsServerApi api) : IRemoteGameUpdate
     {
         try
         {
-            await api.UpdateGame(new WormsServerApi.GamesDtoV1(game.Id, "Complete", game.HostMachine));
+            await api.UpdateGame(new GamesDtoV1(game.Id, "Complete", game.HostMachine));
         }
         catch (HttpRequestException e)
         {

--- a/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
+++ b/src/Worms.Cli.Resources/Remote/IWormsServerApi.cs
@@ -2,15 +2,15 @@ namespace Worms.Cli.Resources.Remote;
 
 internal interface IWormsServerApi
 {
-    Task<WormsServerApi.LatestCliDtoV1> GetLatestCliDetails();
+    Task<LatestCliDtoV1> GetLatestCliDetails();
 
     Task<byte[]> DownloadLatestCli(string platform);
 
-    Task<IReadOnlyCollection<WormsServerApi.GamesDtoV1>> GetGames();
+    Task<IReadOnlyCollection<GamesDtoV1>> GetGames();
 
-    Task<WormsServerApi.GamesDtoV1> CreateGame(WormsServerApi.CreateGameDtoV1 hostMachineName);
+    Task<GamesDtoV1> CreateGame(CreateGameDtoV1 hostMachineName);
 
-    Task UpdateGame(WormsServerApi.GamesDtoV1 newGameDetails);
+    Task UpdateGame(GamesDtoV1 newGameDetails);
 
-    Task<WormsServerApi.ReplayDtoV1> CreateReplay(WormsServerApi.CreateReplayDtoV1 replayFilePath);
+    Task<ReplayDtoV1> CreateReplay(CreateReplayDtoV1 replayFilePath);
 }

--- a/src/Worms.Cli.Resources/Remote/Replays/RemoteReplayCreator.cs
+++ b/src/Worms.Cli.Resources/Remote/Replays/RemoteReplayCreator.cs
@@ -3,8 +3,8 @@ using Serilog;
 
 namespace Worms.Cli.Resources.Remote.Replays;
 
-internal sealed class RemoteReplayCreator
-    (IWormsServerApi api) : IResourceCreator<RemoteReplay, RemoteReplayCreateParameters>
+internal sealed class RemoteReplayCreator(IWormsServerApi api)
+    : IResourceCreator<RemoteReplay, RemoteReplayCreateParameters>
 {
     public async Task<RemoteReplay> Create(
         RemoteReplayCreateParameters parameters,
@@ -13,8 +13,7 @@ internal sealed class RemoteReplayCreator
     {
         try
         {
-            var apiReplay = await api.CreateReplay(
-                new WormsServerApi.CreateReplayDtoV1(parameters.Name, parameters.FilePath));
+            var apiReplay = await api.CreateReplay(new CreateReplayDtoV1(parameters.Name, parameters.FilePath));
             return new RemoteReplay(apiReplay.Id, apiReplay.Name, apiReplay.Status);
         }
         catch (HttpRequestException e)

--- a/src/Worms.Cli.Resources/Remote/WormsServerDtos.cs
+++ b/src/Worms.Cli.Resources/Remote/WormsServerDtos.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace Worms.Cli.Resources.Remote;
+
+public sealed record LatestCliDtoV1(
+    [property: JsonPropertyName("latestVersion")]
+    Version LatestVersion,
+    [property: JsonPropertyName("fileLocations")]
+    IReadOnlyDictionary<string, string> FileLocations);
+
+public sealed record CreateGameDtoV1(
+    [property: JsonPropertyName("hostMachine")]
+    string HostMachine);
+
+public sealed record GamesDtoV1(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("hostMachine")]
+    string HostMachine);
+
+public sealed record CreateReplayDtoV1(string Name, string ReplayFilePath);
+
+public sealed record ReplayDtoV1(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("status")] string Status);

--- a/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
+++ b/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimAnalyzers>true</TrimAnalyzers>
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
+++ b/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0"/>
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="8.0.0"/>
-    <PackageReference Include="RestSharp" Version="110.2.0"/>
     <PackageReference Include="Serilog" Version="3.1.1"/>
   </ItemGroup>
 

--- a/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
+++ b/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTrimmable>true</IsTrimmable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
+++ b/src/Worms.Cli.Resources/Worms.Cli.Resources.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimAnalyzers>true</TrimAnalyzers>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions" Version="20.0.4"/>
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0"/>

--- a/src/Worms.Cli/CliStructure.cs
+++ b/src/Worms.Cli/CliStructure.cs
@@ -1,4 +1,7 @@
-﻿using System.CommandLine.Builder;
+﻿using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using Microsoft.Extensions.DependencyInjection;
 using Worms.Cli.Commands;
 using Worms.Cli.Commands.Resources;
 using Worms.Cli.Commands.Resources.Games;
@@ -11,45 +14,53 @@ namespace Worms.Cli;
 
 internal static class CliStructure
 {
-    internal static CommandLineBuilder BuildCommandLine()
+    internal static CommandLineBuilder BuildCommandLine(IServiceProvider serviceProvider)
     {
         var rootCommand = new Root();
-        rootCommand.AddCommand(new Auth());
-        rootCommand.AddCommand(new Version());
-        rootCommand.AddCommand(new Update());
-        rootCommand.AddCommand(new Setup());
-        rootCommand.AddCommand(new Host());
+        rootCommand.Add<Auth, AuthHandler>(serviceProvider);
+        rootCommand.Add<Version, VersionHandler>(serviceProvider);
+        rootCommand.Add<Update, UpdateHandler>(serviceProvider);
+        rootCommand.Add<Setup, SetupHandler>(serviceProvider);
+        rootCommand.Add<Host, HostHandler>(serviceProvider);
 
         var viewCommand = new View();
-        viewCommand.AddCommand(new ViewReplay());
+        viewCommand.Add<ViewReplay, ViewReplayHandler>(serviceProvider);
         rootCommand.AddCommand(viewCommand);
 
         var processCommand = new Process();
-        processCommand.AddCommand(new ProcessReplay());
+        processCommand.Add<ProcessReplay, ProcessReplayHandler>(serviceProvider);
         rootCommand.AddCommand(processCommand);
 
         var getCommand = new Get();
-        getCommand.AddCommand(new GetScheme());
-        getCommand.AddCommand(new GetReplay());
-        getCommand.AddCommand(new GetGame());
+        getCommand.Add<GetScheme, GetSchemeHandler>(serviceProvider);
+        getCommand.Add<GetReplay, GetReplayHandler>(serviceProvider);
+        getCommand.Add<GetGame, GetGameHandler>(serviceProvider);
         rootCommand.AddCommand(getCommand);
 
         var deleteCommand = new Delete();
-        deleteCommand.AddCommand(new DeleteScheme());
-        deleteCommand.AddCommand(new DeleteReplay());
+        deleteCommand.Add<DeleteScheme, DeleteSchemeHandler>(serviceProvider);
+        deleteCommand.Add<DeleteReplay, DeleteReplayHandler>(serviceProvider);
         rootCommand.AddCommand(deleteCommand);
 
         var createCommand = new Create();
-        createCommand.AddCommand(new CreateScheme());
-        createCommand.AddCommand(new CreateGif());
+        createCommand.Add<CreateScheme, CreateSchemeHandler>(serviceProvider);
+        createCommand.Add<CreateGif, CreateGifHandler>(serviceProvider);
         rootCommand.AddCommand(createCommand);
 
         var browseCommand = new Browse();
-        browseCommand.AddCommand(new BrowseScheme());
-        browseCommand.AddCommand(new BrowseReplay());
-        browseCommand.AddCommand(new BrowseGif());
+        browseCommand.Add<BrowseScheme, BrowseSchemeHandler>(serviceProvider);
+        browseCommand.Add<BrowseReplay, BrowseReplayHandler>(serviceProvider);
+        browseCommand.Add<BrowseGif, BrowseGifHandler>(serviceProvider);
         rootCommand.AddCommand(browseCommand);
 
         return new CommandLineBuilder(rootCommand);
+    }
+
+    private static void Add<TC, TH>(this Command rootCommand, IServiceProvider serviceProvider)
+        where TC : Command, new() where TH : ICommandHandler
+    {
+        var auth = new TC();
+        auth.SetHandler(context => serviceProvider.GetRequiredService<TH>().InvokeAsync(context));
+        rootCommand.AddCommand(auth);
     }
 }

--- a/src/Worms.Cli/CommandLine/PackageManagers/GitHubReleasesPackageManager.cs
+++ b/src/Worms.Cli/CommandLine/PackageManagers/GitHubReleasesPackageManager.cs
@@ -53,10 +53,8 @@ public class GitHubReleasePackageManager
 
         foreach (var file in files)
         {
-            var raw = await _gitHubClient.Connection.Get<byte[]>(
-                    new Uri(file.Url),
-                    new Dictionary<string, string>(),
-                    "application/octet-stream")
+            var raw = await _gitHubClient.Connection
+                .GetRaw(new Uri(file.BrowserDownloadUrl), new Dictionary<string, string>())
                 .ConfigureAwait(false);
             await File.WriteAllBytesAsync(Path.Combine(downloadToFolderPath, file.Name), raw.Body)
                 .ConfigureAwait(false);

--- a/src/Worms.Cli/Commands/Auth.cs
+++ b/src/Worms.Cli/Commands/Auth.cs
@@ -12,7 +12,6 @@ internal sealed class Auth : Command
         AddAlias("login");
 }
 
-// ReSharper disable once ClassNeverInstantiated.Global
 internal sealed class AuthHandler(ILoginService loginService, ILogger logger) : ICommandHandler
 {
     public int Invoke(InvocationContext context) => Task.Run(async () => await InvokeAsync(context)).Result;

--- a/src/Worms.Cli/Commands/Host.cs
+++ b/src/Worms.Cli/Commands/Host.cs
@@ -51,7 +51,6 @@ internal sealed class Host : Command
     }
 }
 
-// ReSharper disable once ClassNeverInstantiated.Global
 internal sealed class HostHandler(
     IWormsLocator wormsLocator,
     IWormsRunner wormsRunner,

--- a/src/Worms.Cli/Commands/Version.cs
+++ b/src/Worms.Cli/Commands/Version.cs
@@ -12,11 +12,8 @@ internal sealed class Version : Command
         : base("version", "Get the current version of the Worms CLI") { }
 }
 
-// ReSharper disable once ClassNeverInstantiated.Global
-internal sealed class VersionHandler(
-    IWormsLocator wormsLocator,
-    CliInfoRetriever cliInfoRetriever,
-    ILogger logger) : ICommandHandler
+internal sealed class VersionHandler(IWormsLocator wormsLocator, CliInfoRetriever cliInfoRetriever, ILogger logger)
+    : ICommandHandler
 {
     public int Invoke(InvocationContext context) => Task.Run(async () => await InvokeAsync(context)).Result;
 

--- a/src/Worms.Cli/Configuration/ConfigManager.cs
+++ b/src/Worms.Cli/Configuration/ConfigManager.cs
@@ -36,7 +36,7 @@ internal sealed class ConfigManager : IConfigManager
         if (_fileSystem.File.Exists(configPath))
         {
             var configContent = _fileSystem.File.ReadAllText(configPath);
-            var config = JsonSerializer.Deserialize<Config>(configContent);
+            var config = JsonSerializer.Deserialize(configContent, JsonContext.Default.Config);
             return config ?? new Config();
         }
 
@@ -56,6 +56,8 @@ internal sealed class ConfigManager : IConfigManager
             SlackWebHook = config.SlackWebHook
         };
 
-        _fileSystem.File.WriteAllText(_localConfigPath, JsonSerializer.Serialize(localConfig));
+        _fileSystem.File.WriteAllText(
+            _localConfigPath,
+            JsonSerializer.Serialize(localConfig, JsonContext.Default.Config));
     }
 }

--- a/src/Worms.Cli/JsonContext.cs
+++ b/src/Worms.Cli/JsonContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+using Worms.Cli.Configuration;
+using Worms.Cli.Slack;
+
+namespace Worms.Cli;
+
+[JsonSerializable(typeof(SlackMessage))]
+[JsonSerializable(typeof(Config))]
+internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/Worms.Cli/Modules/CliModule.cs
+++ b/src/Worms.Cli/Modules/CliModule.cs
@@ -5,6 +5,11 @@ using Worms.Armageddon.Files.Modules;
 using Worms.Armageddon.Game.Modules;
 using Worms.Cli.CommandLine;
 using Worms.Cli.CommandLine.PackageManagers;
+using Worms.Cli.Commands;
+using Worms.Cli.Commands.Resources.Games;
+using Worms.Cli.Commands.Resources.Gifs;
+using Worms.Cli.Commands.Resources.Replays;
+using Worms.Cli.Commands.Resources.Schemes;
 using Worms.Cli.Configuration;
 using Worms.Cli.League;
 using Worms.Cli.Resources;
@@ -24,6 +29,29 @@ public class CliModule : Module
     protected override void Load(ContainerBuilder builder)
     {
         RegisterOsModules(builder);
+
+        // Commands
+        _ = builder.RegisterType<AuthHandler>();
+        _ = builder.RegisterType<HostHandler>();
+        _ = builder.RegisterType<SetupHandler>();
+        _ = builder.RegisterType<UpdateHandler>();
+        _ = builder.RegisterType<VersionHandler>();
+
+        _ = builder.RegisterType<GetGameHandler>();
+
+        _ = builder.RegisterType<BrowseGifHandler>();
+        _ = builder.RegisterType<CreateGifHandler>();
+
+        _ = builder.RegisterType<BrowseReplayHandler>();
+        _ = builder.RegisterType<DeleteReplayHandler>();
+        _ = builder.RegisterType<GetReplayHandler>();
+        _ = builder.RegisterType<ProcessReplayHandler>();
+        _ = builder.RegisterType<ViewReplayHandler>();
+
+        _ = builder.RegisterType<BrowseSchemeHandler>();
+        _ = builder.RegisterType<CreateSchemeHandler>();
+        _ = builder.RegisterType<DeleteSchemeHandler>();
+        _ = builder.RegisterType<GetSchemeHandler>();
 
         // FileSystem
         _ = builder.RegisterType<FileSystem>().As<IFileSystem>();

--- a/src/Worms.Cli/Program.cs
+++ b/src/Worms.Cli/Program.cs
@@ -1,22 +1,13 @@
 ﻿using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
 using System.CommandLine.Parsing;
 using System.Globalization;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
-using Worms.Cli.Commands;
-using Worms.Cli.Commands.Resources.Games;
-using Worms.Cli.Commands.Resources.Gifs;
-using Worms.Cli.Commands.Resources.Replays;
-using Worms.Cli.Commands.Resources.Schemes;
 using Worms.Cli.Logging;
 using Worms.Cli.Modules;
-using Version = Worms.Cli.Commands.Version;
-using Host = Worms.Cli.Commands.Host;
 
 namespace Worms.Cli;
 
@@ -24,45 +15,28 @@ internal static class Program
 {
     public static async Task<int> Main(string[] args)
     {
+        var serviceProvider = GetServiceProvider(args);
+        var runner = CliStructure.BuildCommandLine(serviceProvider).UseDefaults().Build();
+
+        var result = await runner.InvokeAsync(args).ConfigureAwait(false);
+
+        await serviceProvider.DisposeAsync().ConfigureAwait(false);
+        return result;
+    }
+
+    private static AutofacServiceProvider GetServiceProvider(string[] args)
+    {
         var logger = new LoggerConfiguration().MinimumLevel.Is(GetLogEventLevel(args))
             .WriteTo.ColoredConsole(formatProvider: CultureInfo.CurrentCulture)
             .CreateLogger();
 
-        var runner = CliStructure.BuildCommandLine()
-            .UseHost(
-                _ => new HostBuilder(),
-                (builder) =>
-                    {
-                        _ = builder.ConfigureServices(x => x.AddHttpClient());
-                        _ = builder.UseServiceProviderFactory(new AutofacServiceProviderFactory())
-                            .ConfigureContainer<ContainerBuilder>(
-                                container =>
-                                    {
-                                        _ = container.RegisterModule<CliModule>();
-                                        _ = container.RegisterInstance<ILogger>(logger);
-                                    })
-                            .UseCommandHandler<Auth, AuthHandler>()
-                            .UseCommandHandler<Version, VersionHandler>()
-                            .UseCommandHandler<Update, UpdateHandler>()
-                            .UseCommandHandler<Setup, SetupHandler>()
-                            .UseCommandHandler<Host, HostHandler>()
-                            .UseCommandHandler<ViewReplay, ViewReplayHandler>()
-                            .UseCommandHandler<ProcessReplay, ProcessReplayHandler>()
-                            .UseCommandHandler<GetScheme, GetSchemeHandler>()
-                            .UseCommandHandler<GetReplay, GetReplayHandler>()
-                            .UseCommandHandler<GetGame, GetGameHandler>()
-                            .UseCommandHandler<DeleteScheme, DeleteSchemeHandler>()
-                            .UseCommandHandler<DeleteReplay, DeleteReplayHandler>()
-                            .UseCommandHandler<CreateScheme, CreateSchemeHandler>()
-                            .UseCommandHandler<CreateGif, CreateGifHandler>()
-                            .UseCommandHandler<BrowseScheme, BrowseSchemeHandler>()
-                            .UseCommandHandler<BrowseReplay, BrowseReplayHandler>()
-                            .UseCommandHandler<BrowseGif, BrowseGifHandler>();
-                    })
-            .UseDefaults()
-            .Build();
-
-        return await runner.InvokeAsync(args);
+        var serviceCollection = new ServiceCollection().AddHttpClient();
+        var containerBuilder = new ContainerBuilder();
+        containerBuilder.Populate(serviceCollection);
+        _ = containerBuilder.RegisterModule<CliModule>();
+        _ = containerBuilder.RegisterInstance<ILogger>(logger);
+        var container = containerBuilder.Build();
+        return new AutofacServiceProvider(container);
     }
 
     private static LogEventLevel GetLogEventLevel(string[] args) =>

--- a/src/Worms.Cli/Resources/Schemes/SchemeTextPrinter.cs
+++ b/src/Worms.Cli/Resources/Schemes/SchemeTextPrinter.cs
@@ -40,7 +40,7 @@ internal sealed class SchemeTextPrinter(ISchemeTextWriter schemeTextWriter) : IR
     private static string GetWeaponSummary(Scheme.WeaponList weapons)
     {
         var summary = "";
-        foreach (var weaponName in (Weapon[]) Enum.GetValues(typeof(Weapon)))
+        foreach (var weaponName in Enum.GetValues<Weapon>())
         {
             var weapon = weapons[weaponName];
             if (weapon.Ammo > 0)

--- a/src/Worms.Cli/Slack/SlackAnnouncer.cs
+++ b/src/Worms.Cli/Slack/SlackAnnouncer.cs
@@ -17,8 +17,8 @@ internal sealed class SlackAnnouncer : ISlackAnnouncer
         var slackMessage = new SlackMessage { Text = $"<!here> Hosting at: wa://{hostName}" };
 
         using var client = new HttpClient();
-        var slackUrl = new System.Uri(webHookUrl);
-        var body = JsonSerializer.Serialize(slackMessage);
+        var slackUrl = new Uri(webHookUrl);
+        var body = JsonSerializer.Serialize(slackMessage, JsonContext.Default.SlackMessage);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
 
         var response = await client.PostAsync(slackUrl, content).ConfigureAwait(false);

--- a/src/Worms.Cli/Worms.Cli.csproj
+++ b/src/Worms.Cli/Worms.Cli.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1"/>
     <PackageReference Include="System.IO.Abstractions" Version="20.0.4"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli/Worms.Cli.csproj
+++ b/src/Worms.Cli/Worms.Cli.csproj
@@ -4,8 +4,9 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>worms</AssemblyName>
     <Version>0.0.1</Version>
-    <IsTrimmable>true</IsTrimmable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli/Worms.Cli.csproj
+++ b/src/Worms.Cli/Worms.Cli.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0"/>
     <PackageReference Include="Octokit" Version="9.0.0"/>
     <PackageReference Include="Newtonsoft.json" Version="13.0.3"/>
-    <PackageReference Include="RestSharp" Version="110.2.0"/>
     <PackageReference Include="Serilog" Version="3.1.1"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1"/>
     <PackageReference Include="System.IO.Abstractions" Version="20.0.4"/>

--- a/src/Worms.Cli/Worms.Cli.csproj
+++ b/src/Worms.Cli/Worms.Cli.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>worms</AssemblyName>
     <Version>0.0.1</Version>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimAnalyzers>true</TrimAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli/Worms.Cli.csproj
+++ b/src/Worms.Cli/Worms.Cli.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>worms</AssemblyName>
     <Version>0.0.1</Version>
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimAnalyzers>true</TrimAnalyzers>
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Enable Trimming and AOT analysers and fix warnings
- Removes two dependencies that require reflection to work.

Still need to remove:
- Autofac
- Octokit
- Serilog

as these all require reflection and produce triming warnings.
