### PR TITLE
Fix issue with upgrading from 0.26.x

### DIFF
--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -57,6 +57,7 @@ cli.package.windows: cli.version
             /p:PublishSingleFile=true \
             /p:Version=$(cli_VERSION) \
             /p:DebugType=none
+	@cp src/Worms.Cli/*.ps1 .artifacts/win-x64/
 	@echo $(cli_VERSION) > .artifacts/win-x64/version.txt
 	@echo ""
 

--- a/src/Worms.Cli/Install.ps1
+++ b/src/Worms.Cli/Install.ps1
@@ -1,0 +1,14 @@
+## This script remains for updates from versions before 0.27.0
+$installDirPath = Join-Path $env:LOCALAPPDATA '\Programs\Worms\'
+$updateDirPath = $PSScriptRoot + '\*'
+
+function Install-Cli() {
+    if(!(test-path $installDirPath))
+    {
+        New-Item -ItemType Directory -Force -Path $installDirPath | Out-Null
+    }
+
+    Copy-item -Force -Recurse $updateDirPath -Destination $installDirPath
+}
+
+Install-Cli


### PR DESCRIPTION
Brings back the Install.ps1 script that is expected in the `.update` directory to complete installation when upgrading from a version before 0.27.0