### PR TITLE
Use Azure managed certs rather than manual refresh

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -48,6 +48,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Get Database Version
         id: database-version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Get Version
         id: database-version

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
@@ -1,6 +1,6 @@
 config:
   azure-native:location: northeurope
-  worms.davideadie.dev:domain: davideadie.dev
-  worms.davideadie.dev:subdomain: worms
-  worms.davideadie.dev:slack_hook_url:
-    secure: AAABAMBDbCuFxnGggS6osWhsab+EvI++gQGZ6sHowT7s4AlPVjwe3STavCoYRQJ3fhff+OTMvB1JBcUu1g/sVvmY2Q3+KBOOq8E9CDuWuGWxV59kLZ1IZR/+DM8iI9dAO2xzoLUZW7LiX/EqMQ==
+  worms-hub:domain: davideadie.dev
+  worms-hub:slack_hook_url:
+    secure: AAABAJJds0CqFrxrEAzqlacvLr+wJ9HSE5idZ4LJpCdEmDJVmYwgFNWKQQOAOvKHo/EXHdrvLB1qw+EAsFUKeqltTo25bDJVblFBTenskUpyQbhNLx9idtlEV+Tz44PEAX570ExqggwWq1nD/A==
+  worms-hub:subdomain: worms

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
@@ -1,4 +1,5 @@
 config:
   azure-native:location: northeurope
+  worms.davideadie.dev:domain: worms.davideadie.dev
   worms.davideadie.dev:slack_hook_url:
     secure: AAABAMBDbCuFxnGggS6osWhsab+EvI++gQGZ6sHowT7s4AlPVjwe3STavCoYRQJ3fhff+OTMvB1JBcUu1g/sVvmY2Q3+KBOOq8E9CDuWuGWxV59kLZ1IZR/+DM8iI9dAO2xzoLUZW7LiX/EqMQ==

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
@@ -1,5 +1,6 @@
 config:
   azure-native:location: northeurope
-  worms.davideadie.dev:domain: worms.davideadie.dev
+  worms.davideadie.dev:domain: davideadie.dev
+  worms.davideadie.dev:subdomain: worms
   worms.davideadie.dev:slack_hook_url:
     secure: AAABAMBDbCuFxnGggS6osWhsab+EvI++gQGZ6sHowT7s4AlPVjwe3STavCoYRQJ3fhff+OTMvB1JBcUu1g/sVvmY2Q3+KBOOq8E9CDuWuGWxV59kLZ1IZR/+DM8iI9dAO2xzoLUZW7LiX/EqMQ==

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
@@ -2,5 +2,5 @@ config:
   azure-native:location: northeurope
   worms-hub:domain: davideadie.dev
   worms-hub:slack_hook_url:
-    secure: AAABAFCWyz8K+xluP2PyHN10orbX/aJ0au6VA9LhpnfpuBb21ZT4jd84/EeHXLrpBkCaGuQs3uR68K9ZLJbFnbDptwR1QjHMk4Bm73HI1/TTCbpzqZ4nS4S80JSaPL9o2qoqczZc6ogbjbArKw==
+    secure: AAABALd+pKgZTMNqRUNq86YIneHsqbzGvE7BO3QBzA3sp6mN767fmYvVgSwrNebHZjnz/Un9xeng5Bo2ykuP0OBASmFztfdIc3XS00sfGcCbyKHG6hdZJJRZA3nhqgJMQyqr/ocp4/Z02jOwEQ==
   worms-hub:subdomain: worms

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.prod.yaml
@@ -2,5 +2,5 @@ config:
   azure-native:location: northeurope
   worms-hub:domain: davideadie.dev
   worms-hub:slack_hook_url:
-    secure: AAABAJJds0CqFrxrEAzqlacvLr+wJ9HSE5idZ4LJpCdEmDJVmYwgFNWKQQOAOvKHo/EXHdrvLB1qw+EAsFUKeqltTo25bDJVblFBTenskUpyQbhNLx9idtlEV+Tz44PEAX570ExqggwWq1nD/A==
+    secure: AAABAFCWyz8K+xluP2PyHN10orbX/aJ0au6VA9LhpnfpuBb21ZT4jd84/EeHXLrpBkCaGuQs3uR68K9ZLJbFnbDptwR1QjHMk4Bm73HI1/TTCbpzqZ4nS4S80JSaPL9o2qoqczZc6ogbjbArKw==
   worms-hub:subdomain: worms

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
@@ -1,5 +1,6 @@
 config:
   azure-native:location: northeurope
-  worms.davideadie.dev:domain: worms-test.davideadie.dev
+  worms.davideadie.dev:domain: davideadie.dev
+  worms.davideadie.dev:subdomain: worms-test
   worms.davideadie.dev:slack_hook_url:
     secure: AAABANi2KS6KFb/mnNmv5rsAZ9PeBl5dSJ1gxstw37Sixi0k2Vjbz4CCSnImDcCGA3BURUqLUI7TicF+UQm6kBu2Cttb

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
@@ -1,4 +1,5 @@
 config:
   azure-native:location: northeurope
+  worms.davideadie.dev:domain: worms-test.davideadie.dev
   worms.davideadie.dev:slack_hook_url:
     secure: AAABANi2KS6KFb/mnNmv5rsAZ9PeBl5dSJ1gxstw37Sixi0k2Vjbz4CCSnImDcCGA3BURUqLUI7TicF+UQm6kBu2Cttb

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
@@ -2,5 +2,5 @@ config:
   azure-native:location: northeurope
   worms-hub:domain: davideadie.dev
   worms-hub:slack_hook_url:
-    secure: AAABAEhSZl9/AVw7APPVVIda8K3LXd4l/SKpsgo31dNMngodprdn5lI3vp4Q5WagmzNCTpsiHePMAv2d0dC0lJqWNrQ+
+    secure: AAABAAMvb4/GY6hYkLsoGafwNLY4qwCOFTHh++kvTGvTBKXiYHM4BsPjjVVWAokimCc9skYPKfPZEHAmkRAR1x4/5a8U
   worms-hub:subdomain: worms-test

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.test.yaml
@@ -1,6 +1,6 @@
 config:
   azure-native:location: northeurope
-  worms.davideadie.dev:domain: davideadie.dev
-  worms.davideadie.dev:subdomain: worms-test
-  worms.davideadie.dev:slack_hook_url:
-    secure: AAABANi2KS6KFb/mnNmv5rsAZ9PeBl5dSJ1gxstw37Sixi0k2Vjbz4CCSnImDcCGA3BURUqLUI7TicF+UQm6kBu2Cttb
+  worms-hub:domain: davideadie.dev
+  worms-hub:slack_hook_url:
+    secure: AAABAEhSZl9/AVw7APPVVIda8K3LXd4l/SKpsgo31dNMngodprdn5lI3vp4Q5WagmzNCTpsiHePMAv2d0dC0lJqWNrQ+
+  worms-hub:subdomain: worms-test

--- a/deployment/Worms.Hub.Infrastructure/Pulumi.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.yaml
@@ -1,3 +1,3 @@
-name: worms.davideadie.dev
+name: worms-hub
 runtime: dotnet
 description: The Worms Hub Server

--- a/deployment/Worms.Hub.Infrastructure/Worms.Hub.Infrastructure.csproj
+++ b/deployment/Worms.Hub.Infrastructure/Worms.Hub.Infrastructure.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
       <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+      <PackageReference Include="Pulumi.Cloudflare" Version="5.35.1" />
       <PackageReference Include="Pulumi.Random" Version="4.16.3" />
   </ItemGroup>
 

--- a/deployment/Worms.Hub.Infrastructure/src/ContainerApps/Dns.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/ContainerApps/Dns.cs
@@ -1,0 +1,38 @@
+﻿using Pulumi;
+using Pulumi.AzureNative.App;
+using Cloudflare = Pulumi.Cloudflare;
+
+namespace Worms.Hub.Infrastructure.ContainerApps;
+
+public class Dns
+{
+    public static void Config(Config config, ManagedEnvironment managedEnvironment)
+    {
+        var subdomain = config.Require("subdomain");
+        var domain = config.Require("domain");
+        var ipAddress = managedEnvironment.StaticIp;
+        var challengeTxtValue =
+            managedEnvironment.CustomDomainConfiguration.Apply(x => x?.CustomDomainVerificationId ?? "");
+        var zoneId = Cloudflare.GetZone.Invoke(new() { Name = domain }).Apply(x => x.Id);
+
+        _ = new Cloudflare.Record(
+            "dns-entry-ip",
+            new()
+            {
+                ZoneId = zoneId,
+                Name = subdomain,
+                Value = ipAddress,
+                Type = "A"
+            });
+
+        _ = new Cloudflare.Record(
+            "dns-entry-txt",
+            new()
+            {
+                ZoneId = zoneId,
+                Name = "asuid." + subdomain,
+                Value = challengeTxtValue,
+                Type = "TXT"
+            });
+    }
+}

--- a/deployment/Worms.Hub.Infrastructure/src/ContainerApps/Environment.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/ContainerApps/Environment.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Pulumi.AzureNative.App;
+using Pulumi.AzureNative.App.Inputs;
+using Pulumi.AzureNative.OperationalInsights;
+using Pulumi.AzureNative.Resources;
+using Storage = Pulumi.AzureNative.Storage;
+
+namespace Worms.Hub.Infrastructure.ContainerApps;
+
+public class Environment
+{
+    public static (ManagedEnvironment, ManagedEnvironmentsStorage) Config(
+        ResourceGroup resourceGroup,
+        Workspace logAnalytics,
+        Storage.StorageAccount storageAccount,
+        Storage.FileShare fileShare)
+    {
+        var logAnalyticsSharedKeys = GetSharedKeys.Invoke(
+            new()
+            {
+                ResourceGroupName = resourceGroup.Name,
+                WorkspaceName = logAnalytics.Name
+            });
+
+        var managedEnvironment = new ManagedEnvironment(
+            "azure-container-apps-environment",
+            new()
+            {
+                EnvironmentName = "Worms-Hub",
+                ResourceGroupName = resourceGroup.Name,
+                AppLogsConfiguration = new AppLogsConfigurationArgs
+                {
+                    Destination = "log-analytics",
+                    LogAnalyticsConfiguration = new LogAnalyticsConfigurationArgs
+                    {
+                        CustomerId = logAnalytics.CustomerId,
+                        SharedKey = logAnalyticsSharedKeys.Apply(
+                            x => x.PrimarySharedKey ?? throw new Exception("No primary shared key found")),
+                    }
+                }
+            });
+
+        var managedEnvironmentsStorage = new ManagedEnvironmentsStorage(
+            "azure-container-apps-storage",
+            new()
+            {
+                StorageName = "worms-hub-storage",
+                ResourceGroupName = resourceGroup.Name,
+                EnvironmentName = managedEnvironment.Name,
+                Properties = new ManagedEnvironmentStoragePropertiesArgs
+                {
+                    AzureFile = new AzureFilePropertiesArgs
+                    {
+                        AccessMode = AccessMode.ReadWrite,
+                        AccountKey = Storage.ListStorageAccountKeys.Invoke(
+                                new()
+                                {
+                                    ResourceGroupName = resourceGroup.Name,
+                                    AccountName = storageAccount.Name
+                                })
+                            .Apply(x => x.Keys[0].Value),
+                        AccountName = storageAccount.Name,
+                        ShareName = fileShare.Name,
+                    },
+                },
+            });
+
+        return (managedEnvironment, managedEnvironmentsStorage);
+    }
+}

--- a/deployment/Worms.Hub.Infrastructure/src/ContainerApps/Gateway.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/ContainerApps/Gateway.cs
@@ -3,137 +3,24 @@ using System.Threading.Tasks;
 using Pulumi;
 using Pulumi.AzureNative.App;
 using Pulumi.AzureNative.App.Inputs;
-using Pulumi.AzureNative.OperationalInsights;
 using Pulumi.AzureNative.Resources;
-using Storage = Pulumi.AzureNative.Storage;
 using CustomDomainArgs = Pulumi.AzureNative.App.Inputs.CustomDomainArgs;
-using Cloudflare = Pulumi.Cloudflare;
 
-namespace Worms.Hub.Infrastructure;
+namespace Worms.Hub.Infrastructure.ContainerApps;
 
-public static class ContainerApps
+public static class Gateway
 {
     public static async Task<ContainerApp> Config(
         ResourceGroup resourceGroup,
         Config config,
-        Workspace logAnalytics,
-        Storage.StorageAccount storageAccount,
-        Storage.FileShare fileShare,
+        ManagedEnvironment managedEnvironment,
+        ManagedEnvironmentsStorage managedEnvironmentStorage,
         Output<string> databaseConnectionString)
     {
-        var subdomain = config.Get("subdomain");
-        var domain = config.Get("domain");
-        var url = subdomain + "." + domain;
-
-        var logAnalyticsSharedKeys = GetSharedKeys.Invoke(
-            new()
-            {
-                ResourceGroupName = resourceGroup.Name,
-                WorkspaceName = logAnalytics.Name
-            });
-
-        var kubeEnv = new ManagedEnvironment(
-            "azure-container-apps-environment",
-            new()
-            {
-                EnvironmentName = "Worms-Hub",
-                ResourceGroupName = resourceGroup.Name,
-                AppLogsConfiguration = new AppLogsConfigurationArgs
-                {
-                    Destination = "log-analytics",
-                    LogAnalyticsConfiguration = new LogAnalyticsConfigurationArgs
-                    {
-                        CustomerId = logAnalytics.CustomerId,
-                        SharedKey = logAnalyticsSharedKeys.Apply(
-                            x => x.PrimarySharedKey ?? throw new Exception("No primary shared key found")),
-                    }
-                }
-            });
-
-        var ipAddress = kubeEnv.StaticIp;
-        var challengeTxtValue = kubeEnv.CustomDomainConfiguration.Apply(x => x?.CustomDomainVerificationId ?? "");
-        var zoneId = Cloudflare.GetZone.Invoke(new(){Name = domain}).Apply(x => x.Id);
-
-        _ = new Cloudflare.Record("dns-entry-ip", new()
-        {
-            ZoneId = zoneId,
-            Name = subdomain,
-            Value = ipAddress,
-            Type = "A"
-        });
-
-        _ = new Cloudflare.Record("dns-entry-txt", new()
-        {
-            ZoneId = zoneId,
-            Name = "asuid." + subdomain,
-            Value = challengeTxtValue,
-            Type = "TXT"
-        });
-
-        var managedEnvironmentsStorage = new ManagedEnvironmentsStorage(
-            "azure-container-apps-storage",
-            new()
-            {
-                StorageName = "worms-hub-storage",
-                ResourceGroupName = resourceGroup.Name,
-                EnvironmentName = kubeEnv.Name,
-                Properties = new ManagedEnvironmentStoragePropertiesArgs
-                {
-                    AzureFile = new AzureFilePropertiesArgs
-                    {
-                        AccessMode = AccessMode.ReadWrite,
-                        AccountKey = Storage.ListStorageAccountKeys.Invoke(
-                                new()
-                                {
-                                    ResourceGroupName = resourceGroup.Name,
-                                    AccountName = storageAccount.Name
-                                })
-                            .Apply(x => x.Keys[0].Value),
-                        AccountName = storageAccount.Name,
-                        ShareName = fileShare.Name,
-                    },
-                },
-            });
-
-        var customDomainArgs = new InputList<CustomDomainArgs>();
-
-        // Managed Cert will only exist from second run
-        GetManagedCertificateResult? certificate = null;
-
-        try
-        {
-            certificate = await GetManagedCertificate.InvokeAsync(
-                new()
-                {
-                    ManagedCertificateName = "worms-hub-certificate",
-                    EnvironmentName = "Worms-Hub",
-                    ResourceGroupName = "Worms-Hub-test"
-                });
-        }
-        catch (Exception)
-        {
-            // Certificate not found
-        }
-
-        if (certificate is not null)
-        {
-            customDomainArgs.Add(
-                new CustomDomainArgs
-                {
-                    BindingType = "SniEnabled",
-                    CertificateId = certificate.Id,
-                    Name = url,
-                });
-        }
-        else
-        {
-            customDomainArgs.Add(
-                new CustomDomainArgs
-                {
-                    BindingType = "Disabled",
-                    Name = url,
-                });
-        }
+        var subdomain = config.Require("subdomain");
+        var domain = config.Require("domain");
+        var url = $"{subdomain}.{domain}";
+        var certificateId = await GetManagedCertificateId();
 
         var containerApp = new ContainerApp(
             "worms-hub-gateway",
@@ -141,14 +28,29 @@ public static class ContainerApps
             {
                 ContainerAppName = "worms-gateway",
                 ResourceGroupName = resourceGroup.Name,
-                ManagedEnvironmentId = kubeEnv.Id,
+                ManagedEnvironmentId = managedEnvironment.Id,
                 Configuration = new ConfigurationArgs
                 {
                     Ingress = new IngressArgs
                     {
                         External = true,
                         TargetPort = 8080,
-                        CustomDomains = customDomainArgs,
+                        CustomDomains = certificateId is not null ?
+                        [
+                            new CustomDomainArgs
+                            {
+                                BindingType = "SniEnabled",
+                                CertificateId = certificateId,
+                                Name = url,
+                            }
+                        ] :
+                        [
+                            new CustomDomainArgs
+                            {
+                                Name = url,
+                                BindingType = "Disabled",
+                            }
+                        ]
                     },
                     Secrets =
                     [
@@ -221,20 +123,20 @@ public static class ContainerApps
                         {
                             Name = "worms-hub-volume",
                             StorageType = StorageType.AzureFile,
-                            StorageName = managedEnvironmentsStorage.Name,
+                            StorageName = managedEnvironmentStorage.Name,
                         }
                     }
                 }
             });
 
         // Create a managed certificate - Must be done after env has custom domain added
-        var cert = new ManagedCertificate(
+        _ = new ManagedCertificate(
             "worms-hub-certificate",
             new()
             {
                 ManagedCertificateName = "worms-hub-certificate",
                 ResourceGroupName = resourceGroup.Name,
-                EnvironmentName = kubeEnv.Name,
+                EnvironmentName = managedEnvironment.Name,
                 Properties = new ManagedCertificatePropertiesArgs()
                 {
                     SubjectName = url,
@@ -244,5 +146,28 @@ public static class ContainerApps
             new CustomResourceOptions { DependsOn = { containerApp } });
 
         return containerApp;
+    }
+
+    private static async Task<string?> GetManagedCertificateId()
+    {
+        // Managed Cert will only exist from second run
+        GetManagedCertificateResult? certificate = null;
+
+        try
+        {
+            certificate = await GetManagedCertificate.InvokeAsync(
+                new()
+                {
+                    ManagedCertificateName = "worms-hub-certificate",
+                    EnvironmentName = "Worms-Hub",
+                    ResourceGroupName = Utils.GetResourceName("Worms-Hub")
+                });
+        }
+        catch (Exception)
+        {
+            // Certificate not found
+        }
+
+        return certificate?.Id;
     }
 }

--- a/deployment/Worms.Hub.Infrastructure/src/FileShare.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/FileShare.cs
@@ -17,7 +17,7 @@ public static class FileShare
             {
                 AccountName = storageAccount.Name,
                 ResourceGroupName = resourceGroup.Name,
-                EnabledProtocols = Storage.EnabledProtocols.SMB,
+                ShareName = "file-share",
             });
     }
 }

--- a/deployment/Worms.Hub.Infrastructure/src/Program.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/Program.cs
@@ -5,8 +5,5 @@ namespace Worms.Hub.Infrastructure;
 
 public static class Program
 {
-    public static Task<int> Main()
-    {
-        return Deployment.RunAsync<WormsHub>();
-    }
+    public static Task<int> Main() => Deployment.RunAsync<WormsHub>();
 }

--- a/deployment/Worms.Hub.Infrastructure/src/StorageAccount.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/StorageAccount.cs
@@ -12,7 +12,7 @@ public static class StorageAccount
             "storage-account",
             new()
             {
-                AccountName = "wormstest",
+                AccountName = Utils.GetResourceNameAlphaNumericOnly("wormstest"),
                 ResourceGroupName = resourceGroup.Name,
                 LargeFileSharesState = Storage.LargeFileSharesState.Enabled,
                 Kind = Storage.Kind.StorageV2,

--- a/deployment/Worms.Hub.Infrastructure/src/Utils.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/Utils.cs
@@ -7,4 +7,10 @@ public static class Utils
         var stack = Pulumi.Deployment.Instance.StackName;
         return stack == "prod" ? name : $"{name}-{stack}";
     }
+
+    public static string GetResourceNameAlphaNumericOnly(string name)
+    {
+        var stack = Pulumi.Deployment.Instance.StackName;
+        return stack == "prod" ? name : $"{name}{stack}";
+    }
 }

--- a/deployment/Worms.Hub.Infrastructure/src/WormsHub.cs
+++ b/deployment/Worms.Hub.Infrastructure/src/WormsHub.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Pulumi;
 using Pulumi.AzureNative.OperationalInsights;
 using Pulumi.AzureNative.Resources;
@@ -50,13 +51,15 @@ public class WormsHub : Stack
         DatabaseUser = server.AdministratorLogin;
         DatabasePassword = databasePassword;
 
-        var containerApp = ContainerApps.Config(
+        var containerApp = Task.Run(() => ContainerApps.Config(
             resourceGroup,
             config,
             logAnalytics,
             storage,
             fileShare,
-            DatabaseAdoNet);
+            DatabaseAdoNet))
+            .GetAwaiter()
+            .GetResult();
 
         var protocol = isProd ? "https://" : "http://";
 


### PR DESCRIPTION
- Sadly there's a circular dependency between the ACA Container and the Certificate so a double deploy is required.
- This currently doesn't work for `pulumi destroy` due to the same circular dependency