### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/zz-release-cli.yml
+++ b/.github/workflows/zz-release-cli.yml
@@ -1,6 +1,6 @@
 name: ZZ - Release - CLI
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:

--- a/build/flyway-summary.sh
+++ b/build/flyway-summary.sh
@@ -1,4 +1,5 @@
-#!/bin/bash 
+#!/bin/bash
+set -euo pipefail
 
 PATHTOJSON=$1
 

--- a/build/release-github.sh
+++ b/build/release-github.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 ReleaseName=$1
 Tag=$2
 GitHubToken=$3

--- a/build/version.sh
+++ b/build/version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 NEXT_VERSION="$1"
 TAG_PREFIX="$2"


### PR DESCRIPTION
The release to GitHub currently fails silently. Therefore no new CLIs have been uploaded since 0.29.49