### PR TITLE
Stop Replay Processor knowing about the database

### DIFF
--- a/.github/workflows/zz-build-hub.yml
+++ b/.github/workflows/zz-build-hub.yml
@@ -30,6 +30,29 @@ jobs:
         run: |
           make gateway.package
 
+  build-replay-updater:
+    name: Replay Updater
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Package
+        run: |
+          make replay-updater.package
+
   build-replay-processor:
     name: Replay Processor
     runs-on: ubuntu-latest

--- a/.github/workflows/zz-release-hub.yml
+++ b/.github/workflows/zz-release-hub.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       gateway: ${{ steps.filter.outputs.gateway == 'true' || steps.filter.outputs.common == 'true' }}
+      replay-updater: ${{ steps.filter.outputs.replay-updater == 'true' || steps.filter.outputs.common == 'true' }}
       replay-processor: ${{ steps.filter.outputs.replay-processor == 'true' || steps.filter.outputs.common == 'true' }}
     steps:
     - name: Checkout
@@ -26,12 +27,22 @@ jobs:
         filters: |
           gateway:
             - 'src/Worms.Hub.Gateway/**'
+            - 'src/Worms.Hub.Queues/**'
+            - 'src/Worms.Hub.ReplayProcessor.Queues/**'
             - 'src/Worms.Hub.Storage/**'
             - 'build/docker/gateway/**'
+          replay-updater:
+            - 'src/Worms.Hub.ReplayUpdater/**'
+            - 'src/Worms.Hub.Queues/**'
+            - 'src/Worms.Hub.ReplayUpdater.Queues/**'
+            - 'src/Worms.Hub.Storage/**'
+            - 'build/docker/replay-updater/**'
           replay-processor:
             - 'src/Worms.Hub.ReplayProcessor/**'
-            - 'src/Worms.Hub.Storage/**'
             - 'src/Worms.Armageddon.Game/**'
+            - 'src/Worms.Hub.Queues/**'
+            - 'src/Worms.Hub.ReplayProcessor.Queues/**'
+            - 'src/Worms.Hub.ReplayUpdater.Queues/**'
             - 'build/docker/replay-processor/**'
           common:
             - 'src/Directory.Build.props'
@@ -85,6 +96,53 @@ jobs:
       - name: Release
         run: |
           make gateway.release.dockerhub
+
+  release-replay-updater-github:
+    name: Replay Updater - GitHub
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.replay-updater == 'true' && github.ref == 'refs/heads/main' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        run: |
+          make replay-updater.release.github GITHUB_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+  release-replay-updater-dockerhub:
+    name: Replay Processor - DockerHub
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.replay-updater == 'true' && github.ref == 'refs/heads/main' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: theeadie
+          password: ${{ secrets.DockerHubAccessToken }}
+
+      - name: Release
+        run: |
+          make replay-updater.release.dockerhub
 
   release-replay-processor-github:
     name: Replay Processor - GitHub

--- a/Worms.sln
+++ b/Worms.sln
@@ -27,6 +27,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.Queues", "src\Wor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.ReplayProcessor.Queues", "src\Worms.Hub.ReplayProcessor.Queues\Worms.Hub.ReplayProcessor.Queues.csproj", "{31670712-E626-4150-84CE-38DEFCE45276}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.ReplayUpdater", "src\Worms.Hub.ReplayUpdater\Worms.Hub.ReplayUpdater.csproj", "{4DE03937-B2F9-44C1-ACFA-18A948B99260}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.ReplayUpdater.Queues", "src\Worms.Hub.ReplayUpdater.Queues\Worms.Hub.ReplayUpdater.Queues.csproj", "{1DADED53-0822-437E-8866-372C3B66D80F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +88,14 @@ Global
 		{31670712-E626-4150-84CE-38DEFCE45276}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31670712-E626-4150-84CE-38DEFCE45276}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31670712-E626-4150-84CE-38DEFCE45276}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DE03937-B2F9-44C1-ACFA-18A948B99260}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DE03937-B2F9-44C1-ACFA-18A948B99260}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DE03937-B2F9-44C1-ACFA-18A948B99260}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DE03937-B2F9-44C1-ACFA-18A948B99260}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DADED53-0822-437E-8866-372C3B66D80F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DADED53-0822-437E-8866-372C3B66D80F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DADED53-0822-437E-8866-372C3B66D80F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DADED53-0822-437E-8866-372C3B66D80F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/Worms.sln
+++ b/Worms.sln
@@ -23,6 +23,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Armageddon.Game.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Armageddon.Game.Fake", "src\Worms.Armageddon.Game.Fake\Worms.Armageddon.Game.Fake.csproj", "{10CB1CDA-F901-4EBC-BEE8-2C8C41DA35A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.Queues", "src\Worms.Hub.Queues\Worms.Hub.Queues.csproj", "{BB2B0E38-96D8-44D4-AE29-5C7A5E701E92}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.ReplayProcessor.Queues", "src\Worms.Hub.ReplayProcessor.Queues\Worms.Hub.ReplayProcessor.Queues.csproj", "{31670712-E626-4150-84CE-38DEFCE45276}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +76,14 @@ Global
 		{10CB1CDA-F901-4EBC-BEE8-2C8C41DA35A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10CB1CDA-F901-4EBC-BEE8-2C8C41DA35A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10CB1CDA-F901-4EBC-BEE8-2C8C41DA35A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB2B0E38-96D8-44D4-AE29-5C7A5E701E92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB2B0E38-96D8-44D4-AE29-5C7A5E701E92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB2B0E38-96D8-44D4-AE29-5C7A5E701E92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB2B0E38-96D8-44D4-AE29-5C7A5E701E92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31670712-E626-4150-84CE-38DEFCE45276}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31670712-E626-4150-84CE-38DEFCE45276}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31670712-E626-4150-84CE-38DEFCE45276}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31670712-E626-4150-84CE-38DEFCE45276}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/build/docker/gateway/Dockerfile
+++ b/build/docker/gateway/Dockerfile
@@ -4,10 +4,14 @@ WORKDIR /app
 
 COPY src/Directory.Build.props .
 COPY .editorconfig .
+COPY src/Worms.Hub.Queues/Worms.Hub.Queues.csproj ./src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
+COPY src/Worms.Hub.ReplayProcessor.Queues/Worms.Hub.ReplayProcessor.Queues.csproj ./src/Worms.Hub.ReplayProcessor.Queues/Worms.Hub.ReplayProcessor.Queues.csproj
 COPY src/Worms.Hub.Storage/Worms.Hub.Storage.csproj ./src/Worms.Hub.Storage/Worms.Hub.Storage.csproj
 COPY src/Worms.Hub.Gateway/Worms.Hub.Gateway.csproj ./src/Worms.Hub.Gateway/Worms.Hub.Gateway.csproj
 RUN dotnet restore src/Worms.Hub.Gateway/Worms.Hub.Gateway.csproj
 
+COPY src/Worms.Hub.Queues ./src/Worms.Hub.Queues
+COPY src/Worms.Hub.ReplayProcessor.Queues ./src/Worms.Hub.ReplayProcessor.Queues
 COPY src/Worms.Hub.Storage ./src/Worms.Hub.Storage
 COPY src/Worms.Hub.Gateway ./src/Worms.Hub.Gateway
 ARG VERSION=0.0.1

--- a/build/docker/replay-processor/Dockerfile
+++ b/build/docker/replay-processor/Dockerfile
@@ -5,12 +5,16 @@ WORKDIR /app
 COPY src/Directory.Build.props .
 COPY .editorconfig .
 COPY src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj ./src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
-COPY src/Worms.Hub.Storage/Worms.Hub.Storage.csproj ./src/Worms.Hub.Storage/Worms.Hub.Storage.csproj
+COPY src/Worms.Hub.Queues/Worms.Hub.Queues.csproj ./src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
+COPY src/Worms.Hub.ReplayProcessor.Queues/Worms.Hub.ReplayProcessor.Queues.csproj ./src/Worms.Hub.ReplayProcessor.Queues/Worms.Hub.ReplayProcessor.Queues.csproj
+COPY src/Worms.Hub.ReplayUpdater.Queues/Worms.Hub.ReplayUpdater.Queues.csproj ./src/Worms.Hub.ReplayUpdater.Queues/Worms.Hub.ReplayUpdater.Queues.csproj
 COPY src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj ./src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
 RUN dotnet restore src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj -r linux-x64
 
 COPY src/Worms.Armageddon.Game ./src/Worms.Armageddon.Game
-COPY src/Worms.Hub.Storage ./src/Worms.Hub.Storage
+COPY src/Worms.Hub.Queues ./src/Worms.Hub.Queues
+COPY src/Worms.Hub.ReplayProcessor.Queues ./src/Worms.Hub.ReplayProcessor.Queues
+COPY src/Worms.Hub.ReplayUpdater.Queues ./src/Worms.Hub.ReplayUpdater.Queues
 COPY src/Worms.Hub.ReplayProcessor ./src/Worms.Hub.ReplayProcessor
 ARG VERSION=0.0.1
 RUN dotnet publish \

--- a/build/docker/replay-updater/Dockerfile
+++ b/build/docker/replay-updater/Dockerfile
@@ -1,0 +1,36 @@
+#### Build ####
+FROM mcr.microsoft.com/dotnet/sdk:9.0.304@sha256:ae000be75dac94fc40e00f0eee903289e985995cc06dac3937469254ce5b60b6 AS build
+WORKDIR /app
+
+COPY src/Directory.Build.props .
+COPY .editorconfig .
+COPY src/Worms.Hub.Queues/Worms.Hub.Queues.csproj ./src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
+COPY src/Worms.Hub.ReplayUpdater.Queues/Worms.Hub.ReplayUpdater.Queues.csproj ./src/Worms.Hub.ReplayUpdater.Queues/Worms.Hub.ReplayUpdater.Queues.csproj
+COPY src/Worms.Hub.Storage/Worms.Hub.Storage.csproj ./src/Worms.Hub.Storage/Worms.Hub.Storage.csproj
+COPY src/Worms.Hub.ReplayUpdater/Worms.Hub.ReplayUpdater.csproj ./src/Worms.Hub.ReplayUpdater/Worms.Hub.ReplayUpdater.csproj
+RUN dotnet restore src/Worms.Hub.ReplayUpdater/Worms.Hub.ReplayUpdater.csproj -r linux-x64
+
+COPY src/Worms.Hub.Queues ./src/Worms.Hub.Queues
+COPY src/Worms.Hub.ReplayUpdater.Queues ./src/Worms.Hub.ReplayUpdater.Queues
+COPY src/Worms.Hub.Storage ./src/Worms.Hub.Storage
+COPY src/Worms.Hub.ReplayUpdater ./src/Worms.Hub.ReplayUpdater
+ARG VERSION=0.0.1
+RUN dotnet publish \
+    src/Worms.Hub.ReplayUpdater/Worms.Hub.ReplayUpdater.csproj \
+    -c Release \
+    -o out \
+    --no-restore \
+    -r linux-x64 \
+    --self-contained true \
+    -p:AssemblyVersion=${VERSION} \
+    -p:Version=${VERSION}
+
+#### Test ####
+FROM build AS test
+RUN dotnet test --no-restore --no-build --verbosity normal
+
+#### Runtime ####
+FROM mcr.microsoft.com/dotnet/runtime:9.0.8@sha256:52011e65ae82d61566a8a028ef72e0a77dbbab6c9233212fc28ad67bc55f1354
+WORKDIR /app
+COPY --from=build /app/out .
+ENTRYPOINT ["./Worms.Hub.ReplayUpdater"]

--- a/build/docker/replay-updater/Dockerfile.dockerignore
+++ b/build/docker/replay-updater/Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+# Ignore everything
+**
+
+# Except for these files
+!/src
+!/scripts
+!.editorconfig
+
+**/bin
+**/obj

--- a/build/docker/replay-updater/config.mk
+++ b/build/docker/replay-updater/config.mk
@@ -1,0 +1,2 @@
+replay-updater_NEXT_VERSION := 0.1
+replay-updater_TAG_PREFIX := replay-updater/v

--- a/build/docker/replay-updater/docker-bake.hcl
+++ b/build/docker/replay-updater/docker-bake.hcl
@@ -1,0 +1,2 @@
+﻿variable "IMAGE_NAME" { default = "theeadie/worms-hub-replay-updater" }
+variable "DOCKERFILE_PATH" { default = "build/docker/replay-updater/Dockerfile" }

--- a/build/version.sh
+++ b/build/version.sh
@@ -5,17 +5,15 @@ NEXT_VERSION="$1"
 TAG_PREFIX="$2"
 
 # Read Version parts
-IFS='.'  
+IFS='.'
 read -r -a VERSION_PARTS <<<"$NEXT_VERSION"
-  
+
 MAJOR="${VERSION_PARTS[0]}"
 MINOR="${VERSION_PARTS[1]}"
 PATCH=0
 
 # Get last tag
-LATEST_TAG=$(git describe --tags --match "$TAG_PREFIX*" --abbrev=0 2>/dev/null)
-HEAD_HASH=$(git rev-parse --verify HEAD)
-TAG_HASH=$(git log -1 --format=format:"%H" "$LATEST_TAG" 2>/dev/null | tail -n1)
+LATEST_TAG=$(git describe --tags --match "$TAG_PREFIX*" --abbrev=0 2>/dev/null || true)
 
 if [[ -z "$LATEST_TAG" ]]; then
     >&2 echo "No previous versions found"
@@ -23,6 +21,9 @@ if [[ -z "$LATEST_TAG" ]]; then
     echo "$NEXT_VERSION.0"
     exit
 fi
+
+HEAD_HASH=$(git rev-parse --verify HEAD)
+TAG_HASH=$(git log -1 --format=format:"%H" "$LATEST_TAG" 2>/dev/null | tail -n1)
 
 if [[ -n "$TAG_PREFIX" ]]; then
     LATEST_TAG=${LATEST_TAG#"$TAG_PREFIX"}
@@ -36,7 +37,7 @@ if [[ "$HEAD_HASH" == "$TAG_HASH" ]]; then
 fi
 
 # Read Version parts
-IFS='.'  
+IFS='.'
 read -r -a VERSION_PARTS <<<"$LATEST_TAG"
 
 LATEST_MAJOR="${VERSION_PARTS[0]}"

--- a/src/Worms.Hub.Gateway/API/Controllers/ReplaysController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/ReplaysController.cs
@@ -34,9 +34,10 @@ internal sealed class ReplaysController(
 
         var tempFilename = await replayFiles.SaveFileContents(parameters.ReplayFile.OpenReadStream());
         var replay = repository.Create(new Replay("0", parameters.Name, "Pending", tempFilename, null));
+        var replayPath = replayFiles.GetReplayPath(replay.Filename);
 
         // Enqueue the replay for processing
-        var message = new ReplayToProcessMessage(replay.Id);
+        var message = new ReplayToProcessMessage(replayPath);
         await replayProcessor.EnqueueMessage(message);
 
         return ReplayDto.FromDomain(replay);

--- a/src/Worms.Hub.Gateway/API/Controllers/ReplaysController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/ReplaysController.cs
@@ -1,10 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
 using Worms.Hub.Gateway.API.DTOs;
 using Worms.Hub.Gateway.API.Validators;
+using Worms.Hub.Queues;
+using Worms.Hub.ReplayProcessor.Queue;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Domain;
 using Worms.Hub.Storage.Files;
-using Worms.Hub.Storage.Queues;
 
 namespace Worms.Hub.Gateway.API.Controllers;
 

--- a/src/Worms.Hub.Gateway/Worms.Hub.Gateway.csproj
+++ b/src/Worms.Hub.Gateway/Worms.Hub.Gateway.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Worms.Hub.ReplayProcessor.Queues\Worms.Hub.ReplayProcessor.Queues.csproj"/>
     <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj"/>
   </ItemGroup>
 

--- a/src/Worms.Hub.Queues/IMessageQueue.cs
+++ b/src/Worms.Hub.Queues/IMessageQueue.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Worms.Hub.Storage.Queues;
+namespace Worms.Hub.Queues;
 
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix")]
 public interface IMessageQueue<T>

--- a/src/Worms.Hub.Queues/MessageDetails.cs
+++ b/src/Worms.Hub.Queues/MessageDetails.cs
@@ -1,3 +1,3 @@
-namespace Worms.Hub.Storage.Queues;
+namespace Worms.Hub.Queues;
 
 public record MessageDetails(string MessageId, string PopReceipt);

--- a/src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
+++ b/src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
@@ -4,10 +4,5 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.22.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3"/>
-  </ItemGroup>
-
+  
 </Project>

--- a/src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
+++ b/src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="12.22.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Worms.Hub.ReplayProcessor.Queues/ReplayToProcessMessage.cs
+++ b/src/Worms.Hub.ReplayProcessor.Queues/ReplayToProcessMessage.cs
@@ -1,3 +1,3 @@
 namespace Worms.Hub.ReplayProcessor.Queue;
 
-public record ReplayToProcessMessage(string ReplayFileName);
+public record ReplayToProcessMessage(string ReplayPath);

--- a/src/Worms.Hub.ReplayProcessor.Queues/ReplayToProcessMessage.cs
+++ b/src/Worms.Hub.ReplayProcessor.Queues/ReplayToProcessMessage.cs
@@ -1,3 +1,3 @@
 namespace Worms.Hub.ReplayProcessor.Queue;
 
-public record ReplayToProcessMessage(string ReplayId);
+public record ReplayToProcessMessage(string ReplayFileName);

--- a/src/Worms.Hub.ReplayProcessor.Queues/ReplayToProcessMessage.cs
+++ b/src/Worms.Hub.ReplayProcessor.Queues/ReplayToProcessMessage.cs
@@ -1,3 +1,3 @@
-namespace Worms.Hub.Storage.Queues;
+namespace Worms.Hub.ReplayProcessor.Queue;
 
 public record ReplayToProcessMessage(string ReplayId);

--- a/src/Worms.Hub.ReplayProcessor.Queues/ReplaysToProcess.cs
+++ b/src/Worms.Hub.ReplayProcessor.Queues/ReplaysToProcess.cs
@@ -22,7 +22,7 @@ internal sealed class ReplaysToProcess(IConfiguration configuration) : IMessageQ
         var connectionString = configuration.GetConnectionString("Storage");
         var queueClient = new QueueClient(connectionString, QueueName);
         _ = await queueClient.CreateIfNotExistsAsync();
-        _ = await queueClient.SendMessageAsync(message.ReplayFileName);
+        _ = await queueClient.SendMessageAsync(message.ReplayPath);
     }
 
     public async Task<(ReplayToProcessMessage?, MessageDetails?)> DequeueMessage()

--- a/src/Worms.Hub.ReplayProcessor.Queues/ReplaysToProcess.cs
+++ b/src/Worms.Hub.ReplayProcessor.Queues/ReplaysToProcess.cs
@@ -1,7 +1,8 @@
 using Azure.Storage.Queues;
 using Microsoft.Extensions.Configuration;
+using Worms.Hub.Queues;
 
-namespace Worms.Hub.Storage.Queues;
+namespace Worms.Hub.ReplayProcessor.Queue;
 
 internal sealed class ReplaysToProcess(IConfiguration configuration) : IMessageQueue<ReplayToProcessMessage>
 {

--- a/src/Worms.Hub.ReplayProcessor.Queues/ServiceRegistration.cs
+++ b/src/Worms.Hub.ReplayProcessor.Queues/ServiceRegistration.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+using Worms.Hub.Queues;
+
+namespace Worms.Hub.ReplayProcessor.Queue;
+
+public static class ServiceRegistration
+{
+    public static IServiceCollection AddReplayToProcessQueueServices(this IServiceCollection builder) =>
+        builder.AddScoped<IMessageQueue<ReplayToProcessMessage>, ReplaysToProcess>();
+}

--- a/src/Worms.Hub.ReplayProcessor.Queues/Worms.Hub.ReplayProcessor.Queues.csproj
+++ b/src/Worms.Hub.ReplayProcessor.Queues/Worms.Hub.ReplayProcessor.Queues.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Worms.Hub.ReplayProcessor.Queue</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="12.22.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Worms.Hub.Queues\Worms.Hub.Queues.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Worms.Hub.ReplayProcessor/CheckForMessagesService.cs
+++ b/src/Worms.Hub.ReplayProcessor/CheckForMessagesService.cs
@@ -1,4 +1,5 @@
-using Worms.Hub.Storage.Queues;
+using Worms.Hub.Queues;
+using Worms.Hub.ReplayProcessor.Queue;
 
 namespace Worms.Hub.ReplayProcessor;
 

--- a/src/Worms.Hub.ReplayProcessor/Processor.cs
+++ b/src/Worms.Hub.ReplayProcessor/Processor.cs
@@ -66,7 +66,7 @@ internal sealed class Processor(
         }
 
         // Send a message to the replay updater queue
-        await outputQueue.EnqueueMessage(new ReplayToUpdateMessage(message.ReplayPath));
+        await outputQueue.EnqueueMessage(new ReplayToUpdateMessage(message.ReplayPath, logPath));
 
         // Delete the message from the queue
         await inputQueue.DeleteMessage(token);

--- a/src/Worms.Hub.ReplayProcessor/Processor.cs
+++ b/src/Worms.Hub.ReplayProcessor/Processor.cs
@@ -1,39 +1,34 @@
 using Worms.Armageddon.Game;
 using Worms.Hub.Queues;
 using Worms.Hub.ReplayProcessor.Queue;
-using Worms.Hub.Storage.Database;
-using Worms.Hub.Storage.Domain;
-using Worms.Hub.Storage.Files;
 
 namespace Worms.Hub.ReplayProcessor;
 
 internal sealed class Processor(
-    IMessageQueue<ReplayToProcessMessage> messageQueue,
+    IMessageQueue<ReplayToProcessMessage> inputQueue,
+    IMessageQueue<ReplayToUpdateMessage> outputQueue,
     IWormsArmageddon wormsArmageddon,
-    IRepository<Replay> replayRepository,
-    ReplayFiles replayFiles,
+    IConfiguration configuration,
     ILogger<Processor> logger)
 {
     public async Task ProcessReplay()
     {
         logger.LogInformation("Starting replay processor...");
 
-        var (message, token) = await messageQueue.DequeueMessage();
+        var (message, token) = await inputQueue.DequeueMessage();
         if (message is null || token is null)
         {
             logger.LogInformation("No messages to process.");
             return;
         }
 
-        // Check replay is in database
-        var replay = replayRepository.GetAll().FirstOrDefault(x => x.Id == message.ReplayId);
-        if (replay is null)
+        // Check replay is in the folder
+        var replayPath = GetReplayPath(message.ReplayFileName);
+        if (!File.Exists(replayPath))
         {
-            logger.LogError("Replay not found in database: {Id}", message.ReplayId);
+            logger.LogError("Replay not found on disk: {FileName}", message.ReplayFileName);
             return;
         }
-
-        var replayPath = replayFiles.GetReplayPath(replay);
 
         // Check game is installed
         if (!GameIsInstalled())
@@ -64,7 +59,7 @@ internal sealed class Processor(
 
         // Generate replay log
         await wormsArmageddon.GenerateReplayLog(replayPath);
-        var logPath = replayFiles.GetLogPath(replay);
+        var logPath = GetLogPath(replayPath);
 
         if (logPath is null)
         {
@@ -72,18 +67,11 @@ internal sealed class Processor(
             return;
         }
 
-        var replayLog = await File.ReadAllTextAsync(logPath);
-
-        // Update the database with the log
-        var updatedReplay = replay with
-        {
-            Status = "Processed",
-            FullLog = replayLog
-        };
-        replayRepository.Update(updatedReplay);
+        // Send a message to the replay updater queue
+        await outputQueue.EnqueueMessage(new ReplayToUpdateMessage(message.ReplayFileName));
 
         // Delete the message from the queue
-        await messageQueue.DeleteMessage(token);
+        await inputQueue.DeleteMessage(token);
 
         logger.LogInformation("Replay processor finished.");
     }
@@ -141,4 +129,24 @@ internal sealed class Processor(
             }
         }
     }
+
+    private string GetReplayPath(string replayFileName)
+    {
+        ArgumentNullException.ThrowIfNull(replayFileName);
+        return Path.Combine(GetReplayFolderPath(), replayFileName);
+    }
+
+    private string? GetLogPath(string replayFileName)
+    {
+        ArgumentNullException.ThrowIfNull(replayFileName);
+        var fileName = replayFileName.EndsWith(".WAGame", StringComparison.InvariantCultureIgnoreCase)
+            ? Path.GetFileNameWithoutExtension(replayFileName)
+            : replayFileName;
+
+        var logPath = Path.Combine(GetReplayFolderPath(), $"{fileName}.log");
+        return File.Exists(logPath) ? logPath : null;
+    }
+
+    private string GetReplayFolderPath() =>
+        configuration["Storage:TempReplayFolder"] ?? throw new ArgumentException("Temp replay folder not configured");
 }

--- a/src/Worms.Hub.ReplayProcessor/Processor.cs
+++ b/src/Worms.Hub.ReplayProcessor/Processor.cs
@@ -1,8 +1,9 @@
 using Worms.Armageddon.Game;
+using Worms.Hub.Queues;
+using Worms.Hub.ReplayProcessor.Queue;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Domain;
 using Worms.Hub.Storage.Files;
-using Worms.Hub.Storage.Queues;
 
 namespace Worms.Hub.ReplayProcessor;
 

--- a/src/Worms.Hub.ReplayProcessor/ServiceRegistration.cs
+++ b/src/Worms.Hub.ReplayProcessor/ServiceRegistration.cs
@@ -1,14 +1,10 @@
 using Worms.Armageddon.Game;
 using Worms.Hub.ReplayProcessor.Queue;
-using Worms.Hub.Storage;
 
 namespace Worms.Hub.ReplayProcessor;
 
 internal static class ServiceRegistration
 {
     public static IServiceCollection AddReplayProcessorServices(this IServiceCollection builder) =>
-        builder.AddHubStorageServices()
-            .AddWormsArmageddonGameServices()
-            .AddReplayToProcessQueueServices()
-            .AddScoped<Processor>();
+        builder.AddWormsArmageddonGameServices().AddReplayToProcessQueueServices().AddScoped<Processor>();
 }

--- a/src/Worms.Hub.ReplayProcessor/ServiceRegistration.cs
+++ b/src/Worms.Hub.ReplayProcessor/ServiceRegistration.cs
@@ -1,4 +1,5 @@
 using Worms.Armageddon.Game;
+using Worms.Hub.ReplayProcessor.Queue;
 using Worms.Hub.Storage;
 
 namespace Worms.Hub.ReplayProcessor;
@@ -6,5 +7,8 @@ namespace Worms.Hub.ReplayProcessor;
 internal static class ServiceRegistration
 {
     public static IServiceCollection AddReplayProcessorServices(this IServiceCollection builder) =>
-        builder.AddHubStorageServices().AddWormsArmageddonGameServices().AddScoped<Processor>();
+        builder.AddHubStorageServices()
+            .AddWormsArmageddonGameServices()
+            .AddReplayToProcessQueueServices()
+            .AddScoped<Processor>();
 }

--- a/src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
+++ b/src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Worms.Armageddon.Game\Worms.Armageddon.Game.csproj"/>
+    <ProjectReference Include="..\Worms.Hub.ReplayProcessor.Queues\Worms.Hub.ReplayProcessor.Queues.csproj"/>
     <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj"/>
   </ItemGroup>
 

--- a/src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
+++ b/src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\Worms.Armageddon.Game\Worms.Armageddon.Game.csproj"/>
     <ProjectReference Include="..\Worms.Hub.ReplayProcessor.Queues\Worms.Hub.ReplayProcessor.Queues.csproj"/>
     <ProjectReference Include="..\Worms.Hub.ReplayUpdater.Queues\Worms.Hub.ReplayUpdater.Queues.csproj"/>
-    <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
+++ b/src/Worms.Hub.ReplayProcessor/Worms.Hub.ReplayProcessor.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Worms.Armageddon.Game\Worms.Armageddon.Game.csproj"/>
     <ProjectReference Include="..\Worms.Hub.ReplayProcessor.Queues\Worms.Hub.ReplayProcessor.Queues.csproj"/>
+    <ProjectReference Include="..\Worms.Hub.ReplayUpdater.Queues\Worms.Hub.ReplayUpdater.Queues.csproj"/>
     <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj"/>
   </ItemGroup>
 

--- a/src/Worms.Hub.ReplayUpdater.Queues/ReplayToUpdateMessage.cs
+++ b/src/Worms.Hub.ReplayUpdater.Queues/ReplayToUpdateMessage.cs
@@ -1,3 +1,3 @@
 namespace Worms.Hub.ReplayProcessor.Queue;
 
-public record ReplayToUpdateMessage(string ReplayFileName);
+public record ReplayToUpdateMessage(string ReplayPath);

--- a/src/Worms.Hub.ReplayUpdater.Queues/ReplayToUpdateMessage.cs
+++ b/src/Worms.Hub.ReplayUpdater.Queues/ReplayToUpdateMessage.cs
@@ -1,3 +1,3 @@
 namespace Worms.Hub.ReplayProcessor.Queue;
 
-public record ReplayToUpdateMessage(string ReplayPath);
+public record ReplayToUpdateMessage(string ReplayPath, string ReplayLogPath);

--- a/src/Worms.Hub.ReplayUpdater.Queues/ReplayToUpdateMessage.cs
+++ b/src/Worms.Hub.ReplayUpdater.Queues/ReplayToUpdateMessage.cs
@@ -1,0 +1,3 @@
+namespace Worms.Hub.ReplayProcessor.Queue;
+
+public record ReplayToUpdateMessage(string ReplayFileName);

--- a/src/Worms.Hub.ReplayUpdater.Queues/ReplaysToUpdate.cs
+++ b/src/Worms.Hub.ReplayUpdater.Queues/ReplaysToUpdate.cs
@@ -22,7 +22,7 @@ internal sealed class ReplaysToUpdate(IConfiguration configuration) : IMessageQu
         var connectionString = configuration.GetConnectionString("Storage");
         var queueClient = new QueueClient(connectionString, QueueName);
         _ = await queueClient.CreateIfNotExistsAsync();
-        _ = await queueClient.SendMessageAsync(message.ReplayFileName);
+        _ = await queueClient.SendMessageAsync(message.ReplayPath);
     }
 
     public async Task<(ReplayToUpdateMessage?, MessageDetails?)> DequeueMessage()

--- a/src/Worms.Hub.ReplayUpdater.Queues/ReplaysToUpdate.cs
+++ b/src/Worms.Hub.ReplayUpdater.Queues/ReplaysToUpdate.cs
@@ -4,9 +4,9 @@ using Worms.Hub.Queues;
 
 namespace Worms.Hub.ReplayProcessor.Queue;
 
-internal sealed class ReplaysToProcess(IConfiguration configuration) : IMessageQueue<ReplayToProcessMessage>
+internal sealed class ReplaysToUpdate(IConfiguration configuration) : IMessageQueue<ReplayToUpdateMessage>
 {
-    private const string QueueName = "replays-to-process";
+    private const string QueueName = "replays-to-update";
 
     public async Task<bool> HasPendingMessage()
     {
@@ -17,7 +17,7 @@ internal sealed class ReplaysToProcess(IConfiguration configuration) : IMessageQ
         return peekedMessage.Value is not null;
     }
 
-    public async Task EnqueueMessage(ReplayToProcessMessage message)
+    public async Task EnqueueMessage(ReplayToUpdateMessage message)
     {
         var connectionString = configuration.GetConnectionString("Storage");
         var queueClient = new QueueClient(connectionString, QueueName);
@@ -25,7 +25,7 @@ internal sealed class ReplaysToProcess(IConfiguration configuration) : IMessageQ
         _ = await queueClient.SendMessageAsync(message.ReplayFileName);
     }
 
-    public async Task<(ReplayToProcessMessage?, MessageDetails?)> DequeueMessage()
+    public async Task<(ReplayToUpdateMessage?, MessageDetails?)> DequeueMessage()
     {
         var connectionString = configuration.GetConnectionString("Storage");
         var queueClient = new QueueClient(connectionString, QueueName);
@@ -33,7 +33,7 @@ internal sealed class ReplaysToProcess(IConfiguration configuration) : IMessageQ
         var message = await queueClient.ReceiveMessageAsync();
         return message.Value is null
             ? (null, null)
-            : (new ReplayToProcessMessage(message.Value.MessageText),
+            : (new ReplayToUpdateMessage(message.Value.MessageText),
                 new MessageDetails(message.Value.MessageId, message.Value.PopReceipt));
     }
 

--- a/src/Worms.Hub.ReplayUpdater.Queues/ServiceRegistration.cs
+++ b/src/Worms.Hub.ReplayUpdater.Queues/ServiceRegistration.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+using Worms.Hub.Queues;
+
+namespace Worms.Hub.ReplayProcessor.Queue;
+
+public static class ServiceRegistration
+{
+    public static IServiceCollection AddReplayToUpdateQueueServices(this IServiceCollection builder) =>
+        builder.AddScoped<IMessageQueue<ReplayToUpdateMessage>, ReplaysToUpdate>();
+}

--- a/src/Worms.Hub.ReplayUpdater.Queues/Worms.Hub.ReplayUpdater.Queues.csproj
+++ b/src/Worms.Hub.ReplayUpdater.Queues/Worms.Hub.ReplayUpdater.Queues.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Worms.Hub.ReplayProcessor.Queue</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="12.22.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Worms.Hub.Queues\Worms.Hub.Queues.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Worms.Hub.ReplayUpdater/CheckForMessagesService.cs
+++ b/src/Worms.Hub.ReplayUpdater/CheckForMessagesService.cs
@@ -1,0 +1,25 @@
+using Worms.Hub.Queues;
+using Worms.Hub.ReplayProcessor.Queue;
+
+namespace Worms.Hub.ReplayUpdater;
+
+internal sealed class CheckForMessagesService(IServiceProvider serviceProvider) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var messageQueue = scope.ServiceProvider.GetRequiredService<IMessageQueue<ReplayToUpdateMessage>>();
+        var processor = scope.ServiceProvider.GetRequiredService<Processor>();
+
+        await Task.Yield();
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            if (await messageQueue.HasPendingMessage())
+            {
+                await processor.UpdateReplay();
+            }
+
+            await Task.Delay(1000, stoppingToken);
+        }
+    }
+}

--- a/src/Worms.Hub.ReplayUpdater/Processor.cs
+++ b/src/Worms.Hub.ReplayUpdater/Processor.cs
@@ -1,0 +1,65 @@
+using Worms.Hub.Queues;
+using Worms.Hub.ReplayProcessor.Queue;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+using Worms.Hub.Storage.Files;
+
+namespace Worms.Hub.ReplayUpdater;
+
+internal sealed class Processor(
+    IMessageQueue<ReplayToUpdateMessage> messageQueue,
+    IRepository<Replay> replayRepository,
+    ReplayFiles replayFiles,
+    ILogger<Processor> logger)
+{
+    public async Task UpdateReplay()
+    {
+        logger.LogInformation("Starting replay updater...");
+
+        var (message, token) = await messageQueue.DequeueMessage();
+        if (message is null || token is null)
+        {
+            logger.LogInformation("No messages to process.");
+            return;
+        }
+
+        // Check replay is in the folder
+        var replayPath = replayFiles.GetReplayPath(message.ReplayFileName);
+        if (!File.Exists(replayPath))
+        {
+            logger.LogError("Replay not found on disk: {ReplayPath}", replayPath);
+            return;
+        }
+
+        // Check replay has a log file generated
+        var logPath = replayFiles.GetLogPath(replayPath);
+        if (logPath is null)
+        {
+            logger.LogError("Log file not found from replay path: {ReplayPath}", replayPath);
+            return;
+        }
+
+        // Check the replay exists in the database
+        var replay = replayRepository.GetAll().FirstOrDefault(r => r.Filename == message.ReplayFileName);
+        if (replay is null)
+        {
+            logger.LogError("Replay not found in database: {ReplayPath}", replayPath);
+            return;
+        }
+
+        var replayLog = await File.ReadAllTextAsync(logPath);
+
+        // Update the database with the log
+        var updatedReplay = replay with
+        {
+            Status = "Processed",
+            FullLog = replayLog
+        };
+        replayRepository.Update(updatedReplay);
+
+        // Delete the message from the queue
+        await messageQueue.DeleteMessage(token);
+
+        logger.LogInformation("Replay updater finished.");
+    }
+}

--- a/src/Worms.Hub.ReplayUpdater/Processor.cs
+++ b/src/Worms.Hub.ReplayUpdater/Processor.cs
@@ -24,7 +24,7 @@ internal sealed class Processor(
         }
 
         // Check replay is in the folder
-        var replayPath = replayFiles.GetReplayPath(message.ReplayFileName);
+        var replayPath = replayFiles.GetReplayPath(message.ReplayPath);
         if (!File.Exists(replayPath))
         {
             logger.LogError("Replay not found on disk: {ReplayPath}", replayPath);
@@ -40,7 +40,7 @@ internal sealed class Processor(
         }
 
         // Check the replay exists in the database
-        var replay = replayRepository.GetAll().FirstOrDefault(r => r.Filename == message.ReplayFileName);
+        var replay = replayRepository.GetAll().FirstOrDefault(r => r.Filename == message.ReplayPath);
         if (replay is null)
         {
             logger.LogError("Replay not found in database: {ReplayPath}", replayPath);

--- a/src/Worms.Hub.ReplayUpdater/Processor.cs
+++ b/src/Worms.Hub.ReplayUpdater/Processor.cs
@@ -32,10 +32,9 @@ internal sealed class Processor(
         }
 
         // Check replay has a log file generated
-        var logPath = replayFiles.GetLogPath(replayPath);
-        if (logPath is null)
+        if (!File.Exists(message.ReplayLogPath))
         {
-            logger.LogError("Log file not found from replay path: {ReplayPath}", replayPath);
+            logger.LogError("Log file not found: {LogPath}", message.ReplayLogPath);
             return;
         }
 
@@ -47,7 +46,7 @@ internal sealed class Processor(
             return;
         }
 
-        var replayLog = await File.ReadAllTextAsync(logPath);
+        var replayLog = await File.ReadAllTextAsync(message.ReplayLogPath);
 
         // Update the database with the log
         var updatedReplay = replay with

--- a/src/Worms.Hub.ReplayUpdater/Program.cs
+++ b/src/Worms.Hub.ReplayUpdater/Program.cs
@@ -1,0 +1,30 @@
+using Worms.Hub.ReplayUpdater;
+
+var configuration = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
+    .AddJsonFile("appsettings.json", false, true)
+    .AddEnvironmentVariables("WORMS_")
+    .Build();
+
+// Run as a batch job when in Production
+// These means we can scale to zero when there are no messages to process
+if (configuration["BATCH"] == "true")
+{
+    var serviceProvider = new ServiceCollection().AddReplayUpdaterServices()
+        .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug).AddSimpleConsole(c => c.SingleLine = true))
+        .AddSingleton<IConfiguration>(configuration)
+        .BuildServiceProvider();
+    var processor = serviceProvider.GetService<Processor>();
+    await processor!.UpdateReplay();
+    return;
+}
+
+// Run as a hosted service when in Development
+// This means we can run continuously and check for messages
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureLogging((_, builder) => builder.AddSimpleConsole(c => c.SingleLine = true))
+    .ConfigureAppConfiguration(config => config.AddConfiguration(configuration))
+    .ConfigureServices(s => s.AddReplayUpdaterServices())
+    .ConfigureServices(services => services.AddHostedService<CheckForMessagesService>())
+    .Build();
+
+await host.RunAsync();

--- a/src/Worms.Hub.ReplayUpdater/ServiceRegistration.cs
+++ b/src/Worms.Hub.ReplayUpdater/ServiceRegistration.cs
@@ -1,0 +1,10 @@
+using Worms.Hub.ReplayProcessor.Queue;
+using Worms.Hub.Storage;
+
+namespace Worms.Hub.ReplayUpdater;
+
+internal static class ServiceRegistration
+{
+    public static IServiceCollection AddReplayUpdaterServices(this IServiceCollection builder) =>
+        builder.AddHubStorageServices().AddReplayToUpdateQueueServices().AddScoped<Processor>();
+}

--- a/src/Worms.Hub.ReplayUpdater/Worms.Hub.ReplayUpdater.csproj
+++ b/src/Worms.Hub.ReplayUpdater/Worms.Hub.ReplayUpdater.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Worms.Hub.ReplayUpdater.Queues\Worms.Hub.ReplayUpdater.Queues.csproj"/>
+    <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Worms.Hub.ReplayUpdater/appsettings.json
+++ b/src/Worms.Hub.ReplayUpdater/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "Storage": "UseDevelopmentStorage=true"
+  }
+}

--- a/src/Worms.Hub.Storage/Files/ReplayFiles.cs
+++ b/src/Worms.Hub.Storage/Files/ReplayFiles.cs
@@ -1,23 +1,21 @@
 using Microsoft.Extensions.Configuration;
-using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Storage.Files;
 
 public class ReplayFiles(IConfiguration configuration)
 {
-    public string GetReplayPath(Replay replay)
+    public string GetReplayPath(string replayFileName)
     {
-        ArgumentNullException.ThrowIfNull(replay);
-        return Path.Combine(GetReplayFolderPath(), replay.Filename);
+        ArgumentNullException.ThrowIfNull(replayFileName);
+        return Path.Combine(GetReplayFolderPath(), replayFileName);
     }
 
-    public string? GetLogPath(Replay replay)
+    public string? GetLogPath(string replayFileName)
     {
-        ArgumentNullException.ThrowIfNull(replay);
-
-        var fileName = replay.Filename.EndsWith(".WAGame", StringComparison.InvariantCultureIgnoreCase)
-            ? Path.GetFileNameWithoutExtension(replay.Filename)
-            : replay.Filename;
+        ArgumentNullException.ThrowIfNull(replayFileName);
+        var fileName = replayFileName.EndsWith(".WAGame", StringComparison.InvariantCultureIgnoreCase)
+            ? Path.GetFileNameWithoutExtension(replayFileName)
+            : replayFileName;
 
         var logPath = Path.Combine(GetReplayFolderPath(), $"{fileName}.log");
         return File.Exists(logPath) ? logPath : null;

--- a/src/Worms.Hub.Storage/ServiceRegistration.cs
+++ b/src/Worms.Hub.Storage/ServiceRegistration.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Domain;
 using Worms.Hub.Storage.Files;
-using Worms.Hub.Storage.Queues;
 
 namespace Worms.Hub.Storage;
 
@@ -13,6 +12,5 @@ public static class ServiceRegistration
             .AddScoped<IRepository<Replay>, ReplaysRepository>()
             .AddScoped<CliFiles>()
             .AddScoped<ReplayFiles>()
-            .AddScoped<SchemeFiles>()
-            .AddScoped<IMessageQueue<ReplayToProcessMessage>, ReplaysToProcess>();
+            .AddScoped<SchemeFiles>();
 }


### PR DESCRIPTION
This PR splits out a new service for updating the database with new Replay details. This should reduce how often the Replay Processor needs to be rebuild (and therefore manually tested). Following this change the Replay Processor only needs to be updated if:
- The base Queue implementation changes (or library is updated)
- The message definitions for its input event change
- The message definitions for its output event change
- The code to run Worms changes
- The code in the Replay Processor changes