### PR TITLE
Improved Windows process runner

### DIFF
--- a/src/Worms.Armageddon.Game/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Game/ServiceRegistration.cs
@@ -35,11 +35,16 @@ public static class ServiceRegistration
     }
 
     [SupportedOSPlatform("windows")]
-    private static IServiceCollection AddWindowsServices(this IServiceCollection builder) =>
-        builder.AddScoped<ISteamService, SteamService>()
+    private static IServiceCollection AddWindowsServices(this IServiceCollection builder)
+    {
+        _ = Environment.GetEnvironmentVariable("WORMS_TOGGLE_NEW_WA_RUNNER") == "true"
+            ? builder.AddScoped<IWormsRunner, WormsRunner2>()
+            : builder.AddScoped<IWormsRunner, WormsRunner>();
+
+        return builder.AddScoped<ISteamService, SteamService>()
             .AddScoped<IWormsLocator, WormsLocator>()
-            .AddScoped<IWormsRunner, WormsRunner>()
             .AddScoped<IRegistry, Registry>();
+    }
 
     private static IServiceCollection AddLinuxServices(this IServiceCollection builder) =>
         builder.AddScoped<IWormsLocator, Linux.WormsLocator>().AddScoped<IWormsRunner, Linux.WormsRunner>();

--- a/src/Worms.Armageddon.Game/System/IProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/IProcessRunner.cs
@@ -6,7 +6,9 @@ internal interface IProcessRunner
 {
     IProcess Start(string fileName, params string[] args);
 
-    IProcess FindProcess(string processName);
+    IProcess? FindProcess(string processName);
+
+    IProcess? FindProcess(string processName, TimeSpan timeout);
 
     IProcess Start(ProcessStartInfo processStartInfo);
 }

--- a/src/Worms.Armageddon.Game/System/IProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/IProcessRunner.cs
@@ -4,9 +4,9 @@ namespace Worms.Armageddon.Game.System;
 
 internal interface IProcessRunner
 {
-    IProcess? Start(string fileName, params string[] args);
+    IProcess Start(string fileName, params string[] args);
 
-    IProcess? FindProcess(string processName);
+    IProcess FindProcess(string processName);
 
-    IProcess? Start(ProcessStartInfo processStartInfo);
+    IProcess Start(ProcessStartInfo processStartInfo);
 }

--- a/src/Worms.Armageddon.Game/System/ProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/ProcessRunner.cs
@@ -22,8 +22,6 @@ internal class ProcessRunner : IProcessRunner
 
     public IProcess? FindProcess(string processName, TimeSpan timeout)
     {
-        using var span = Activity.Current;
-
         IProcess? process = null;
         while (process is null && timeout.TotalMilliseconds > 0)
         {
@@ -33,7 +31,7 @@ internal class ProcessRunner : IProcessRunner
             timeout -= TimeSpan.FromMilliseconds(500);
         }
 
-        _ = span?.SetTag(Telemetry.Spans.ProcessRunner.TimeToFindProcess, timeout.Milliseconds);
+        _ = Activity.Current?.SetTag(Telemetry.Spans.ProcessRunner.TimeToFindProcess, timeout.Milliseconds);
         return process;
     }
 

--- a/src/Worms.Armageddon.Game/System/ProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/ProcessRunner.cs
@@ -4,13 +4,13 @@ namespace Worms.Armageddon.Game.System;
 
 internal class ProcessRunner : IProcessRunner
 {
-    public IProcess? Start(string fileName, params string[] args) =>
+    public IProcess Start(string fileName, params string[] args) =>
         new Process(global::System.Diagnostics.Process.Start(fileName, string.Join(" ", args.ToList())));
 
-    public IProcess? FindProcess(string processName)
+    public IProcess FindProcess(string processName)
     {
         IProcess? process = null;
-        for (var retryCount = 0; process is null && retryCount <= 5; retryCount++)
+        while (process == null)
         {
             Thread.Sleep(500);
             var foundProcess = global::System.Diagnostics.Process.GetProcessesByName(processName).FirstOrDefault();

--- a/src/Worms.Armageddon.Game/Telemetry.cs
+++ b/src/Worms.Armageddon.Game/Telemetry.cs
@@ -11,5 +11,10 @@ public static class Telemetry
             public const string Args = "worms.armageddon.args";
             public const string ExitCode = "worms.armageddon.exit_code";
         }
+
+        internal static class ProcessRunner
+        {
+            public const string TimeToFindProcess = "worms.process.runner.time_to_find_process_ms";
+        }
     }
 }

--- a/src/Worms.Armageddon.Game/Telemetry.cs
+++ b/src/Worms.Armageddon.Game/Telemetry.cs
@@ -9,6 +9,7 @@ public static class Telemetry
             public const string SpanName = "Worms Armageddon";
             public const string Version = "worms.armageddon.version";
             public const string Args = "worms.armageddon.args";
+            public const string ExitCode = "worms.armageddon.exit_code";
         }
     }
 }

--- a/src/Worms.Armageddon.Game/Win/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner.cs
@@ -12,50 +12,49 @@ internal sealed class WormsRunner(
 {
     public Task RunWorms(params string[] wormsArgs)
     {
-        return Task.Run(
-            async () =>
-                {
-                    using var span = Activity.Current?.Source.StartActivity(
-                        Telemetry.Spans.WormsArmageddon.SpanName,
-                        ActivityKind.Client);
+        return Task.Run(async () =>
+            {
+                using var span = Activity.Current?.Source.StartActivity(
+                    Telemetry.Spans.WormsArmageddon.SpanName,
+                    ActivityKind.Client);
 
-                    var gameInfo = wormsLocator.Find();
-                    if (!gameInfo.IsInstalled)
+                var gameInfo = wormsLocator.Find();
+                if (!gameInfo.IsInstalled)
+                {
+                    _ = span?.SetStatus(ActivityStatusCode.Error);
+                    throw new InvalidOperationException("Worms Armageddon is not installed");
+                }
+
+                logger.Log(LogLevel.Debug, "Running Worms Armageddon: {Path}", gameInfo.ExeLocation);
+                logger.Log(LogLevel.Debug, "Args: {Arguments}", wormsArgs.ToList());
+
+                _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Version, gameInfo.Version);
+                _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Args, wormsArgs);
+
+                using (var process = processRunner.Start(gameInfo.ExeLocation, wormsArgs))
+                {
+                    if (process == null)
                     {
                         _ = span?.SetStatus(ActivityStatusCode.Error);
-                        throw new InvalidOperationException("Worms Armageddon is not installed");
+                        throw new InvalidOperationException("Unable to start worms process");
                     }
 
-                    logger.Log(LogLevel.Debug, "Running Worms Armageddon: {Path}", gameInfo.ExeLocation);
-                    logger.Log(LogLevel.Debug, "Args: {Arguments}", wormsArgs.ToList());
+                    await process.WaitForExitAsync();
+                    logger.Log(LogLevel.Debug, "Launcher process exited with code: {ExitCode}", process.ExitCode);
+                }
 
-                    _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Version, gameInfo.Version);
-                    _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Args, wormsArgs);
+                logger.Log(LogLevel.Debug, "Waiting for Steam prompt...");
+                steamService.WaitForSteamPrompt();
 
-                    using (var process = processRunner.Start(gameInfo.ExeLocation, wormsArgs))
-                    {
-                        if (process == null)
-                        {
-                            _ = span?.SetStatus(ActivityStatusCode.Error);
-                            throw new InvalidOperationException("Unable to start worms process");
-                        }
+                var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
 
-                        await process.WaitForExitAsync();
-                        logger.Log(LogLevel.Debug, "Launcher process exited with code: {ExitCode}", process.ExitCode);
-                    }
+                if (wormsProcess is not null)
+                {
+                    await wormsProcess.WaitForExitAsync();
+                    logger.Log(LogLevel.Debug, "Worms process exited with code: {ExitCode}", wormsProcess.ExitCode);
+                }
 
-                    logger.Log(LogLevel.Debug, "Waiting for Steam prompt...");
-                    steamService.WaitForSteamPrompt();
-
-                    var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
-
-                    if (wormsProcess is not null)
-                    {
-                        await wormsProcess.WaitForExitAsync();
-                        logger.Log(LogLevel.Debug, "Worms process exited with code: {ExitCode}", wormsProcess.ExitCode);
-                    }
-
-                    return Task.CompletedTask;
-                });
+                return Task.CompletedTask;
+            });
     }
 }

--- a/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
@@ -32,9 +32,13 @@ internal sealed class WormsRunner2(
 
                 using (processRunner.Start(gameInfo.ExeLocation, wormsArgs))
                 {
+                    logger.Log(LogLevel.Debug, "Looking for worms process: {ProcessName}...", gameInfo.ProcessName);
                     var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
+                    logger.Log(LogLevel.Debug, "Process found");
+                    logger.Log(LogLevel.Debug, "Waiting for process to exit...");
                     await wormsProcess.WaitForExitAsync();
                     logger.Log(LogLevel.Debug, "Worms process exited with code: {ExitCode}", wormsProcess.ExitCode);
+                    _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.ExitCode, wormsProcess.ExitCode);
                 }
             });
     }

--- a/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Worms.Armageddon.Game.System;
+
+namespace Worms.Armageddon.Game.Win;
+
+internal sealed class WormsRunner2(
+    IWormsLocator wormsLocator,
+    ISteamService steamService,
+    IProcessRunner processRunner,
+    ILogger<WormsRunner2> logger) : IWormsRunner
+{
+    public Task RunWorms(params string[] wormsArgs)
+    {
+        return Task.Run(async () =>
+            {
+                using var span = Activity.Current?.Source.StartActivity(
+                    Telemetry.Spans.WormsArmageddon.SpanName,
+                    ActivityKind.Client);
+
+                var gameInfo = wormsLocator.Find();
+                if (!gameInfo.IsInstalled)
+                {
+                    _ = span?.SetStatus(ActivityStatusCode.Error);
+                    throw new InvalidOperationException("Worms Armageddon is not installed");
+                }
+
+                logger.Log(LogLevel.Debug, "Running Worms Armageddon: {Path}", gameInfo.ExeLocation);
+                logger.Log(LogLevel.Debug, "Args: {Arguments}", wormsArgs.ToList());
+
+                _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Version, gameInfo.Version);
+                _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Args, wormsArgs);
+
+                using (var process = processRunner.Start(gameInfo.ExeLocation, wormsArgs))
+                {
+                    if (process == null)
+                    {
+                        _ = span?.SetStatus(ActivityStatusCode.Error);
+                        throw new InvalidOperationException("Unable to start worms process");
+                    }
+
+                    await process.WaitForExitAsync();
+                    logger.Log(LogLevel.Debug, "Launcher process exited with code: {ExitCode}", process.ExitCode);
+                }
+
+                logger.Log(LogLevel.Debug, "Waiting for Steam prompt...");
+                steamService.WaitForSteamPrompt();
+
+                var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
+
+                if (wormsProcess is not null)
+                {
+                    await wormsProcess.WaitForExitAsync();
+                    logger.Log(LogLevel.Debug, "Worms process exited with code: {ExitCode}", wormsProcess.ExitCode);
+                }
+
+                return Task.CompletedTask;
+            });
+    }
+}

--- a/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
@@ -6,7 +6,6 @@ namespace Worms.Armageddon.Game.Win;
 
 internal sealed class WormsRunner2(
     IWormsLocator wormsLocator,
-    ISteamService steamService,
     IProcessRunner processRunner,
     ILogger<WormsRunner2> logger) : IWormsRunner
 {
@@ -31,30 +30,12 @@ internal sealed class WormsRunner2(
                 _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Version, gameInfo.Version);
                 _ = span?.SetTag(Telemetry.Spans.WormsArmageddon.Args, wormsArgs);
 
-                using (var process = processRunner.Start(gameInfo.ExeLocation, wormsArgs))
+                using (processRunner.Start(gameInfo.ExeLocation, wormsArgs))
                 {
-                    if (process == null)
-                    {
-                        _ = span?.SetStatus(ActivityStatusCode.Error);
-                        throw new InvalidOperationException("Unable to start worms process");
-                    }
-
-                    await process.WaitForExitAsync();
-                    logger.Log(LogLevel.Debug, "Launcher process exited with code: {ExitCode}", process.ExitCode);
-                }
-
-                logger.Log(LogLevel.Debug, "Waiting for Steam prompt...");
-                steamService.WaitForSteamPrompt();
-
-                var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
-
-                if (wormsProcess is not null)
-                {
+                    var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
                     await wormsProcess.WaitForExitAsync();
                     logger.Log(LogLevel.Debug, "Worms process exited with code: {ExitCode}", wormsProcess.ExitCode);
                 }
-
-                return Task.CompletedTask;
             });
     }
 }

--- a/src/Worms.Cli/Commands/Host.cs
+++ b/src/Worms.Cli/Commands/Host.cs
@@ -58,9 +58,7 @@ internal sealed class HostHandler(
     private const string LeagueName = "redgate";
     private const string Domain = "red-gate.com";
 
-    public override async Task<int> InvokeAsync(
-        ParseResult parseResult,
-        CancellationToken cancellationToken = default)
+    public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         _ = Activity.Current?.SetTag("name", Telemetry.Spans.Host.SpanName);
 
@@ -176,6 +174,14 @@ internal sealed class HostHandler(
         if (replay is null)
         {
             logger.LogWarning("No replay found to upload");
+            return;
+        }
+
+        // Check if the replay was created during this session
+        var timeSinceGameEnded = DateTime.UtcNow - replay.Details.Date.ToUniversalTime();
+        if (timeSinceGameEnded > TimeSpan.FromHours(1))
+        {
+            logger.LogWarning("No recent replay found to upload");
             return;
         }
 


### PR DESCRIPTION
This PR adds a new experimental process runner for Windows when the `WORMS_TOGGLE_NEW_WA_RUNNER` env var is set to `true`

This new runner:
- No longer contains code to handle the Steam "Do you want to launch" dialog. I've not seen it in years.
- When the process is not found it will now error rather than siliently continuing
- Locating the process will now wait for 5 minues. Steam can start up / update while this is waiting.
- Much improved telemetry

This PR also checks how old the replay is and only uploads it if its from the last hour.

Fixes: #1037