### PR TITLE
Fix analyzer warnings and code scanning alerts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -267,6 +267,7 @@ resharper_enforce_if_statement_braces_highlighting = warning
 resharper_enforce_lock_statement_braces_highlighting = warning
 resharper_enforce_using_statement_braces_highlighting = warning
 resharper_enforce_while_statement_braces_highlighting = warning
+resharper_explicit_caller_info_argument_highlighting = none
 resharper_heuristic_unreachable_code_highlighting = none
 resharper_member_can_be_protected_global_highlighting = none
 resharper_redundant_base_qualifier_highlighting = warning
@@ -290,6 +291,8 @@ dotnet_diagnostic.CA1308.severity = none
 dotnet_diagnostic.CA1303.severity = none
 # CA2007 only applies to libraries that may be consumed by UI frameworks
 dotnet_diagnostic.CA2007.severity = none
+# CA1873 flags logging calls as expensive - not a concern for this project
+dotnet_diagnostic.CA1873.severity = none
 # Workaround for https://github.com/dotnet/roslyn/issues/41640
 dotnet_diagnostic.IDE0005.severity = suggestion
 

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -29,7 +29,8 @@ jobs:
           mkdir -p sarif
           dotnet build Worms.sln /p:Sarif=true
           dotnet tool install --local Sarif.Multitool
-          dotnet sarif merge sarif/*.sarif --recurse true --merge-runs --output-file=roslyn.sarif
+          dotnet sarif merge sarif/*.sarif --recurse true --merge-runs --output-file=roslyn-raw.sarif
+          dotnet sarif suppress roslyn-raw.sarif --output-file roslyn.sarif
 
       - name: Upload Rosyln SARIF
         if: always()

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -36,6 +36,14 @@ jobs:
           jq '.runs[].results |= map(select(has("suppressions") == false or (.suppressions | length) == 0))' roslyn.sarif > roslyn.filtered.sarif
           mv roslyn.filtered.sarif roslyn.sarif
 
+      - name: Check for warnings
+        run: |
+          RESULTS=$(jq '[.runs[].results[]] | length' roslyn.sarif)
+          if [ "$RESULTS" -gt 0 ]; then
+            echo "::error::Roslyn found $RESULTS warning(s)"
+            exit 1
+          fi
+
       - name: Upload Rosyln SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@v4
@@ -60,6 +68,14 @@ jobs:
         run: |
           dotnet tool install --local JetBrains.ReSharper.GlobalTools
           dotnet jb inspectcode Worms.sln --output=jetbrains.sarif --format=sarif
+
+      - name: Check for warnings
+        run: |
+          RESULTS=$(jq '[.runs[].results[]] | length' jetbrains.sarif)
+          if [ "$RESULTS" -gt 0 ]; then
+            echo "::error::JetBrains InspectCode found $RESULTS warning(s)"
+            exit 1
+          fi
 
       - name: Upload JetBrains SARIF
         if: always()

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -29,8 +29,12 @@ jobs:
           mkdir -p sarif
           dotnet build Worms.sln /p:Sarif=true
           dotnet tool install --local Sarif.Multitool
-          dotnet sarif merge sarif/*.sarif --recurse true --merge-runs --output-file=roslyn-raw.sarif
-          dotnet sarif suppress roslyn-raw.sarif --output-file roslyn.sarif
+          dotnet sarif merge sarif/*.sarif --recurse true --merge-runs --output-file=roslyn.sarif
+
+      - name: Remove suppressed results
+        run: |
+          jq '.runs[].results |= map(select(has("suppressions") == false or (.suppressions | length) == 0))' roslyn.sarif > roslyn.filtered.sarif
+          mv roslyn.filtered.sarif roslyn.sarif
 
       - name: Upload Rosyln SARIF
         if: always()

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0"/>
   </ItemGroup>
 </Project>

--- a/deployment/Worms.Hub.Infrastructure/Azure/ContainerApps/Environment.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/ContainerApps/Environment.cs
@@ -34,7 +34,7 @@ internal static class Environment
                     {
                         CustomerId = logAnalytics.CustomerId,
                         SharedKey = logAnalyticsSharedKeys.Apply(
-                            x => x.PrimarySharedKey ?? throw new Exception("No primary shared key found")),
+                            x => x.PrimarySharedKey ?? throw new InvalidOperationException("No primary shared key found")),
                     }
                 }
             });

--- a/deployment/Worms.Hub.Infrastructure/Azure/ContainerApps/Gateway.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/ContainerApps/Gateway.cs
@@ -197,7 +197,7 @@ internal static class Gateway
                     ResourceGroupName = Utils.GetResourceName("Worms-Hub")
                 });
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             // Certificate not found
         }

--- a/deployment/Worms.Hub.Infrastructure/Azure/Database.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/Database.cs
@@ -54,7 +54,7 @@ internal static class Database
                 ServerName = server.Name,
             });
 
-        var sqlFwRuleAllowAll = new DBForPostgreSQL.FirewallRule(
+        _ = new DBForPostgreSQL.FirewallRule(
             "postgres-firewall-rule",
             new()
             {
@@ -69,7 +69,7 @@ internal static class Database
         {
             var myIp = Output.Create(Utils.GetMyPublicIp());
 
-            var firewallRule = new DBForPostgreSQL.FirewallRule(
+            _ = new DBForPostgreSQL.FirewallRule(
                 "allow-my-ip",
                 new()
                 {

--- a/deployment/Worms.Hub.Infrastructure/Azure/FileShare.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/FileShare.cs
@@ -9,7 +9,7 @@ internal static class FileShare
     public static Storage.FileShare Config(
         ResourceGroup resourceGroup,
         Storage.StorageAccount storageAccount,
-        Config config) =>
+        Config _) =>
         new(
             "file-share",
             new()

--- a/deployment/Worms.Hub.Infrastructure/Azure/StorageAccount.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/StorageAccount.cs
@@ -6,7 +6,7 @@ namespace Worms.Hub.Infrastructure.Azure;
 
 internal static class StorageAccount
 {
-    public static (Storage.StorageAccount storageAccount, Output<string> accessToken) Config(ResourceGroup resourceGroup, Config config)
+    public static (Storage.StorageAccount storageAccount, Output<string> accessToken) Config(ResourceGroup resourceGroup, Config _)
     {
         var storage = new Storage.StorageAccount(
             "storage-account",

--- a/deployment/Worms.Hub.Infrastructure/Azure/Utils.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/Utils.cs
@@ -17,6 +17,6 @@ internal static class Utils
     public static async Task<string> GetMyPublicIp()
     {
         using var http = new HttpClient();
-        return (await http.GetStringAsync("https://api.ipify.org")).Trim();
+        return (await http.GetStringAsync(new Uri("https://api.ipify.org"))).Trim();
     }
 }

--- a/deployment/Worms.Hub.Infrastructure/Azure/Utils.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/Utils.cs
@@ -2,6 +2,8 @@ namespace Worms.Hub.Infrastructure.Azure;
 
 internal static class Utils
 {
+    private static readonly HttpClient HttpClient = new();
+
     public static string GetResourceName(string name)
     {
         var stack = Pulumi.Deployment.Instance.StackName;
@@ -14,9 +16,6 @@ internal static class Utils
         return stack == "prod" ? name : name + stack;
     }
 
-    public static async Task<string> GetMyPublicIp()
-    {
-        using var http = new HttpClient();
-        return (await http.GetStringAsync(new Uri("https://api.ipify.org"))).Trim();
-    }
+    public static async Task<string> GetMyPublicIp() =>
+        (await HttpClient.GetStringAsync(new Uri("https://api.ipify.org"))).Trim();
 }

--- a/deployment/Worms.Hub.Infrastructure/Azure/WormsHub.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/WormsHub.cs
@@ -63,10 +63,10 @@ internal static class WormsHub
             queueConnStr);
 
         // WA Runner
-        var waRunner = WaRunner.Config(resourceGroup, config, containerApp, containerAppStorage, queueConnStr);
+        _ = WaRunner.Config(resourceGroup, config, containerApp, containerAppStorage, queueConnStr);
 
         // Worker
-        var worker = Worker.Config(
+        _ = Worker.Config(
             resourceGroup,
             config,
             containerApp,

--- a/src/Worms.Armageddon.Files/Replays/Filename/ReplayFilenameInfo.cs
+++ b/src/Worms.Armageddon.Files/Replays/Filename/ReplayFilenameInfo.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Armageddon.Files.Replays.Filename;
 
+[PublicAPI]
 public record ReplayFilenameInfo(
     DateTime Date,
     string GameMode,

--- a/src/Worms.Armageddon.Files/Replays/ReplayResource.cs
+++ b/src/Worms.Armageddon.Files/Replays/ReplayResource.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Armageddon.Files.Replays;
 
+[PublicAPI]
 public record ReplayResource(
     DateTime Date,
     bool Processed,
@@ -8,6 +11,7 @@ public record ReplayResource(
     IReadOnlyCollection<Turn> Turns,
     string FullLog);
 
+[PublicAPI]
 public record Team(string Name, string Machine, TeamColour Colour)
 {
     public static Team Local(string name, TeamColour colour) => new(name, "local", colour);
@@ -25,6 +29,7 @@ public enum TeamColour
     Cyan = 5
 }
 
+[PublicAPI]
 public record Turn(
     TimeSpan Start,
     TimeSpan End,
@@ -32,6 +37,8 @@ public record Turn(
     IReadOnlyCollection<Weapon> Weapons,
     IReadOnlyCollection<Damage> Damage);
 
+[PublicAPI]
 public record Weapon(string Name, uint? Fuse, string? Modifier);
 
+[PublicAPI]
 public record Damage(Team Team, uint HealthLost, uint WormsKilled);

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/DamageParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/DamageParser.cs
@@ -13,10 +13,10 @@ internal sealed partial class DamageParser : IReplayLineParser
     [GeneratedRegex($"{Timestamp} (•••|���) Damage dealt: {DamageDealtDetails}")]
     private static partial Regex DamageDealt();
 
-    [GeneratedRegex($@"{Number} to {TeamName}")]
+    [GeneratedRegex($"{Number} to {TeamName}")]
     private static partial Regex DamageWithNoKills();
 
-    [GeneratedRegex($@"{Number} \({Number} kills?\) to {TeamName}")]
+    [GeneratedRegex($"{Number} \\({Number} kills?\\) to {TeamName}")]
     private static partial Regex DamageWithKills();
 
     public bool CanParse(string line) => DamageDealt().IsMatch(line);

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/DamageParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/DamageParser.cs
@@ -3,19 +3,27 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class DamageParser : IReplayLineParser
+internal sealed partial class DamageParser : IReplayLineParser
 {
     private const string Timestamp = @"\[(\d+:\d+:\d+.\d+)\]";
     private const string DamageDealtDetails = "(.+)";
     private const string Number = @"(\d+)";
     private const string TeamName = "(.+)";
-    private static readonly Regex DamageDealt = new($"{Timestamp} (•••|���) Damage dealt: {DamageDealtDetails}");
 
-    public bool CanParse(string line) => DamageDealt.IsMatch(line);
+    [GeneratedRegex($"{Timestamp} (•••|���) Damage dealt: {DamageDealtDetails}")]
+    private static partial Regex DamageDealt();
+
+    [GeneratedRegex($@"{Number} to {TeamName}")]
+    private static partial Regex DamageWithNoKills();
+
+    [GeneratedRegex($@"{Number} \({Number} kills?\) to {TeamName}")]
+    private static partial Regex DamageWithKills();
+
+    public bool CanParse(string line) => DamageDealt().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var damageDealt = DamageDealt.Match(line);
+        var damageDealt = DamageDealt().Match(line);
 
         if (damageDealt.Success)
         {
@@ -24,8 +32,8 @@ internal sealed class DamageParser : IReplayLineParser
 
             foreach (var damageDetail in damageDealt.Groups[3].Value.Split(','))
             {
-                var damageWithNoKills = new Regex($"{Number} to {TeamName}").Match(damageDetail);
-                var damageWithKills = new Regex(@$"{Number} \({Number} kills?\) to {TeamName}").Match(damageDetail);
+                var damageWithNoKills = DamageWithNoKills().Match(damageDetail);
+                var damageWithKills = DamageWithKills().Match(damageDetail);
 
                 if (damageWithNoKills.Success)
                 {

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/EndOfTurnParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/EndOfTurnParser.cs
@@ -3,17 +3,19 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class EndOfTurnParser : IReplayLineParser
+internal sealed partial class EndOfTurnParser : IReplayLineParser
 {
     private const string Timestamp = @"\[(\d+:\d+:\d+.\d+)\]";
     private const string TeamName = "(.+)";
-    private static readonly Regex EndOfTurn = new($"{Timestamp} (•••|���) {TeamName} .*; time used:.*sec");
 
-    public bool CanParse(string line) => EndOfTurn.IsMatch(line);
+    [GeneratedRegex($"{Timestamp} (•••|���) {TeamName} .*; time used:.*sec")]
+    private static partial Regex EndOfTurn();
+
+    public bool CanParse(string line) => EndOfTurn().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var endOfTurn = EndOfTurn.Match(line);
+        var endOfTurn = EndOfTurn().Match(line);
 
         if (endOfTurn.Success)
         {

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/StartOfTurnParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/StartOfTurnParser.cs
@@ -3,17 +3,19 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class StartOfTurnParser : IReplayLineParser
+internal sealed partial class StartOfTurnParser : IReplayLineParser
 {
     private const string Timestamp = @"\[(\d+:\d+:\d+.\d+)\]";
     private const string TeamName = "(.+)";
-    private static readonly Regex StartOfTurn = new($"{Timestamp} (•••|���) {TeamName} starts turn");
 
-    public bool CanParse(string line) => StartOfTurn.IsMatch(line);
+    [GeneratedRegex($"{Timestamp} (•••|���) {TeamName} starts turn")]
+    private static partial Regex StartOfTurn();
+
+    public bool CanParse(string line) => StartOfTurn().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var startOfTurn = StartOfTurn.Match(line);
+        var startOfTurn = StartOfTurn().Match(line);
 
         if (startOfTurn.Success)
         {

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/StartTimeParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/StartTimeParser.cs
@@ -3,16 +3,18 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class StartTimeParser : IReplayLineParser
+internal sealed partial class StartTimeParser : IReplayLineParser
 {
     private const string DateAndTime = @"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})";
-    private static readonly Regex StartTime = new($"Game Started at {DateAndTime} GMT");
 
-    public bool CanParse(string line) => StartTime.IsMatch(line);
+    [GeneratedRegex($"Game Started at {DateAndTime} GMT")]
+    private static partial Regex StartTime();
+
+    public bool CanParse(string line) => StartTime().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var match = StartTime.Match(line);
+        var match = StartTime().Match(line);
         if (match.Success)
         {
             _ = builder.WithStartTime(DateTime.Parse(match.Groups[1].Value, CultureInfo.CurrentCulture));

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/TeamParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/TeamParser.cs
@@ -2,21 +2,24 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class TeamParser : IReplayLineParser
+internal sealed partial class TeamParser : IReplayLineParser
 {
     private const string TeamColour = "(Red|Blue|Green|Yellow|Magenta|Cyan)";
     private const string TeamName = "(.+)";
     private const string PlayerName = "(.+)";
 
-    private static readonly Regex TeamSummaryOnline = new($"{TeamColour}:.+\"{PlayerName}\".+as.+\"{TeamName}\"");
-    private static readonly Regex TeamSummaryOffline = new($"{TeamColour}:.+\"{TeamName}\"");
+    [GeneratedRegex($"{TeamColour}:.+\"{PlayerName}\".+as.+\"{TeamName}\"")]
+    private static partial Regex TeamSummaryOnline();
 
-    public bool CanParse(string line) => TeamSummaryOnline.IsMatch(line) || TeamSummaryOffline.IsMatch(line);
+    [GeneratedRegex($"{TeamColour}:.+\"{TeamName}\"")]
+    private static partial Regex TeamSummaryOffline();
+
+    public bool CanParse(string line) => TeamSummaryOnline().IsMatch(line) || TeamSummaryOffline().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var teamSummaryOnlineMatch = TeamSummaryOnline.Match(line);
-        var teamSummaryOfflineMatch = TeamSummaryOffline.Match(line);
+        var teamSummaryOnlineMatch = TeamSummaryOnline().Match(line);
+        var teamSummaryOfflineMatch = TeamSummaryOffline().Match(line);
 
         if (teamSummaryOnlineMatch.Success)
         {

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/WeaponUsedParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/WeaponUsedParser.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class WeaponUsedParser : IReplayLineParser
+internal sealed partial class WeaponUsedParser : IReplayLineParser
 {
     private const string Timestamp = @"\[(\d+:\d+:\d+.\d+)\]";
     private const string TeamName = "(.+)";
@@ -11,26 +11,27 @@ internal sealed class WeaponUsedParser : IReplayLineParser
     private const string Number = @"(\d+)";
     private const string Modifiers = "(.+)";
 
-    private static readonly Regex WeaponUsageWithFuseAndModifier = new(
-        $@"{Timestamp} (•••|���) {TeamName} fires {WeaponName} \({Number} sec, {Modifiers}\)");
+    [GeneratedRegex($@"{Timestamp} (•••|���) {TeamName} fires {WeaponName} \({Number} sec, {Modifiers}\)")]
+    private static partial Regex WeaponUsageWithFuseAndModifier();
 
-    private static readonly Regex WeaponUsageWithFuse =
-        new($@"{Timestamp} (•••|���) {TeamName} fires {WeaponName} \({Number} sec\)");
+    [GeneratedRegex($@"{Timestamp} (•••|���) {TeamName} fires {WeaponName} \({Number} sec\)")]
+    private static partial Regex WeaponUsageWithFuse();
 
-    private static readonly Regex WeaponUsageWithModifier =
-        new($@"{Timestamp} (•••|���) {TeamName} fires {WeaponName} \({Modifiers}\)");
+    [GeneratedRegex($@"{Timestamp} (•••|���) {TeamName} fires {WeaponName} \({Modifiers}\)")]
+    private static partial Regex WeaponUsageWithModifier();
 
-    private static readonly Regex WeaponUsage = new($"{Timestamp} (•••|���) {TeamName} fires {WeaponName}");
+    [GeneratedRegex($"{Timestamp} (•••|���) {TeamName} fires {WeaponName}")]
+    private static partial Regex WeaponUsage();
 
     public bool CanParse(string line) =>
-        WeaponUsageWithFuseAndModifier.IsMatch(line) || WeaponUsageWithFuse.IsMatch(line) || WeaponUsage.IsMatch(line);
+        WeaponUsageWithFuseAndModifier().IsMatch(line) || WeaponUsageWithFuse().IsMatch(line) || WeaponUsage().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var weaponUsedWithFuseAndModifier = WeaponUsageWithFuseAndModifier.Match(line);
-        var weaponUsedWithFuse = WeaponUsageWithFuse.Match(line);
-        var weaponUsedWithModifier = WeaponUsageWithModifier.Match(line);
-        var weaponUsed = WeaponUsage.Match(line);
+        var weaponUsedWithFuseAndModifier = WeaponUsageWithFuseAndModifier().Match(line);
+        var weaponUsedWithFuse = WeaponUsageWithFuse().Match(line);
+        var weaponUsedWithModifier = WeaponUsageWithModifier().Match(line);
+        var weaponUsed = WeaponUsage().Match(line);
 
         if (weaponUsedWithFuseAndModifier.Success)
         {

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/WinnerParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/WinnerParser.cs
@@ -2,18 +2,22 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Files.Replays.Text.Parsers;
 
-internal sealed class WinnerParser : IReplayLineParser
+internal sealed partial class WinnerParser : IReplayLineParser
 {
     private const string TeamName = "(.+)";
-    private static readonly Regex WinnerDraw = new("The round was drawn.");
-    private static readonly Regex Winner = new($"{TeamName} wins the (match!|round.)");
 
-    public bool CanParse(string line) => WinnerDraw.IsMatch(line) || Winner.IsMatch(line);
+    [GeneratedRegex("The round was drawn.")]
+    private static partial Regex WinnerDraw();
+
+    [GeneratedRegex($"{TeamName} wins the (match!|round.)")]
+    private static partial Regex Winner();
+
+    public bool CanParse(string line) => WinnerDraw().IsMatch(line) || Winner().IsMatch(line);
 
     public void Parse(string line, ReplayResourceBuilder builder)
     {
-        var winnerDrawMatch = WinnerDraw.Match(line);
-        var winnerMatch = Winner.Match(line);
+        var winnerDrawMatch = WinnerDraw().Match(line);
+        var winnerMatch = Winner().Match(line);
 
         if (winnerDrawMatch.Success)
         {

--- a/src/Worms.Armageddon.Files/Schemes/WeaponUtils.cs
+++ b/src/Worms.Armageddon.Files/Schemes/WeaponUtils.cs
@@ -1,8 +1,10 @@
 using System.Collections.ObjectModel;
+using JetBrains.Annotations;
 using Syroot.Worms.Armageddon;
 
 namespace Worms.Armageddon.Files.Schemes;
 
+[PublicAPI]
 public static class WeaponUtils
 {
     private static readonly Weapon[] Utilities =

--- a/src/Worms.Armageddon.Files/Schemes/WeaponUtils.cs
+++ b/src/Worms.Armageddon.Files/Schemes/WeaponUtils.cs
@@ -37,8 +37,8 @@ public static class WeaponUtils
         new Dictionary<Weapon, byte[]>
         {
             {
-                Weapon.Bazooka, new byte[]
-                {
+                Weapon.Bazooka,
+                [
                     10,
                     11,
                     0,
@@ -49,11 +49,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.HomingMissile, new byte[]
-                {
+                Weapon.HomingMissile,
+                [
                     10,
                     11,
                     0,
@@ -64,45 +64,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Mortar, new byte[]
-                {
-                    10,
-                    5,
-                    11,
-                    18,
-                    6,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    8,
-                    13,
-                    9,
-                    14
-                }
-            },
-            {
-                Weapon.Grenade, new byte[]
-                {
-                    10,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    18,
-                    13,
-                    14
-                }
-            },
-            {
-                Weapon.ClusterBomb, new byte[]
-                {
+                Weapon.Mortar,
+                [
                     10,
                     5,
                     11,
@@ -117,11 +83,45 @@ public static class WeaponUtils
                     13,
                     9,
                     14
-                }
+                ]
             },
             {
-                Weapon.Skunk, new byte[]
-                {
+                Weapon.Grenade,
+                [
+                    10,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    18,
+                    13,
+                    14
+                ]
+            },
+            {
+                Weapon.ClusterBomb,
+                [
+                    10,
+                    5,
+                    11,
+                    18,
+                    6,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    8,
+                    13,
+                    9,
+                    14
+                ]
+            },
+            {
+                Weapon.Skunk,
+                [
                     10,
                     11,
                     0,
@@ -135,11 +135,11 @@ public static class WeaponUtils
                     9,
                     4,
                     14
-                }
+                ]
             },
             {
-                Weapon.PetrolBomb, new byte[]
-                {
+                Weapon.PetrolBomb,
+                [
                     10,
                     11,
                     0,
@@ -150,11 +150,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.BananaBomb, new byte[]
-                {
+                Weapon.BananaBomb,
+                [
                     //255,
                     10,
                     11,
@@ -170,22 +170,22 @@ public static class WeaponUtils
                     13,
                     9,
                     14
-                }
+                ]
             },
             {
-                Weapon.Handgun, new byte[]
-                {
+                Weapon.Handgun,
+                [
                     10,
                     0,
                     2,
                     4,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Shotgun, new byte[]
-                {
+                Weapon.Shotgun,
+                [
                     10,
                     0,
                     1,
@@ -195,43 +195,43 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Uzi, new byte[]
-                {
+                Weapon.Uzi,
+                [
                     10,
                     0,
                     2,
                     4,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Minigun, new byte[]
-                {
+                Weapon.Minigun,
+                [
                     10,
                     0,
                     2,
                     4,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Longbow, new byte[]
-                {
+                Weapon.Longbow,
+                [
                     0,
                     1,
                     2,
                     3,
                     4
-                }
+                ]
             },
             {
-                Weapon.Airstrike, new byte[]
-                {
+                Weapon.Airstrike,
+                [
                     10,
                     5,
                     11,
@@ -245,11 +245,11 @@ public static class WeaponUtils
                     13,
                     9,
                     14
-                }
+                ]
             },
             {
-                Weapon.NapalmStrike, new byte[]
-                {
+                Weapon.NapalmStrike,
+                [
                     10,
                     5,
                     11,
@@ -263,11 +263,11 @@ public static class WeaponUtils
                     13,
                     9,
                     14
-                }
+                ]
             },
             {
-                Weapon.Mine, new byte[]
-                {
+                Weapon.Mine,
+                [
                     10,
                     11,
                     0,
@@ -278,11 +278,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Firepunch, new byte[]
-                {
+                Weapon.Firepunch,
+                [
                     10,
                     11,
                     0,
@@ -293,11 +293,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Dragonball, new byte[]
-                {
+                Weapon.Dragonball,
+                [
                     10,
                     11,
                     0,
@@ -308,11 +308,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Kamikaze, new byte[]
-                {
+                Weapon.Kamikaze,
+                [
                     10,
                     11,
                     0,
@@ -323,22 +323,22 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
-            { Weapon.Prod, new byte[] { 2 } },
+            { Weapon.Prod, [2] },
             {
-                Weapon.BattleAxe, new byte[]
-                {
+                Weapon.BattleAxe,
+                [
                     0,
                     1,
                     2,
                     3,
                     4
-                }
+                ]
             },
             {
-                Weapon.Blowtorch, new byte[]
-                {
+                Weapon.Blowtorch,
+                [
                     10,
                     11,
                     0,
@@ -349,11 +349,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.PneumaticDrill, new byte[]
-                {
+                Weapon.PneumaticDrill,
+                [
                     10,
                     11,
                     0,
@@ -364,16 +364,16 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
-            { Weapon.Girder, new byte[] { 3 } },
-            { Weapon.NinjaRope, new byte[] { 4 } },
-            { Weapon.Parachute, new byte[] { 0 } },
-            { Weapon.Bungee, new byte[] { 0 } },
-            { Weapon.Teleport, new byte[] { 0 } },
+            { Weapon.Girder, [3] },
+            { Weapon.NinjaRope, [4] },
+            { Weapon.Parachute, [0] },
+            { Weapon.Bungee, [0] },
+            { Weapon.Teleport, [0] },
             {
-                Weapon.Dynamite, new byte[]
-                {
+                Weapon.Dynamite,
+                [
                     10,
                     11,
                     0,
@@ -384,11 +384,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Sheep, new byte[]
-                {
+                Weapon.Sheep,
+                [
                     10,
                     11,
                     0,
@@ -399,11 +399,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.BaseballBat, new byte[]
-                {
+                Weapon.BaseballBat,
+                [
                     10,
                     11,
                     0,
@@ -414,11 +414,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.Flamethrower, new byte[]
-                {
+                Weapon.Flamethrower,
+                [
                     20,
                     10,
                     11,
@@ -430,11 +430,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.HomingPigeon, new byte[]
-                {
+                Weapon.HomingPigeon,
+                [
                     10,
                     11,
                     0,
@@ -445,11 +445,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.MadCow, new byte[]
-                {
+                Weapon.MadCow,
+                [
                     10,
                     11,
                     0,
@@ -460,21 +460,21 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.HolyHandGrenade, new byte[]
-                {
+                Weapon.HolyHandGrenade,
+                [
                     255,
                     0,
                     1,
                     2,
                     3
-                }
+                ]
             },
             {
-                Weapon.OldWoman, new byte[]
-                {
+                Weapon.OldWoman,
+                [
                     10,
                     11,
                     0,
@@ -485,11 +485,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.SheepLauncher, new byte[]
-                {
+                Weapon.SheepLauncher,
+                [
                     10,
                     11,
                     0,
@@ -500,11 +500,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.SuperSheep, new byte[]
-                {
+                Weapon.SuperSheep,
+                [
                     10,
                     11,
                     0,
@@ -515,11 +515,11 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
             {
-                Weapon.MoleBomb, new byte[]
-                {
+                Weapon.MoleBomb,
+                [
                     10,
                     11,
                     0,
@@ -530,32 +530,32 @@ public static class WeaponUtils
                     18,
                     13,
                     14
-                }
+                ]
             },
-            { Weapon.Jetpack, new byte[] { 0 } },
-            { Weapon.LowGravity, new byte[] { 0 } },
-            { Weapon.LaserSight, new byte[] { 0 } },
-            { Weapon.FastWalk, new byte[] { 0 } },
-            { Weapon.Invisibility, new byte[] { 0 } },
-            { Weapon.DamageX2, new byte[] { 0 } },
-            { Weapon.Freeze, new byte[] { 0 } },
-            { Weapon.SuperBananaBomb, new byte[] { 0 } },
-            { Weapon.MineStrike, new byte[] { 0 } },
-            { Weapon.GirderStarterPack, new byte[] { 0 } },
-            { Weapon.Earthquake, new byte[] { 0 } },
-            { Weapon.ScalesOfJustice, new byte[] { 0 } },
-            { Weapon.MingVase, new byte[] { 0 } },
-            { Weapon.MikesCarpetBomb, new byte[] { 0 } },
-            { Weapon.MagicBullet, new byte[] { 0 } },
-            { Weapon.NuclearTest, new byte[] { 0 } },
-            { Weapon.SelectWorm, new byte[] { 0 } },
-            { Weapon.SalvationArmy, new byte[] { 0 } },
-            { Weapon.MoleSquadron, new byte[] { 0 } },
-            { Weapon.MBBomb, new byte[] { 0 } },
-            { Weapon.ConcreteDonkey, new byte[] { 0 } },
-            { Weapon.SuicideBomber, new byte[] { 0 } },
-            { Weapon.SheepStrike, new byte[] { 0 } },
-            { Weapon.MailStrike, new byte[] { 0 } },
-            { Weapon.Armageddon, new byte[] { 0 } }
+            { Weapon.Jetpack, [0] },
+            { Weapon.LowGravity, [0] },
+            { Weapon.LaserSight, [0] },
+            { Weapon.FastWalk, [0] },
+            { Weapon.Invisibility, [0] },
+            { Weapon.DamageX2, [0] },
+            { Weapon.Freeze, [0] },
+            { Weapon.SuperBananaBomb, [0] },
+            { Weapon.MineStrike, [0] },
+            { Weapon.GirderStarterPack, [0] },
+            { Weapon.Earthquake, [0] },
+            { Weapon.ScalesOfJustice, [0] },
+            { Weapon.MingVase, [0] },
+            { Weapon.MikesCarpetBomb, [0] },
+            { Weapon.MagicBullet, [0] },
+            { Weapon.NuclearTest, [0] },
+            { Weapon.SelectWorm, [0] },
+            { Weapon.SalvationArmy, [0] },
+            { Weapon.MoleSquadron, [0] },
+            { Weapon.MBBomb, [0] },
+            { Weapon.ConcreteDonkey, [0] },
+            { Weapon.SuicideBomber, [0] },
+            { Weapon.SheepStrike, [0] },
+            { Weapon.MailStrike, [0] },
+            { Weapon.Armageddon, [0] }
         });
 }

--- a/src/Worms.Armageddon.Files/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Files/ServiceRegistration.cs
@@ -4,10 +4,12 @@ using Worms.Armageddon.Files.Replays.Text;
 using Worms.Armageddon.Files.Replays.Text.Parsers;
 using Worms.Armageddon.Files.Schemes.Binary;
 using Worms.Armageddon.Files.Schemes.Random;
+using JetBrains.Annotations;
 using Worms.Armageddon.Files.Schemes.Text;
 
 namespace Worms.Armageddon.Files;
 
+[PublicAPI]
 public static class ServiceRegistration
 {
     public static IServiceCollection AddWormsArmageddonFilesServices(this IServiceCollection builder) =>

--- a/src/Worms.Armageddon.Game/GameInfo.cs
+++ b/src/Worms.Armageddon.Game/GameInfo.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Armageddon.Game;
 
+[PublicAPI]
 public record GameInfo(
     bool IsInstalled,
     string ExeLocation,

--- a/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -42,44 +42,44 @@ internal sealed class WormsRunner(IWormsLocator wormsLocator, IProcessRunner pro
 
                     using var process = processRunner.Start(processStartInfo);
 
-                    if (process is not null)
+                    if (process is null)
                     {
-                        var processTask = Task.Run(() => process.WaitForExitAsync());
-                        var output = Task.Run(() => PrintStdOut(process));
-                        var errors = Task.Run(() => PrintStdErr(process));
-
-                        await Task.WhenAll(processTask, errors, output);
-                        logger.Log(LogLevel.Debug, "Process exited with code: {ExitCode}", process.ExitCode);
+                        return Task.CompletedTask;
                     }
+
+                    var output = PrintStdOut(process.StandardOutput);
+                    var errors = PrintStdErr(process.StandardError);
+
+                    await process.WaitForExitAsync();
+                    await Task.WhenAll(output, errors);
+                    logger.Log(LogLevel.Debug, "Process exited with code: {ExitCode}", process.ExitCode);
 
                     return Task.CompletedTask;
                 });
     }
 
-    private async Task PrintStdOut(IProcess process)
+    private async Task PrintStdOut(StreamReader? reader)
     {
-        if (process.StandardOutput is null)
+        if (reader is null)
         {
             return;
         }
 
-        while (!process.StandardOutput.EndOfStream)
+        while (await reader.ReadLineAsync() is { } line)
         {
-            var line = await process.StandardOutput.ReadLineAsync();
             logger.Log(LogLevel.Debug, "StdOut: {Message}", line);
         }
     }
 
-    private async Task PrintStdErr(IProcess process)
+    private async Task PrintStdErr(StreamReader? reader)
     {
-        if (process.StandardError is null)
+        if (reader is null)
         {
             return;
         }
 
-        while (!process.StandardError.EndOfStream)
+        while (await reader.ReadLineAsync() is { } line)
         {
-            var line = await process.StandardError.ReadLineAsync();
             logger.Log(LogLevel.Debug, "StdErr: {Message}", line);
         }
     }

--- a/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -42,11 +42,6 @@ internal sealed class WormsRunner(IWormsLocator wormsLocator, IProcessRunner pro
 
                     using var process = processRunner.Start(processStartInfo);
 
-                    if (process is null)
-                    {
-                        return Task.CompletedTask;
-                    }
-
                     var output = PrintStdOut(process.StandardOutput);
                     var errors = PrintStdErr(process.StandardError);
 

--- a/src/Worms.Armageddon.Game/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Game/ServiceRegistration.cs
@@ -5,10 +5,12 @@ using System.Runtime.Versioning;
 using Microsoft.Extensions.DependencyInjection;
 using Worms.Armageddon.Game.System;
 using Worms.Armageddon.Game.Win;
+using JetBrains.Annotations;
 using IFileVersionInfo = Worms.Armageddon.Game.System.IFileVersionInfo;
 
 namespace Worms.Armageddon.Game;
 
+[PublicAPI]
 public static class ServiceRegistration
 {
     public static IServiceCollection AddWormsArmageddonGameServices(this IServiceCollection builder) =>

--- a/src/Worms.Armageddon.Game/Telemetry.cs
+++ b/src/Worms.Armageddon.Game/Telemetry.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Armageddon.Game;
 
+[PublicAPI]
 public static class Telemetry
 {
     internal static class Spans

--- a/src/Worms.Armageddon.Game/Win/SteamService.cs
+++ b/src/Worms.Armageddon.Game/Win/SteamService.cs
@@ -2,11 +2,12 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Game.Win;
 
-internal sealed class SteamService : ISteamService
+internal sealed partial class SteamService : ISteamService
 {
     private const string ProcessName = "Steam";
 
-    private static readonly Regex LaunchGamePromptRegex = new("Allow game launch\\?", RegexOptions.IgnoreCase);
+    [GeneratedRegex("Allow game launch\\?", RegexOptions.IgnoreCase)]
+    private static partial Regex LaunchGamePromptRegex();
 
     public void WaitForSteamPrompt()
     {
@@ -23,7 +24,7 @@ internal sealed class SteamService : ISteamService
 
     private static IntPtr GetSteamPromptWindow()
     {
-        var windows = WindowTools.GetWindowsWithTitleMatching(LaunchGamePromptRegex);
+        var windows = WindowTools.GetWindowsWithTitleMatching(LaunchGamePromptRegex());
         return Array.Find(windows, w => WindowTools.GetProcessForWindow(w)?.ProcessName == ProcessName);
     }
 }

--- a/src/Worms.Armageddon.Game/Win/WindowTools.cs
+++ b/src/Worms.Armageddon.Game/Win/WindowTools.cs
@@ -42,7 +42,7 @@ public static partial class WindowTools
             return null;
         }
 
-        GetWindowThreadProcessId(hWnd, out var processId);
+        _ = GetWindowThreadProcessId(hWnd, out var processId);
         return Process.GetProcessById((int) processId);
     }
 

--- a/src/Worms.Armageddon.Game/Win/WindowTools.cs
+++ b/src/Worms.Armageddon.Game/Win/WindowTools.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace Worms.Armageddon.Game.Win;
 
-public static class WindowTools
+public static partial class WindowTools
 {
     [SuppressMessage("Roslynator", "RCS1163:Unused parameter.", Justification = "Required for P/Invoke.")]
     public static IntPtr[] GetWindowsWithTitleMatching(Regex pattern)
@@ -42,7 +42,7 @@ public static class WindowTools
             return null;
         }
 
-        _ = GetWindowThreadProcessId(hWnd, out var processId);
+        GetWindowThreadProcessId(hWnd, out var processId);
         return Process.GetProcessById((int) processId);
     }
 
@@ -56,24 +56,24 @@ public static class WindowTools
 
     private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
 
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+    private static partial bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern int GetWindowText(IntPtr hWnd, char[] lpString, int nMaxCount);
+    private static partial int GetWindowText(IntPtr hWnd, [Out] char[] lpString, int nMaxCount);
 
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern int GetWindowTextLength(IntPtr hWnd);
+    private static partial int GetWindowTextLength(IntPtr hWnd);
 
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+    private static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern IntPtr SetFocus(IntPtr hWnd);
+    private static partial IntPtr SetFocus(IntPtr hWnd);
 }

--- a/src/Worms.Armageddon.Game/Win/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner.cs
@@ -33,12 +33,6 @@ internal sealed class WormsRunner(
 
                 using (var process = processRunner.Start(gameInfo.ExeLocation, wormsArgs))
                 {
-                    if (process == null)
-                    {
-                        _ = span?.SetStatus(ActivityStatusCode.Error);
-                        throw new InvalidOperationException("Unable to start worms process");
-                    }
-
                     await process.WaitForExitAsync();
                     logger.Log(LogLevel.Debug, "Launcher process exited with code: {ExitCode}", process.ExitCode);
                 }

--- a/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
+++ b/src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
@@ -4,6 +4,7 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worms.Cli.Resources/IResourceCreator.cs
+++ b/src/Worms.Cli.Resources/IResourceCreator.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources;
 
+[PublicAPI]
 public interface IResourceCreator<T, in TParams>
 {
     Task<T> Create(TParams parameters, CancellationToken cancellationToken);

--- a/src/Worms.Cli.Resources/IResourceDeleter.cs
+++ b/src/Worms.Cli.Resources/IResourceDeleter.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources;
 
+[PublicAPI]
 public interface IResourceDeleter<in T>
 {
     void Delete(T resource);

--- a/src/Worms.Cli.Resources/IResourceRetriever.cs
+++ b/src/Worms.Cli.Resources/IResourceRetriever.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources;
 
+[PublicAPI]
 public interface IResourceRetriever<T>
 {
     Task<IReadOnlyCollection<T>> Retrieve(CancellationToken cancellationToken);

--- a/src/Worms.Cli.Resources/IResourceViewer.cs
+++ b/src/Worms.Cli.Resources/IResourceViewer.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources;
 
+[PublicAPI]
 public interface IResourceViewer<in TResource, in TParams>
 {
     Task View(TResource resource, TParams parameters);

--- a/src/Worms.Cli.Resources/Local/Gifs/LocalGif.cs
+++ b/src/Worms.Cli.Resources/Local/Gifs/LocalGif.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Local.Gifs;
 
+[PublicAPI]
 public record LocalGif(string Path);

--- a/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreateParameters.cs
+++ b/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreateParameters.cs
@@ -1,7 +1,9 @@
+using JetBrains.Annotations;
 using Worms.Cli.Resources.Local.Replays;
 
 namespace Worms.Cli.Resources.Local.Gifs;
 
+[PublicAPI]
 public record LocalGifCreateParameters(
     LocalReplay Replay,
     uint Turn,

--- a/src/Worms.Cli.Resources/Local/Replays/LocalReplay.cs
+++ b/src/Worms.Cli.Resources/Local/Replays/LocalReplay.cs
@@ -1,6 +1,8 @@
+using JetBrains.Annotations;
 using Worms.Armageddon.Files.Replays;
 
 namespace Worms.Cli.Resources.Local.Replays;
 
+[PublicAPI]
 public record LocalReplay(ReplayPaths Paths, ReplayResource Details, bool HostedByLocalMachine)
     : ReplayWithContext("local");

--- a/src/Worms.Cli.Resources/Local/Replays/LocalReplayViewParameters.cs
+++ b/src/Worms.Cli.Resources/Local/Replays/LocalReplayViewParameters.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Local.Replays;
 
+[PublicAPI]
 public record LocalReplayViewParameters(uint Turn);

--- a/src/Worms.Cli.Resources/Local/Replays/LocalReplayViewer.cs
+++ b/src/Worms.Cli.Resources/Local/Replays/LocalReplayViewer.cs
@@ -7,7 +7,7 @@ internal sealed class LocalReplayViewer(IWormsArmageddon wormsArmageddon)
 {
     public async Task View(LocalReplay resource, LocalReplayViewParameters parameters)
     {
-        if (parameters.Turn != default)
+        if (parameters.Turn != 0)
         {
             var startTime = resource.Details.Turns.ElementAt((int) parameters.Turn - 1).Start;
             await wormsArmageddon.PlayReplay(resource.Paths.WAgamePath, startTime);

--- a/src/Worms.Cli.Resources/Local/Replays/ReplayPaths.cs
+++ b/src/Worms.Cli.Resources/Local/Replays/ReplayPaths.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Local.Replays;
 
+[PublicAPI]
 public record ReplayPaths(string WAgamePath, string? LogPath);

--- a/src/Worms.Cli.Resources/Local/Schemes/LocalScheme.cs
+++ b/src/Worms.Cli.Resources/Local/Schemes/LocalScheme.cs
@@ -1,5 +1,7 @@
+using JetBrains.Annotations;
 using Syroot.Worms.Armageddon;
 
 namespace Worms.Cli.Resources.Local.Schemes;
 
+[PublicAPI]
 public record LocalScheme(string Path, string Name, Scheme Details) : SchemeWithContext("context");

--- a/src/Worms.Cli.Resources/Local/Schemes/LocalSchemeCreateParameters.cs
+++ b/src/Worms.Cli.Resources/Local/Schemes/LocalSchemeCreateParameters.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Local.Schemes;
 
+[PublicAPI]
 public record LocalSchemeCreateParameters(string Name, string Folder, bool Random, string? Definition);

--- a/src/Worms.Cli.Resources/Remote/Auth/AccessTokens.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/AccessTokens.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Remote.Auth;
 
+[PublicAPI]
 public record AccessTokens(string? AccessToken, string? RefreshToken);

--- a/src/Worms.Cli.Resources/Remote/Auth/DeviceCodeLoginService.cs
+++ b/src/Worms.Cli.Resources/Remote/Auth/DeviceCodeLoginService.cs
@@ -27,7 +27,7 @@ internal sealed class DeviceCodeLoginService(
         BrowserLauncher.OpenBrowser(deviceCodeResponse.VerificationUriComplete.OriginalString);
 
         logger.LogDebug("Requesting tokens...");
-        var tokenResponse = await RequestTokenAsync(deviceCodeResponse, logger, cancellationToken);
+        var tokenResponse = await RequestTokenAsync(deviceCodeResponse, cancellationToken);
 
         if (tokenResponse != null)
         {
@@ -86,13 +86,12 @@ internal sealed class DeviceCodeLoginService(
 
     private async Task<TokenResponse?> RequestTokenAsync(
         DeviceAuthorizationResponse deviceCodeResponse,
-        ILogger logger,
         CancellationToken cancellationToken)
     {
         using var span = Activity.Current?.Source.StartActivity(Telemetry.Spans.GetAuthTokens.SpanName);
-        using var cancellationTokenSource = new CancellationTokenSource();
         var timeout = TimeSpan.FromSeconds(deviceCodeResponse.ExpiresIn);
-        cancellationTokenSource.CancelAfter(timeout);
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
         logger.LogDebug(
             "Checking if code has been confirmed... (Timeout: {TimeoutMinutes} mins)",
@@ -101,10 +100,8 @@ internal sealed class DeviceCodeLoginService(
         using var client = httpClientFactory.CreateClient();
         client.BaseAddress = new Uri(Authority);
 
-        while (!cancellationTokenSource.Token.IsCancellationRequested)
+        while (!linkedCts.Token.IsCancellationRequested)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             using var content = new FormUrlEncodedContent(
                 new Dictionary<string, string>()
                 {
@@ -113,19 +110,19 @@ internal sealed class DeviceCodeLoginService(
                     { "client_id", ClientId }
                 });
 
-            var response = await client.PostAsync(new Uri("oauth/token", UriKind.Relative), content, cancellationToken);
+            var response = await client.PostAsync(new Uri("oauth/token", UriKind.Relative), content, linkedCts.Token);
 
             if (response.IsSuccessStatusCode)
             {
-                var streamAsync = await response.Content.ReadAsStreamAsync(cancellationToken);
+                var streamAsync = await response.Content.ReadAsStreamAsync(linkedCts.Token);
                 await using var stream = streamAsync;
                 return await JsonSerializer.DeserializeAsync(
                     streamAsync,
                     JsonContext.Default.TokenResponse,
-                    cancellationToken);
+                    linkedCts.Token);
             }
 
-            var stringContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var stringContent = await response.Content.ReadAsStringAsync(linkedCts.Token);
 
             if (stringContent.Contains("authorization_pending", StringComparison.InvariantCulture)
                 || stringContent.Contains("slow_down", StringComparison.InvariantCulture))
@@ -133,7 +130,7 @@ internal sealed class DeviceCodeLoginService(
                 logger.LogDebug(
                     "Code not yet confirmed. Retrying in {IntervalSeconds} seconds",
                     deviceCodeResponse.Interval);
-                await Task.Delay(deviceCodeResponse.Interval * 1000, cancellationToken);
+                await Task.Delay(deviceCodeResponse.Interval * 1000, linkedCts.Token);
             }
             else
             {

--- a/src/Worms.Cli.Resources/Remote/Games/IRemoteGameUpdater.cs
+++ b/src/Worms.Cli.Resources/Remote/Games/IRemoteGameUpdater.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Remote.Games;
 
+[PublicAPI]
 public interface IRemoteGameUpdater
 {
     Task SetGameComplete(RemoteGame game, CancellationToken cancellationToken);

--- a/src/Worms.Cli.Resources/Remote/Games/RemoteGame.cs
+++ b/src/Worms.Cli.Resources/Remote/Games/RemoteGame.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Remote.Games;
 
+[PublicAPI]
 public record RemoteGame(string Id, string Status, string HostMachine);

--- a/src/Worms.Cli.Resources/Remote/Leagues/RemoteLeague.cs
+++ b/src/Worms.Cli.Resources/Remote/Leagues/RemoteLeague.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Remote.Leagues;
 
+[PublicAPI]
 public record RemoteLeague(string Name, Version Version);

--- a/src/Worms.Cli.Resources/Remote/Replays/RemoteReplay.cs
+++ b/src/Worms.Cli.Resources/Remote/Replays/RemoteReplay.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Remote.Replays;
 
+[PublicAPI]
 public record RemoteReplay(string Id, string Name, string Status);

--- a/src/Worms.Cli.Resources/Remote/Replays/RemoteReplayCreateParameters.cs
+++ b/src/Worms.Cli.Resources/Remote/Replays/RemoteReplayCreateParameters.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Resources.Remote.Replays;
 
+[PublicAPI]
 public record RemoteReplayCreateParameters(string Name, string FilePath);

--- a/src/Worms.Cli.Resources/Remote/Updates/LinuxCliUpdateDownloader.cs
+++ b/src/Worms.Cli.Resources/Remote/Updates/LinuxCliUpdateDownloader.cs
@@ -15,9 +15,10 @@ internal sealed class LinuxCliUpdateDownloader(IWormsServerApi api, IFileSystem 
         await File.WriteAllBytesAsync(archiveFilePath, bytes);
 
         // Unzip tar.gz file
-        await using var zip = await ZipFile.OpenReadAsync(archiveFilePath);
-        await zip.ExtractToDirectoryAsync(updateFolder);
-        await zip.DisposeAsync();
+        {
+            await using var zip = await ZipFile.OpenReadAsync(archiveFilePath);
+            await zip.ExtractToDirectoryAsync(updateFolder);
+        }
 
         // Delete tar.gz file
         fileSystem.File.Delete(archiveFilePath);

--- a/src/Worms.Cli.Resources/Remote/Updates/WindowsCliUpdateDownloader.cs
+++ b/src/Worms.Cli.Resources/Remote/Updates/WindowsCliUpdateDownloader.cs
@@ -15,9 +15,10 @@ internal sealed class WindowsCliUpdateDownloader(IWormsServerApi api, IFileSyste
         await File.WriteAllBytesAsync(archiveFilePath, bytes);
 
         // Unzip file
-        await using var zip = await ZipFile.OpenReadAsync(archiveFilePath);
-        await zip.ExtractToDirectoryAsync(updateFolder);
-        await zip.DisposeAsync();
+        {
+            await using var zip = await ZipFile.OpenReadAsync(archiveFilePath);
+            await zip.ExtractToDirectoryAsync(updateFolder);
+        }
 
         // Delete zip file
         fileSystem.File.Delete(archiveFilePath);

--- a/src/Worms.Cli.Resources/Remote/WormsServerDtos.cs
+++ b/src/Worms.Cli.Resources/Remote/WormsServerDtos.cs
@@ -1,13 +1,16 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace Worms.Cli.Resources.Remote;
 
+[PublicAPI]
 public sealed record LatestCliDtoV1(
     [property: JsonPropertyName("latestVersion")]
     Version LatestVersion,
     [property: JsonPropertyName("fileLocations")]
     IReadOnlyDictionary<string, string> FileLocations);
 
+[PublicAPI]
 public sealed record LeagueDtoV1(
     [property: JsonPropertyName("id")] string Id,
     [property: JsonPropertyName("name")] string Name,
@@ -16,18 +19,22 @@ public sealed record LeagueDtoV1(
     [property: JsonPropertyName("schemeUrl")]
     Uri SchemeUrl);
 
+[PublicAPI]
 public sealed record CreateGameDtoV1(
     [property: JsonPropertyName("hostMachine")]
     string HostMachine);
 
+[PublicAPI]
 public sealed record GamesDtoV1(
     [property: JsonPropertyName("id")] string Id,
     [property: JsonPropertyName("status")] string Status,
     [property: JsonPropertyName("hostMachine")]
     string HostMachine);
 
+[PublicAPI]
 public sealed record CreateReplayDtoV1(string Name, string ReplayFilePath);
 
+[PublicAPI]
 public sealed record ReplayDtoV1(
     [property: JsonPropertyName("id")] string Id,
     [property: JsonPropertyName("name")] string Name,

--- a/src/Worms.Cli.Resources/ServiceRegistration.cs
+++ b/src/Worms.Cli.Resources/ServiceRegistration.cs
@@ -13,10 +13,12 @@ using Worms.Cli.Resources.Remote.Games;
 using Worms.Cli.Resources.Remote.Leagues;
 using Worms.Cli.Resources.Remote.Replays;
 using Worms.Cli.Resources.Remote.Schemes;
+using JetBrains.Annotations;
 using Worms.Cli.Resources.Remote.Updates;
 
 namespace Worms.Cli.Resources;
 
+[PublicAPI]
 public static class ServiceRegistration
 {
     public static IServiceCollection AddWormsCliResourcesServices(this IServiceCollection builder) =>

--- a/src/Worms.Cli/Commands/Resources/Gifs/CreateGif.cs
+++ b/src/Worms.Cli/Commands/Resources/Gifs/CreateGif.cs
@@ -68,7 +68,7 @@ internal sealed class CreateGifHandler(
         var startOffset = parseResult.GetValue(CreateGif.StartOffset);
         var endOffset = parseResult.GetValue(CreateGif.EndOffset);
 
-        var config = new Config(replayName, turn, fps, speed, startOffset, endOffset);
+        var config = new Config(replayName, turn);
         var replay = await config.Validate(ValidConfig())
             .Map(x => FindReplays(x.ReplayName!, cancellationToken))
             .Validate(Only1ReplayFound(replayName))
@@ -109,18 +109,12 @@ internal sealed class CreateGifHandler(
     private static List<ValidationRule<Config>> ValidConfig() =>
         Valid.Rules<Config>()
             .Must(x => !string.IsNullOrWhiteSpace(x.ReplayName), "No replay provided for the Gif being created")
-            .Must(x => x.Turn != default, "No turn provided for the Gif being created");
+            .Must(x => x.Turn != 0, "No turn provided for the Gif being created");
 
     private async Task<List<LocalReplay>> FindReplays(string pattern, CancellationToken cancellationToken) =>
     [
         .. await replayRetriever.Retrieve(pattern, cancellationToken)
     ];
 
-    private sealed record Config(
-        string? ReplayName,
-        uint Turn,
-        uint FramesPerSecond,
-        uint Speed,
-        uint StartOffset,
-        uint EndOffset);
+    private sealed record Config(string? ReplayName, uint Turn);
 }

--- a/src/Worms.Cli/Commands/Validation/BindExtensions.cs
+++ b/src/Worms.Cli/Commands/Validation/BindExtensions.cs
@@ -1,18 +1,23 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Commands.Validation;
 
 internal static class BindExtensions
 {
     public static Validated<TOut> Bind<T, TOut>(this T value, Func<T, TOut> func) => new Valid<TOut>(func(value!));
 
+    [UsedImplicitly]
     public static async Task<Validated<TOut>> Bind<T, TOut>(this T value, Func<T, Task<TOut>> asyncFunc) =>
         new Valid<TOut>(await asyncFunc(value!));
 
+    [UsedImplicitly]
     public static async Task<Validated<TOut>> Bind<T, TOut>(this Task<T> value, Func<T, Task<TOut>> asyncFunc)
     {
         var result = await value;
         return new Valid<TOut>(await asyncFunc(result));
     }
 
+    [UsedImplicitly]
     public static async Task<Validated<TOut>> Bind<T, TOut>(this Task<T> value, Func<T, TOut> func)
     {
         var result = await value;

--- a/src/Worms.Cli/Commands/Validation/MapExtensions.cs
+++ b/src/Worms.Cli/Commands/Validation/MapExtensions.cs
@@ -1,3 +1,5 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Commands.Validation;
 
 internal static class MapExtensions
@@ -8,6 +10,7 @@ internal static class MapExtensions
     public static async Task<Validated<TOut>> Map<T, TOut>(this Validated<T> value, Func<T, Task<TOut>> asyncFunc) =>
         value.IsValid ? new Valid<TOut>(await asyncFunc(value.Value!)) : new Invalid<TOut>(value.Error);
 
+    [UsedImplicitly]
     public static async Task<Validated<TOut>> Map<T, TOut>(this Task<Validated<T>> value, Func<T, Task<TOut>> asyncFunc)
     {
         var result = await value;

--- a/src/Worms.Cli/Commands/Validation/Validated.cs
+++ b/src/Worms.Cli/Commands/Validation/Validated.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 
 namespace Worms.Cli.Commands.Validation;
 
@@ -17,6 +18,7 @@ internal sealed class Valid<T>(T value) : Validated<T>(true, value, []);
 
 internal sealed class Invalid<T> : Validated<T>
 {
+    [UsedImplicitly]
     public Invalid(string error)
         : base(false, default, [error]) { }
 

--- a/src/Worms.Cli/Commands/Validation/ValidationRule.cs
+++ b/src/Worms.Cli/Commands/Validation/ValidationRule.cs
@@ -30,7 +30,7 @@ internal sealed class RulesFor<T>
         return this;
     }
 
-    public List<ValidationRule<T>> Build() => _rules;
+    private List<ValidationRule<T>> Build() => _rules;
 
     public static implicit operator List<ValidationRule<T>>(RulesFor<T> rules) => [.. rules.Build()];
 }

--- a/src/Worms.Cli/Commands/Validation/ValidationRule.cs
+++ b/src/Worms.Cli/Commands/Validation/ValidationRule.cs
@@ -1,3 +1,5 @@
+using JetBrains.Annotations;
+
 namespace Worms.Cli.Commands.Validation;
 
 internal sealed record ValidationRule<T>(Func<T, bool> Predicate, Func<T, string> Error);
@@ -24,6 +26,7 @@ internal sealed class RulesFor<T>
         return this;
     }
 
+    [UsedImplicitly]
     public RulesFor<T> MustNot(Func<T, bool> rule, Func<T, string> message)
     {
         _rules.Add(new ValidationRule<T>(x => !rule(x), message));

--- a/src/Worms.Cli/League/LeagueUpdater.cs
+++ b/src/Worms.Cli/League/LeagueUpdater.cs
@@ -23,7 +23,7 @@ internal sealed class LeagueUpdater(
 
         logger.LogInformation("Downloading Scheme: {FileName}", downloadFileName);
         _ = Activity.Current?.SetTag(Telemetry.Spans.Scheme.Id, leagueName);
-        _ = Activity.Current?.SetTag(Telemetry.Spans.Scheme.Version, version);
+        _ = Activity.Current?.SetTag(Telemetry.Spans.Scheme.SchemeVersion, version);
 
         await remoteSchemeDownloader.Download(leagueName, downloadFileName, schemesFolder);
     }

--- a/src/Worms.Cli/Telemetry.cs
+++ b/src/Worms.Cli/Telemetry.cs
@@ -106,7 +106,7 @@ internal static class Telemetry
             public const string SpanNameBrowse = "worms browse schemes";
 
             public const string Id = "worms.scheme.id";
-            public const string Version = "worms.scheme.version";
+            public const string SchemeVersion = "worms.scheme.version";
         }
 
         internal static class League

--- a/src/Worms.Hub.Gateway/API/DTOs/CliFileDto.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/CliFileDto.cs
@@ -2,8 +2,8 @@ using JetBrains.Annotations;
 
 namespace Worms.Hub.Gateway.API.DTOs;
 
-[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[PublicAPI]
 internal sealed record CliFileDto(Version LatestVersion, IDictionary<string, string> FileLocations);
 
-[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[PublicAPI]
 internal sealed record UploadCliFileDto(string Platform, Version Version, IFormFile File);

--- a/src/Worms.Hub.Gateway/API/DTOs/CliFileDto.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/CliFileDto.cs
@@ -1,5 +1,9 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Gateway.API.DTOs;
 
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed record CliFileDto(Version LatestVersion, IDictionary<string, string> FileLocations);
 
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed record UploadCliFileDto(string Platform, Version Version, IFormFile File);

--- a/src/Worms.Hub.Gateway/API/DTOs/LeagueDto.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/LeagueDto.cs
@@ -3,7 +3,7 @@ using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.API.DTOs;
 
-[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[PublicAPI]
 internal sealed record LeagueDto(string Id, string Name, Version Version, Uri SchemeUrl)
 {
     internal static LeagueDto FromDomain(League league, Uri schemeUrl) =>

--- a/src/Worms.Hub.Gateway/API/DTOs/LeagueDto.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/LeagueDto.cs
@@ -1,7 +1,9 @@
+using JetBrains.Annotations;
 using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.API.DTOs;
 
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed record LeagueDto(string Id, string Name, Version Version, Uri SchemeUrl)
 {
     internal static LeagueDto FromDomain(League league, Uri schemeUrl) =>

--- a/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
@@ -3,11 +3,11 @@ using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.API.DTOs;
 
-[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[PublicAPI]
 internal sealed record ReplayDto(string Id, string Name, string Status)
 {
     internal static ReplayDto FromDomain(Replay replay) => new(replay.Id, replay.Name, replay.Status);
 }
 
-[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[PublicAPI]
 internal sealed record CreateReplayDto(string Name, IFormFile ReplayFile);

--- a/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
@@ -1,10 +1,13 @@
+using JetBrains.Annotations;
 using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.API.DTOs;
 
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed record ReplayDto(string Id, string Name, string Status)
 {
     internal static ReplayDto FromDomain(Replay replay) => new(replay.Id, replay.Name, replay.Status);
 }
 
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed record CreateReplayDto(string Name, IFormFile ReplayFile);

--- a/src/Worms.Hub.Gateway/Announcers/Slack/SlackAnnouncer.cs
+++ b/src/Worms.Hub.Gateway/Announcers/Slack/SlackAnnouncer.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace Worms.Hub.Gateway.Announcers.Slack;
 
-internal sealed class Announcer(IConfiguration configuration, ILogger<Announcer> logger) : IAnnouncer
+internal sealed class Announcer(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<Announcer> logger) : IAnnouncer
 {
     public async Task AnnounceGameStarting(string hostName)
     {
@@ -57,7 +57,7 @@ internal sealed class Announcer(IConfiguration configuration, ILogger<Announcer>
         var finalMessage = message;
 #endif
 
-        using var client = new HttpClient();
+        using var client = httpClientFactory.CreateClient();
         var slackUrl = new Uri(webHookUrl);
         var body = JsonSerializer.Serialize(finalMessage);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");

--- a/src/Worms.Hub.Gateway/Announcers/Slack/SlackAnnouncer.cs
+++ b/src/Worms.Hub.Gateway/Announcers/Slack/SlackAnnouncer.cs
@@ -51,7 +51,7 @@ internal sealed class Announcer(IConfiguration configuration, ILogger<Announcer>
 
 #if DEBUG
         var finalMessage = new SlackMessage(
-            Text: "Debug: " + message.Text?.Replace("<!here>", "", StringComparison.InvariantCulture),
+            Text: "Debug: " + message.Text.Replace("<!here>", "", StringComparison.InvariantCulture),
             Blocks: message.Blocks?.Replace("<!here>", "", StringComparison.InvariantCulture));
 #else
         var finalMessage = message;

--- a/src/Worms.Hub.Gateway/ServiceRegistration.cs
+++ b/src/Worms.Hub.Gateway/ServiceRegistration.cs
@@ -11,11 +11,12 @@ namespace Worms.Hub.Gateway;
 internal static class ServiceRegistration
 {
     public static IServiceCollection AddGatewayServices(this IServiceCollection builder) =>
-        builder.AddScoped<IAnnouncer, Announcer>().AddScoped<ReplayFileValidator>().AddScoped<CliFileValidator>();
+        builder.AddHttpClient().AddScoped<IAnnouncer, Announcer>().AddScoped<ReplayFileValidator>().AddScoped<CliFileValidator>();
 
     public static IServiceCollection AddWorkerServices(this IServiceCollection builder) =>
         builder.AddHubStorageServices()
             .AddQueueServices()
+            .AddHttpClient()
             .AddScoped<Processor>()
             .AddWormsArmageddonFilesServices()
             .AddScoped<IAnnouncer, Announcer>();

--- a/src/Worms.Hub.Gateway/Telemetry.cs
+++ b/src/Worms.Hub.Gateway/Telemetry.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -9,8 +8,6 @@ internal static class Telemetry
 {
     private const string SourceName = "Worms.Hub.Gateway";
     private const string HoneycombApiKey = "hcaik_01hz7eat48jq3fz3vgg6mred9gzc5pfbgpkx5fvgtbj33hc4sbzpgs1e1h";
-
-    public static readonly ActivitySource Source = new(SourceName);
 
     public static void AddOpenTelemetryWormsHub(this IServiceCollection services)
     {

--- a/src/Worms.Hub.Queues/MessageDetails.cs
+++ b/src/Worms.Hub.Queues/MessageDetails.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Queues;
 
+[PublicAPI]
 public record MessageDetails(string MessageId, string PopReceipt);

--- a/src/Worms.Hub.Queues/ReplayToProcessMessage.cs
+++ b/src/Worms.Hub.Queues/ReplayToProcessMessage.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Queues;
 
+[PublicAPI]
 public record ReplayToProcessMessage(string ReplayFileName);

--- a/src/Worms.Hub.Queues/ReplayToUpdateMessage.cs
+++ b/src/Worms.Hub.Queues/ReplayToUpdateMessage.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Queues;
 
+[PublicAPI]
 public record ReplayToUpdateMessage(string ReplayFileName);

--- a/src/Worms.Hub.Queues/ServiceRegistration.cs
+++ b/src/Worms.Hub.Queues/ServiceRegistration.cs
@@ -1,7 +1,9 @@
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Worms.Hub.Queues;
 
+[PublicAPI]
 public static class ServiceRegistration
 {
     public static IServiceCollection AddQueueServices(this IServiceCollection builder) =>

--- a/src/Worms.Hub.Storage/Database/GamesRepository.cs
+++ b/src/Worms.Hub.Storage/Database/GamesRepository.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Dapper;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
 using Worms.Hub.Storage.Domain;
@@ -53,4 +54,5 @@ internal sealed class GamesRepository(IConfiguration configuration) : IRepositor
     }
 }
 
+[PublicAPI]
 public record GamesDb(int Id, string Status, string HostMachine);

--- a/src/Worms.Hub.Storage/Database/ReplaysRepository.cs
+++ b/src/Worms.Hub.Storage/Database/ReplaysRepository.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Dapper;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
 using Worms.Hub.Storage.Domain;
@@ -71,4 +72,5 @@ internal sealed class ReplaysRepository(IConfiguration configuration) : IReposit
     }
 }
 
+[PublicAPI]
 public record ReplayDb(int Id, string Name, string Status, string Filename, string FullLog);

--- a/src/Worms.Hub.Storage/Domain/CliInfo.cs
+++ b/src/Worms.Hub.Storage/Domain/CliInfo.cs
@@ -1,7 +1,11 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Storage.Domain;
 
+[PublicAPI]
 public sealed record CliInfo(Version Version, IDictionary<Platform, string> PlatformFiles);
 
+[PublicAPI]
 public enum Platform
 {
     Windows = 0,

--- a/src/Worms.Hub.Storage/Domain/Game.cs
+++ b/src/Worms.Hub.Storage/Domain/Game.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Storage.Domain;
 
+[PublicAPI]
 public record Game(string Id, string Status, string HostMachine);

--- a/src/Worms.Hub.Storage/Domain/League.cs
+++ b/src/Worms.Hub.Storage/Domain/League.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Storage.Domain;
 
+[PublicAPI]
 public record League(string Id, string Name, Version Version, string SchemePath);

--- a/src/Worms.Hub.Storage/Domain/Replay.cs
+++ b/src/Worms.Hub.Storage/Domain/Replay.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+
 namespace Worms.Hub.Storage.Domain;
 
+[PublicAPI]
 public sealed record Replay(string Id, string Name, string Status, string Filename, string? FullLog);

--- a/src/Worms.Hub.Storage/ServiceRegistration.cs
+++ b/src/Worms.Hub.Storage/ServiceRegistration.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Domain;
+using JetBrains.Annotations;
 using Worms.Hub.Storage.Files;
 
 namespace Worms.Hub.Storage;
 
+[PublicAPI]
 public static class ServiceRegistration
 {
     public static IServiceCollection AddHubStorageServices(this IServiceCollection builder) =>


### PR DESCRIPTION
## Summary
- Suppress CA1873 (expensive logging) and ExplicitCallerInfoArgument (intentional telemetry overrides) in .editorconfig
- Convert `new Regex(...)` to `[GeneratedRegex]` partial methods (SYSLIB1045) in all parser classes and SteamService
- Convert `new byte[] { ... }` to collection expressions `[...]` in WeaponUtils
- Convert `[DllImport]` to `[LibraryImport]` with source generation (SYSLIB1054) in WindowTools
- Fix async stream reading in Linux WormsRunner to avoid CA2024/CA2025 disposed closure issues
- Scope `await using` blocks to avoid double disposal in CLI update downloaders
- Fix DeviceCodeLoginService: remove parameter shadowing and use linked cancellation tokens
- Fix Infrastructure project: unused parameters, Uri overload, specific exceptions, unused variables
- Remove redundant null checks and unnecessary conditional access operators
- Add JetBrains.Annotations `[PublicAPI]` to DTOs, interfaces, and service registration classes to suppress false-positive JetBrains InspectCode warnings
- Fix code issues: unused record properties, member visibility, member hiding, concrete values
- Filter suppressed warnings from SARIF before uploading to GitHub code scanning

## Test plan
- [x] `dotnet build` shows 0 warnings
- [x] `dotnet test` passes all 299 tests
- [ ] Verify code scanning alerts are reduced after CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)