### PR TITLE
Group Worms Hub Docker image updates into a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,13 @@
         "TestableIO.System.IO.Abstractions",
         "TestableIO.System.IO.Abstractions.TestingHelpers"
       ]
+    },
+    {
+      "groupName": "Worms Hub - Docker Images",
+      "matchPackageNames": [
+        "theeadie/worms-hub-gateway",
+        "theeadie/worms-hub-wa-runner"
+      ]
     }
   ],
   "dependencyDashboard": true


### PR DESCRIPTION
## Summary
- Adds a Renovate `packageRules` entry to group `theeadie/worms-hub-gateway` and `theeadie/worms-hub-wa-runner` Docker image updates into a single PR instead of separate ones

## Test plan
- [ ] Verify Renovate Dependency Dashboard reflects the new grouping on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)