### PR TITLE
Fix process runner finding launcher instead of game

### DIFF
--- a/src/Worms.Armageddon.Game/System/IProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/IProcessRunner.cs
@@ -6,9 +6,9 @@ internal interface IProcessRunner
 {
     IProcess Start(string fileName, params string[] args);
 
-    IProcess? FindProcess(string processName);
+    Task<IProcess?> FindProcess(string processName);
 
-    IProcess? FindProcess(string processName, TimeSpan timeout);
+    Task<IProcess?> FindProcess(string processName, TimeSpan timeout);
 
     IProcess Start(ProcessStartInfo processStartInfo);
 }

--- a/src/Worms.Armageddon.Game/System/ProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/ProcessRunner.cs
@@ -7,12 +7,12 @@ internal class ProcessRunner : IProcessRunner
     public IProcess Start(string fileName, params string[] args) =>
         new Process(global::System.Diagnostics.Process.Start(fileName, string.Join(" ", args.ToList())));
 
-    public IProcess? FindProcess(string processName)
+    public async Task<IProcess?> FindProcess(string processName)
     {
         IProcess? process = null;
         for (var retryCount = 0; process is null && retryCount <= 5; retryCount++)
         {
-            Thread.Sleep(500);
+            await Task.Delay(500);
             var foundProcess = global::System.Diagnostics.Process.GetProcessesByName(processName).FirstOrDefault();
             process = foundProcess is null ? null : new Process(foundProcess);
         }
@@ -20,16 +20,16 @@ internal class ProcessRunner : IProcessRunner
         return process;
     }
 
-    public IProcess? FindProcess(string processName, TimeSpan timeout)
+    public async Task<IProcess?> FindProcess(string processName, TimeSpan timeout)
     {
         // Initial wait to allow the launcher process to exit before polling
-        Thread.Sleep(500);
+        await Task.Delay(500);
         timeout -= TimeSpan.FromMilliseconds(500);
 
         IProcess? process = null;
         while (process is null && timeout.TotalMilliseconds > 0)
         {
-            Thread.Sleep(500);
+            await Task.Delay(500);
             var foundProcess = global::System.Diagnostics.Process.GetProcessesByName(processName)
                 .FirstOrDefault(p => !p.HasExited);
             process = foundProcess is null ? null : new Process(foundProcess);

--- a/src/Worms.Armageddon.Game/System/ProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/ProcessRunner.cs
@@ -22,7 +22,7 @@ internal class ProcessRunner : IProcessRunner
 
     public async Task<IProcess?> FindProcess(string processName, TimeSpan timeout)
     {
-        // Initial wait to allow the launcher process to exit before polling
+        // Initial wait before polling to allow short-lived processes to exit
         await Task.Delay(500);
         timeout -= TimeSpan.FromMilliseconds(500);
 

--- a/src/Worms.Armageddon.Game/System/ProcessRunner.cs
+++ b/src/Worms.Armageddon.Game/System/ProcessRunner.cs
@@ -22,11 +22,16 @@ internal class ProcessRunner : IProcessRunner
 
     public IProcess? FindProcess(string processName, TimeSpan timeout)
     {
+        // Initial wait to allow the launcher process to exit before polling
+        Thread.Sleep(500);
+        timeout -= TimeSpan.FromMilliseconds(500);
+
         IProcess? process = null;
         while (process is null && timeout.TotalMilliseconds > 0)
         {
             Thread.Sleep(500);
-            var foundProcess = global::System.Diagnostics.Process.GetProcessesByName(processName).FirstOrDefault();
+            var foundProcess = global::System.Diagnostics.Process.GetProcessesByName(processName)
+                .FirstOrDefault(p => !p.HasExited);
             process = foundProcess is null ? null : new Process(foundProcess);
             timeout -= TimeSpan.FromMilliseconds(500);
         }

--- a/src/Worms.Armageddon.Game/Win/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner.cs
@@ -40,7 +40,7 @@ internal sealed class WormsRunner(
                 logger.Log(LogLevel.Debug, "Waiting for Steam prompt...");
                 steamService.WaitForSteamPrompt();
 
-                var wormsProcess = processRunner.FindProcess(gameInfo.ProcessName);
+                var wormsProcess = await processRunner.FindProcess(gameInfo.ProcessName);
 
                 if (wormsProcess is not null)
                 {

--- a/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
+++ b/src/Worms.Armageddon.Game/Win/WormsRunner2.cs
@@ -32,18 +32,18 @@ internal sealed class WormsRunner2(
 
                 using (processRunner.Start(gameInfo.ExeLocation, wormsArgs))
                 {
-                    var wormsProcess = FindWormsProcess(gameInfo.ProcessName);
+                    var wormsProcess = await FindWormsProcess(gameInfo.ProcessName);
                     await WaitForExit(wormsProcess);
                 }
             });
     }
 
-    private IProcess FindWormsProcess(string processName)
+    private async Task<IProcess> FindWormsProcess(string processName)
     {
         const int timeoutInMinutes = 5;
         logger.Log(LogLevel.Debug, "Looking for worms process: {ProcessName}...", processName);
 
-        var wormsProcess = processRunner.FindProcess(processName, TimeSpan.FromMinutes(timeoutInMinutes));
+        var wormsProcess = await processRunner.FindProcess(processName, TimeSpan.FromMinutes(timeoutInMinutes));
 
         if (wormsProcess is null)
         {


### PR DESCRIPTION
## Summary
- Filter out already-exited processes in `FindProcess` by checking `HasExited`, preventing the short-lived launcher process from being returned instead of the actual game
- Add an initial 500ms delay before polling to give the launcher time to exit, reducing the chance of finding it in the first place

## Context
When running Worms via Steam, `WA.exe` acts as a launcher that triggers Steam to start the actual game process (also named "WA"). `GetProcessesByName("WA").FirstOrDefault()` could return the launcher, which exits quickly — causing `WaitForExitAsync` to return immediately instead of waiting for the game to finish. This manifested as a Heisenbug where verbose logging added just enough delay to push past the launcher's exit time.

## Test plan
- [x] Existing tests pass (40/40)
- [ ] Manual test on Windows: run `worms host` without `--verbose` and verify it waits for the game to finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)