### PR TITLE
Add authenticated endpoint to download WA game files

### DIFF
--- a/deployment/Worms.Hub.Infrastructure/Azure/ContainerApps/Gateway.cs
+++ b/deployment/Worms.Hub.Infrastructure/Azure/ContainerApps/Gateway.cs
@@ -101,6 +101,11 @@ internal static class Gateway
                                 },
                                 new EnvironmentVarArgs
                                 {
+                                    Name = "WORMS_STORAGE__GameFolder",
+                                    Value = "/storage/game/WA",
+                                },
+                                new EnvironmentVarArgs
+                                {
                                     Name = "WORMS_CONNECTIONSTRINGS__DATABASE",
                                     SecretRef = "database-connection",
                                 },

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
             - "5005:8080"
         volumes:
             - ./sample-data:/data
+            - /home/eadie/games/worms:/game
         environment:
             - ASPNETCORE_ENVIRONMENT=Development
             - WORMS_CONNECTIONSTRINGS__STORAGE=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azure-storage:10000/devstoreaccount1;QueueEndpoint=http://azure-storage:10001/devstoreaccount1;
@@ -58,6 +59,7 @@ services:
             - WORMS_STORAGE__TEMPREPLAYFOLDER=/data/replays
             - WORMS_STORAGE__CLIFOLDER=/data/cli
             - WORMS_STORAGE__SCHEMESFOLDER=/data/schemes
+            - WORMS_STORAGE__GAMEFOLDER=/game
             - WORMS_HUB_DISTRIBUTED=true
             - WORMS_HUB_GATEWAY=true
         depends_on:

--- a/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
@@ -14,7 +14,7 @@ internal sealed class GameFilesController(
     [HttpGet]
     public async Task Get()
     {
-        var gameFolder = gameFiles.GetGameFolderPath();
+        var gameFolder = gameFiles.GameFolderPath;
 
         if (!Directory.Exists(gameFolder))
         {

--- a/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
@@ -1,0 +1,39 @@
+using System.IO.Compression;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Worms.Hub.Storage.Files;
+
+namespace Worms.Hub.Gateway.API.Controllers;
+
+[Route("~/api/v{version:apiVersion}/files/game")]
+internal sealed class GameFilesController(
+    GameFiles gameFiles,
+    ILogger<GameFilesController> logger) : V1ApiController
+{
+    [Authorize(Roles = "download:game")]
+    [HttpGet]
+    public async Task Get()
+    {
+        var gameFolder = gameFiles.GetGameFolderPath();
+
+        if (!Directory.Exists(gameFolder))
+        {
+            logger.Log(LogLevel.Warning, "Game folder not found at {Path}", gameFolder);
+            Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        Response.ContentType = "application/zip";
+        Response.Headers.Append("Content-Disposition", "attachment; filename=\"wa-game.zip\"");
+
+        await using var archive = new ZipArchive(Response.Body, ZipArchiveMode.Create, leaveOpen: true);
+        foreach (var file in Directory.GetFiles(gameFolder, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(gameFolder, file);
+            var entry = archive.CreateEntry(relativePath);
+            await using var entryStream = await entry.OpenAsync();
+            await using var fileStream = System.IO.File.OpenRead(file);
+            await fileStream.CopyToAsync(entryStream);
+        }
+    }
+}

--- a/src/Worms.Hub.Storage/Files/GameFiles.cs
+++ b/src/Worms.Hub.Storage/Files/GameFiles.cs
@@ -4,7 +4,7 @@ namespace Worms.Hub.Storage.Files;
 
 public sealed class GameFiles(IConfiguration configuration)
 {
-    public string GetGameFolderPath() =>
+    public string GameFolderPath { get; } =
         configuration["Storage:GameFolder"]
             ?? throw new ArgumentException("Game folder not configured");
 }

--- a/src/Worms.Hub.Storage/Files/GameFiles.cs
+++ b/src/Worms.Hub.Storage/Files/GameFiles.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Worms.Hub.Storage.Files;
+
+public sealed class GameFiles(IConfiguration configuration)
+{
+    public string GetGameFolderPath() =>
+        configuration["Storage:GameFolder"]
+            ?? throw new ArgumentException("Game folder not configured");
+}

--- a/src/Worms.Hub.Storage/ServiceRegistration.cs
+++ b/src/Worms.Hub.Storage/ServiceRegistration.cs
@@ -14,5 +14,6 @@ public static class ServiceRegistration
             .AddScoped<IRepository<Replay>, ReplaysRepository>()
             .AddScoped<CliFiles>()
             .AddScoped<ReplayFiles>()
-            .AddScoped<SchemeFiles>();
+            .AddScoped<SchemeFiles>()
+            .AddScoped<GameFiles>();
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/files/game` endpoint to the gateway that streams the WA game folder as a zip archive
- Requires `download:game` auth role (needs to be configured in Auth0)
- Adds `GameFiles` storage class and configures the game folder path in docker-compose and Azure infrastructure

## Context
System tests need the Worms Armageddon game files to test the replay processing pipeline end-to-end. The WA folder can't be checked into the repo due to copyright, but a copy exists on the production file share. This endpoint lets system tests download the files at runtime.

## Test plan
- [x] `dotnet build` passes with 0 warnings, 0 errors
- [x] All existing tests pass
- [x] Add `download:game` permission in Auth0
- [ ] Test locally with `docker compose up` and an authenticated request to `/api/v1/files/game`

🤖 Generated with [Claude Code](https://claude.com/claude-code)