### PR TITLE
Add WA runner integration test to CI

### DIFF
--- a/.github/workflows/code-branch.yml
+++ b/.github/workflows/code-branch.yml
@@ -14,12 +14,20 @@ on:
       - ".github/workflows/code-*.yml"
       - ".github/workflows/zz-build-*.yml"
       - ".github/workflows/zz-release-*.yml"
+      - ".github/workflows/zz-detect-changes.yml"
       - ".github/workflows/zz-inspections.yml"
 
 jobs:
+  changes:
+    name: Detect Changes
+    uses: ./.github/workflows/zz-detect-changes.yml
+
   build-hub:
     name: Build - Hub
+    needs: changes
     uses: ./.github/workflows/zz-build-hub.yml
+    with:
+      wa-runner-changed: ${{ needs.changes.outputs.wa-runner }}
     secrets: inherit
 
   build-cli:
@@ -29,7 +37,7 @@ jobs:
 
   actions-timeline:
     name: Timeline
-    needs: [build-hub, build-cli]
+    needs: [changes, build-hub, build-cli]
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/code-branch.yml
+++ b/.github/workflows/code-branch.yml
@@ -27,7 +27,7 @@ jobs:
     needs: changes
     uses: ./.github/workflows/zz-build-hub.yml
     with:
-      wa-runner-changed: ${{ needs.changes.outputs.wa-runner }}
+      wa-runner-test: ${{ needs.changes.outputs.wa-runner-test }}
     secrets: inherit
 
   build-cli:

--- a/.github/workflows/code-branch.yml
+++ b/.github/workflows/code-branch.yml
@@ -32,6 +32,7 @@ jobs:
 
   build-cli:
     name: Build - CLI
+    needs: changes
     uses: ./.github/workflows/zz-build-cli.yml
     secrets: inherit
 

--- a/.github/workflows/code-main.yml
+++ b/.github/workflows/code-main.yml
@@ -27,7 +27,7 @@ jobs:
     needs: changes
     uses: ./.github/workflows/zz-build-hub.yml
     with:
-      wa-runner-changed: ${{ needs.changes.outputs.wa-runner }}
+      wa-runner-test: ${{ needs.changes.outputs.wa-runner-test }}
     secrets: inherit
 
   build-cli:
@@ -40,8 +40,8 @@ jobs:
     needs: [changes, build-hub]
     uses: ./.github/workflows/zz-release-hub.yml
     with:
-      gateway-changed: ${{ needs.changes.outputs.gateway }}
-      wa-runner-changed: ${{ needs.changes.outputs.wa-runner }}
+      gateway-release: ${{ needs.changes.outputs.gateway-release }}
+      wa-runner-release: ${{ needs.changes.outputs.wa-runner-release }}
     secrets: inherit
 
   release-cli:
@@ -49,7 +49,7 @@ jobs:
     needs: [changes, build-cli]
     uses: ./.github/workflows/zz-release-cli.yml
     with:
-      clis-changed: ${{ needs.changes.outputs.clis }}
+      clis-release: ${{ needs.changes.outputs.clis-release }}
     secrets: inherit
 
   actions-timeline:

--- a/.github/workflows/code-main.yml
+++ b/.github/workflows/code-main.yml
@@ -32,6 +32,7 @@ jobs:
 
   build-cli:
     name: Build - CLI
+    needs: changes
     uses: ./.github/workflows/zz-build-cli.yml
     secrets: inherit
 

--- a/.github/workflows/code-main.yml
+++ b/.github/workflows/code-main.yml
@@ -14,12 +14,20 @@ on:
       - ".github/workflows/code-*.yml"
       - ".github/workflows/zz-build-*.yml"
       - ".github/workflows/zz-release-*.yml"
+      - ".github/workflows/zz-detect-changes.yml"
       - ".github/workflows/zz-inspections.yml"
 
 jobs:
+  changes:
+    name: Detect Changes
+    uses: ./.github/workflows/zz-detect-changes.yml
+
   build-hub:
     name: Build - Hub
+    needs: changes
     uses: ./.github/workflows/zz-build-hub.yml
+    with:
+      wa-runner-changed: ${{ needs.changes.outputs.wa-runner }}
     secrets: inherit
 
   build-cli:
@@ -29,19 +37,24 @@ jobs:
 
   release-hub:
     name: Release - Hub
-    needs: build-hub
+    needs: [changes, build-hub]
     uses: ./.github/workflows/zz-release-hub.yml
+    with:
+      gateway-changed: ${{ needs.changes.outputs.gateway }}
+      wa-runner-changed: ${{ needs.changes.outputs.wa-runner }}
     secrets: inherit
 
   release-cli:
     name: Release - CLI
-    needs: build-cli
+    needs: [changes, build-cli]
     uses: ./.github/workflows/zz-release-cli.yml
+    with:
+      clis-changed: ${{ needs.changes.outputs.clis }}
     secrets: inherit
 
   actions-timeline:
     name: Timeline
-    needs: [build-hub, build-cli, release-hub, release-cli]
+    needs: [changes, build-hub, build-cli, release-hub, release-cli]
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/zz-build-hub.yml
+++ b/.github/workflows/zz-build-hub.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      wa-runner-changed:
+        type: string
+        required: true
 
 jobs:
   build-gateway:
@@ -56,6 +60,7 @@ jobs:
   test-wa-runner:
     name: WA Runner Integration Test
     needs: build-wa-runner
+    if: ${{ inputs.wa-runner-changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/zz-build-hub.yml
+++ b/.github/workflows/zz-build-hub.yml
@@ -53,6 +53,41 @@ jobs:
         run: |
           make wa-runner.package
 
+  test-wa-runner:
+    name: WA Runner Integration Test
+    needs: build-wa-runner
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download WA game files
+        run: |
+          bash build/download-wa-game.sh "${{ secrets.WORMSHUB_CLIENTID }}" "${{ secrets.WORMSHUB_CLIENTSECRET }}" "${{ runner.temp }}/wa-game"
+
+      - name: Run integration test
+        env:
+          WA_GAME_PATH: ${{ runner.temp }}/wa-game
+        run: |
+          dotnet test src/Worms.Hub.Armageddon.Runner.Tests --filter Category=Integration
+
   build-database:
     name: Database
     runs-on: ubuntu-latest

--- a/.github/workflows/zz-build-hub.yml
+++ b/.github/workflows/zz-build-hub.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_call:
     inputs:
-      wa-runner-changed:
+      wa-runner-test:
         type: string
         required: true
 
@@ -60,7 +60,7 @@ jobs:
   test-wa-runner:
     name: WA Runner Integration Test
     needs: build-wa-runner
-    if: ${{ inputs.wa-runner-changed == 'true' }}
+    if: ${{ inputs.wa-runner-test == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -6,21 +6,24 @@ permissions:
 on:
   workflow_call:
     outputs:
-      gateway:
-        value: ${{ jobs.changes.outputs.gateway }}
-      wa-runner:
-        value: ${{ jobs.changes.outputs.wa-runner }}
-      clis:
-        value: ${{ jobs.changes.outputs.clis }}
+      gateway-release:
+        value: ${{ jobs.changes.outputs.gateway-release }}
+      wa-runner-release:
+        value: ${{ jobs.changes.outputs.wa-runner-release }}
+      wa-runner-test:
+        value: ${{ jobs.changes.outputs.wa-runner-test }}
+      clis-release:
+        value: ${{ jobs.changes.outputs.clis-release }}
 
 jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      gateway: ${{ steps.filter.outputs.gateway == 'true' || steps.filter.outputs.hub-common == 'true' }}
-      wa-runner: ${{ steps.filter.outputs.wa-runner == 'true' || steps.filter.outputs.hub-common == 'true' }}
-      clis: ${{ steps.filter.outputs.clis == 'true' }}
+      gateway-release: ${{ steps.filter.outputs.gateway == 'true' || steps.filter.outputs.hub-common == 'true' }}
+      wa-runner-release: ${{ steps.filter.outputs.wa-runner == 'true' || steps.filter.outputs.hub-common == 'true' }}
+      wa-runner-test: ${{ steps.filter.outputs.wa-runner == 'true' || steps.filter.outputs.wa-runner-test == 'true' || steps.filter.outputs.hub-common == 'true' }}
+      clis-release: ${{ steps.filter.outputs.clis == 'true' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -39,10 +42,11 @@ jobs:
             - 'build/docker/gateway/**'
           wa-runner:
             - 'src/Worms.Hub.Armageddon.Runner/**'
-            - 'src/Worms.Hub.Armageddon.Runner.Tests/**'
             - 'src/Worms.Armageddon.Game/**'
             - 'src/Worms.Hub.Queues/**'
             - 'build/docker/wa-runner/**'
+          wa-runner-test:
+            - 'src/Worms.Hub.Armageddon.Runner.Tests/**'
             - 'build/download-wa-game.sh'
           hub-common:
             - 'src/Directory.Build.props'

--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -1,0 +1,59 @@
+name: ZZ - Detect Changes
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  workflow_call:
+    outputs:
+      gateway:
+        value: ${{ jobs.changes.outputs.gateway }}
+      wa-runner:
+        value: ${{ jobs.changes.outputs.wa-runner }}
+      clis:
+        value: ${{ jobs.changes.outputs.clis }}
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      gateway: ${{ steps.filter.outputs.gateway == 'true' || steps.filter.outputs.hub-common == 'true' }}
+      wa-runner: ${{ steps.filter.outputs.wa-runner == 'true' || steps.filter.outputs.hub-common == 'true' }}
+      clis: ${{ steps.filter.outputs.clis == 'true' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Filter
+      uses: dorny/paths-filter@v4
+      id: filter
+      with:
+        filters: |
+          gateway:
+            - 'src/Worms.Armageddon.Files/**'
+            - 'src/Worms.Hub.Gateway/**'
+            - 'src/Worms.Hub.Queues/**'
+            - 'src/Worms.Hub.Storage/**'
+            - 'build/docker/gateway/**'
+          wa-runner:
+            - 'src/Worms.Hub.Armageddon.Runner/**'
+            - 'src/Worms.Hub.Armageddon.Runner.Tests/**'
+            - 'src/Worms.Armageddon.Game/**'
+            - 'src/Worms.Hub.Queues/**'
+            - 'build/docker/wa-runner/**'
+            - 'build/download-wa-game.sh'
+          hub-common:
+            - 'src/Directory.Build.props'
+            - '.github/workflows/hub-*.yml'
+            - 'build/docker/makefile'
+            - 'build/*.sh'
+          clis:
+            - 'src/Worms.Cli/**'
+            - 'src/Worms.Cli.*/**'
+            - 'src/Worms.Armageddon.Files/**'
+            - 'src/Worms.Armageddon.Game/**'
+            - 'src/Directory.Build.props'
+            - 'build/cli/**'
+            - '.github/workflows/hub-*.yml'

--- a/.github/workflows/zz-release-cli.yml
+++ b/.github/workflows/zz-release-cli.yml
@@ -5,38 +5,17 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      clis-changed:
+        type: string
+        required: true
 
 jobs:
 
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      clis: ${{ steps.filter.outputs.clis == 'true' }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Filter
-      uses: dorny/paths-filter@v4
-      id: filter
-      with:
-        filters: |
-          clis:
-            - 'src/Worms.Cli/**'
-            - 'src/Worms.Cli.*/**'
-            - 'src/Worms.Armageddon.Files/**'
-            - 'src/Worms.Armageddon.Game/**'
-            - 'src/Directory.Build.props'
-            - 'build/cli/**'
-            - '.github/workflows/hub-*.yml'
-
   release-cli-github:
     name: Release - GitHub
-    needs: changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.clis == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.clis-changed == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,9 +31,8 @@ jobs:
 
   release-cli-wormshub:
     name: Release - Worms Hub
-    needs: changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.clis == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.clis-changed == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -75,9 +53,8 @@ jobs:
 
   release-cli-dockerhub:
     name: Release - DockerHub
-    needs: changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.clis == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.clis-changed == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/zz-release-cli.yml
+++ b/.github/workflows/zz-release-cli.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_call:
     inputs:
-      clis-changed:
+      clis-release:
         type: string
         required: true
 
@@ -15,7 +15,7 @@ jobs:
   release-cli-github:
     name: Release - GitHub
     runs-on: ubuntu-latest
-    if: ${{ inputs.clis-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.clis-release == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -32,7 +32,7 @@ jobs:
   release-cli-wormshub:
     name: Release - Worms Hub
     runs-on: ubuntu-latest
-    if: ${{ inputs.clis-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.clis-release == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -54,7 +54,7 @@ jobs:
   release-cli-dockerhub:
     name: Release - DockerHub
     runs-on: ubuntu-latest
-    if: ${{ inputs.clis-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.clis-release == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/zz-release-hub.yml
+++ b/.github/workflows/zz-release-hub.yml
@@ -5,47 +5,20 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      gateway-changed:
+        type: string
+        required: true
+      wa-runner-changed:
+        type: string
+        required: true
 
 jobs:
-
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      gateway: ${{ steps.filter.outputs.gateway == 'true' || steps.filter.outputs.common == 'true' }}
-      wa-runner: ${{ steps.filter.outputs.wa-runner == 'true' || steps.filter.outputs.common == 'true' }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Filter
-      uses: dorny/paths-filter@v4
-      id: filter
-      with:
-        filters: |
-          gateway:
-            - 'src/Worms.Armageddon.Files/**'
-            - 'src/Worms.Hub.Gateway/**'
-            - 'src/Worms.Hub.Queues/**'
-            - 'src/Worms.Hub.Storage/**'
-            - 'build/docker/gateway/**'
-          wa-runner:
-            - 'src/Worms.Hub.Armageddon.Runner/**'
-            - 'src/Worms.Armageddon.Game/**'
-            - 'src/Worms.Hub.Queues/**'
-            - 'build/docker/wa-runner/**'
-          common:
-            - 'src/Directory.Build.props'
-            - '.github/workflows/hub-*.yml'
-            - 'build/docker/makefile'
-            - 'build/*.sh'
 
   release-gateway-github:
     name: Gateway - GitHub
     runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.gateway == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.gateway-changed == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout
@@ -60,8 +33,7 @@ jobs:
   release-gateway-dockerhub:
     name: Gateway - DockerHub
     runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.gateway == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.gateway-changed == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout
@@ -91,8 +63,7 @@ jobs:
   release-wa-runner-github:
     name: WA Runner - GitHub
     runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.wa-runner == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.wa-runner-changed == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout
@@ -107,8 +78,7 @@ jobs:
   release-wa-runner-dockerhub:
     name: WA Runner - DockerHub
     runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.wa-runner == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.wa-runner-changed == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/zz-release-hub.yml
+++ b/.github/workflows/zz-release-hub.yml
@@ -6,10 +6,10 @@ permissions:
 on:
   workflow_call:
     inputs:
-      gateway-changed:
+      gateway-release:
         type: string
         required: true
-      wa-runner-changed:
+      wa-runner-release:
         type: string
         required: true
 
@@ -18,7 +18,7 @@ jobs:
   release-gateway-github:
     name: Gateway - GitHub
     runs-on: ubuntu-latest
-    if: ${{ inputs.gateway-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.gateway-release == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout
@@ -33,7 +33,7 @@ jobs:
   release-gateway-dockerhub:
     name: Gateway - DockerHub
     runs-on: ubuntu-latest
-    if: ${{ inputs.gateway-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.gateway-release == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
   release-wa-runner-github:
     name: WA Runner - GitHub
     runs-on: ubuntu-latest
-    if: ${{ inputs.wa-runner-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.wa-runner-release == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout
@@ -78,7 +78,7 @@ jobs:
   release-wa-runner-dockerhub:
     name: WA Runner - DockerHub
     runs-on: ubuntu-latest
-    if: ${{ inputs.wa-runner-changed == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.wa-runner-release == 'true' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout

--- a/build/download-wa-game.sh
+++ b/build/download-wa-game.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+ClientId=$1
+ClientSecret=$2
+OutputDir=$3
+AuthServerUrl=https://eadie.eu.auth0.com/oauth/token
+TokenAudience=worms.davideadie.dev
+
+echo "Getting auth token..."
+
+GetAuthTokenResponse=$(curl --request POST \
+    --url "$AuthServerUrl" \
+    --header 'content-type: application/json' \
+    --data '{
+        "client_id": "'"$ClientId"'",
+        "client_secret": "'"$ClientSecret"'",
+        "audience": "'"$TokenAudience"'",
+        "grant_type": "client_credentials" }')
+
+AuthToken=$(echo $GetAuthTokenResponse | jq -r '.access_token')
+
+if [ "$AuthToken" = "null" ] || [ -z "$AuthToken" ]; then
+    echo "Failed to get auth token. Response:"
+    echo "$GetAuthTokenResponse"
+    exit 1
+fi
+
+echo "Downloading WA game files..."
+
+mkdir -p "$OutputDir"
+
+HttpCode=$(curl --request GET \
+    --url "https://worms.davideadie.dev/api/v1/files/game" \
+    --header "authorization: Bearer $AuthToken" \
+    --output "$OutputDir/wa-game.zip" \
+    --write-out "%{http_code}" \
+    -L)
+
+if [ "$HttpCode" -ne 200 ]; then
+    echo "Download failed with HTTP $HttpCode. Response body:"
+    cat "$OutputDir/wa-game.zip"
+    rm -f "$OutputDir/wa-game.zip"
+    exit 1
+fi
+
+echo "Extracting WA game files..."
+
+unzip -o "$OutputDir/wa-game.zip" -d "$OutputDir"
+rm "$OutputDir/wa-game.zip"
+
+echo "WA game files downloaded to $OutputDir"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
             - "5005:8080"
         volumes:
             - ./sample-data:/data
-            - /home/eadie/games/worms:/game
+            - ${WA_GAME_PATH:-/home/eadie/games/worms}:/game
         environment:
             - ASPNETCORE_ENVIRONMENT=Development
             - WORMS_CONNECTIONSTRINGS__STORAGE=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azure-storage:10000/devstoreaccount1;QueueEndpoint=http://azure-storage:10001/devstoreaccount1;
@@ -92,7 +92,7 @@ services:
             context: .
         volumes:
             - ./sample-data:/data
-            - /home/eadie/games/worms:/game
+            - ${WA_GAME_PATH:-/home/eadie/games/worms}:/game
         environment:
             - WORMS_CONNECTIONSTRINGS__STORAGE=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azure-storage:10000/devstoreaccount1;QueueEndpoint=http://azure-storage:10001/devstoreaccount1;
             - WORMS_STORAGE__TEMPREPLAYFOLDER=/data/replays


### PR DESCRIPTION
## Summary
- Adds a new `test-wa-runner` job to the hub build workflow that runs after `build-wa-runner`
- Downloads WA game files from the production endpoint using OAuth2 auth (same credentials as CLI upload)
- Makes the game file path in `docker-compose.yaml` configurable via `WA_GAME_PATH` env var (defaults to existing local path)

## Prerequisites
- The Auth0 client (`WORMSHUB_CLIENTID`) needs the `download:game` permission configured

## Test plan
- [x] Verify Auth0 client has `download:game` permission
- [x] Push branch and confirm the `test-wa-runner` job appears in the workflow
- [ ] Confirm it runs after `build-wa-runner` completes
- [ ] Verify game files download successfully
- [ ] Verify integration test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)