### PR TITLE
Fix game download endpoint to build ZIP in memory

### DIFF
--- a/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
@@ -12,28 +12,30 @@ internal sealed class GameFilesController(
 {
     [Authorize(Roles = "download:game")]
     [HttpGet]
-    public async Task Get()
+    public async Task<IActionResult> Get()
     {
         var gameFolder = gameFiles.GameFolderPath;
 
         if (!Directory.Exists(gameFolder))
         {
             logger.Log(LogLevel.Warning, "Game folder not found at {Path}", gameFolder);
-            Response.StatusCode = StatusCodes.Status404NotFound;
-            return;
+            return NotFound();
         }
 
-        Response.ContentType = "application/zip";
-        Response.Headers.Append("Content-Disposition", "attachment; filename=\"wa-game.zip\"");
-
-        await using var archive = new ZipArchive(Response.Body, ZipArchiveMode.Create, leaveOpen: true);
-        foreach (var file in Directory.GetFiles(gameFolder, "*", SearchOption.AllDirectories))
+        var memoryStream = new MemoryStream();
+        await using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
         {
-            var relativePath = Path.GetRelativePath(gameFolder, file);
-            var entry = archive.CreateEntry(relativePath);
-            await using var entryStream = await entry.OpenAsync();
-            await using var fileStream = System.IO.File.OpenRead(file);
-            await fileStream.CopyToAsync(entryStream);
+            foreach (var file in Directory.GetFiles(gameFolder, "*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(gameFolder, file);
+                var entry = archive.CreateEntry(relativePath);
+                await using var entryStream = await entry.OpenAsync();
+                await using var fileStream = System.IO.File.OpenRead(file);
+                await fileStream.CopyToAsync(entryStream);
+            }
         }
+
+        memoryStream.Position = 0;
+        return File(memoryStream, "application/zip", "wa-game.zip");
     }
 }

--- a/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/GameFilesController.cs
@@ -22,12 +22,16 @@ internal sealed class GameFilesController(
             return NotFound();
         }
 
+        var files = Directory.GetFiles(gameFolder, "*", SearchOption.AllDirectories);
+        logger.LogInformation("Zipping {Count} files from {Path}", files.Length, gameFolder);
+
         var memoryStream = new MemoryStream();
         await using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
         {
-            foreach (var file in Directory.GetFiles(gameFolder, "*", SearchOption.AllDirectories))
+            foreach (var file in files)
             {
                 var relativePath = Path.GetRelativePath(gameFolder, file);
+                logger.LogDebug("Adding {File} to archive", relativePath);
                 var entry = archive.CreateEntry(relativePath);
                 await using var entryStream = await entry.OpenAsync();
                 await using var fileStream = System.IO.File.OpenRead(file);
@@ -35,6 +39,7 @@ internal sealed class GameFilesController(
             }
         }
 
+        logger.LogInformation("Archive created: {Size} bytes", memoryStream.Length);
         memoryStream.Position = 0;
         return File(memoryStream, "application/zip", "wa-game.zip");
     }


### PR DESCRIPTION
## Summary
- The game files download endpoint was streaming the ZIP directly to `Response.Body`, which silently truncated the archive when errors occurred mid-stream (only `CRASH.DMP` was included instead of all game files)
- Changed to build the ZIP in a `MemoryStream` first, so errors surface as 500s and `Content-Length` is set correctly

## Test plan
- [ ] Deploy and verify the `/api/v1/files/game` endpoint returns a complete ZIP with all game files
- [ ] Verify error cases (missing folder) return proper HTTP status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)