### PR TITLE
Bump gateway image to 0.8.31

### DIFF
--- a/deployment/Worms.Hub.Infrastructure/Pulumi.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.yaml
@@ -4,6 +4,6 @@ description: The Worms Hub Server
 config:
     azure-native:location: northeurope
     worms-hub:domain: davideadie.dev
-    worms-hub:gateway-image: theeadie/worms-hub-gateway:0.8.30
+    worms-hub:gateway-image: theeadie/worms-hub-gateway:0.8.31
     worms-hub:wa-runner-image: theeadie/worms-hub-wa-runner:0.5.21
     worms-hub:database-version: 0.2.2


### PR DESCRIPTION
## Summary
- Bump gateway image from 0.8.30 to 0.8.31
- Includes fix for game download endpoint (builds ZIP in memory instead of streaming) and added logging

## Test plan
- [ ] Verify deployment succeeds
- [ ] Test `/api/v1/files/game` endpoint returns a complete ZIP with all game files

🤖 Generated with [Claude Code](https://claude.com/claude-code)