### PR TITLE
Fix Wine process hanging on Ubuntu 24

### DIFF
--- a/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -46,8 +46,16 @@ internal sealed class WormsRunner(IWormsLocator wormsLocator, IProcessRunner pro
                     var errors = PrintStdErr(process.StandardError);
 
                     await process.WaitForExitAsync();
-                    await Task.WhenAll(output, errors);
                     logger.Log(LogLevel.Debug, "Process exited with code: {ExitCode}", process.ExitCode);
+
+                    // On Ubuntu 24, child processes (e.g. wineserver) can hold stdout/stderr
+                    // pipes open after the main process exits. Wait briefly for output to
+                    // drain, then move on rather than hanging indefinitely.
+                    var readComplete = Task.WhenAll(output, errors);
+                    if (await Task.WhenAny(readComplete, Task.Delay(TimeSpan.FromSeconds(10))) != readComplete)
+                    {
+                        logger.Log(LogLevel.Warning, "Timed out waiting for process output streams to close");
+                    }
 
                     return Task.CompletedTask;
                 });


### PR DESCRIPTION
## Summary
- On Ubuntu 24, child processes (e.g. wineserver) hold stdout/stderr pipes open after the main Wine process exits
- This causes `WaitForExitAsync` to return but the output stream readers in `WormsRunner` to hang indefinitely
- The runner never reaches the code that sends the output queue message, causing the integration test to time out
- Adds a 10-second timeout for draining process output after exit, so the runner proceeds even if child processes hold pipes open

## Test plan
- [ ] Run integration test: `dotnet test --filter Category=Integration` (with no Docker cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)