### PR TITLE
Fix Wine process hanging and improve CI for Ubuntu 24

### DIFF
--- a/.github/workflows/zz-build-hub.yml
+++ b/.github/workflows/zz-build-hub.yml
@@ -62,6 +62,7 @@ jobs:
     needs: build-wa-runner
     if: ${{ inputs.wa-runner-test == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -91,7 +92,7 @@ jobs:
         env:
           WA_GAME_PATH: ${{ runner.temp }}/wa-game
         run: |
-          dotnet test src/Worms.Hub.Armageddon.Runner.Tests --filter Category=Integration
+          dotnet test src/Worms.Hub.Armageddon.Runner.Tests --filter Category=Integration --verbosity normal
 
   build-database:
     name: Database

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,9 @@ services:
         build:
             dockerfile: build/docker/wa-runner/Dockerfile
             context: .
+            cache_from:
+                - type=gha,scope=package-theeadie/worms-hub-wa-runner
+                - type=gha,scope=build-theeadie/worms-hub-wa-runner
         volumes:
             - ./sample-data:/data
             - ${WA_GAME_PATH:-/home/eadie/games/worms}:/game

--- a/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -48,14 +48,12 @@ internal sealed class WormsRunner(IWormsLocator wormsLocator, IProcessRunner pro
                     await process.WaitForExitAsync();
                     logger.Log(LogLevel.Debug, "Process exited with code: {ExitCode}", process.ExitCode);
 
-                    // On Ubuntu 24, child processes (e.g. wineserver) can hold stdout/stderr
-                    // pipes open after the main process exits. Wait briefly for output to
-                    // drain, then move on rather than hanging indefinitely.
-                    var readComplete = Task.WhenAll(output, errors);
-                    if (await Task.WhenAny(readComplete, Task.Delay(TimeSpan.FromSeconds(10))) != readComplete)
-                    {
-                        logger.Log(LogLevel.Warning, "Timed out waiting for process output streams to close");
-                    }
+                    // On Ubuntu 24, child processes (e.g. wineserver) can inherit and hold
+                    // stdout/stderr pipes open after the main process exits. Closing the
+                    // streams forces EOF on the readers so they complete immediately.
+                    process.StandardOutput?.Close();
+                    process.StandardError?.Close();
+                    await Task.WhenAll(output, errors);
 
                     return Task.CompletedTask;
                 });

--- a/src/Worms.Hub.Armageddon.Runner.Tests/ProcessReplayShould.cs
+++ b/src/Worms.Hub.Armageddon.Runner.Tests/ProcessReplayShould.cs
@@ -114,9 +114,31 @@ internal sealed class ProcessReplayShould
         using var process = Process.Start(
             new ProcessStartInfo("docker", $"compose {arguments}")
             {
-                WorkingDirectory = workingDirectory
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             })!;
+
+        var stdoutReader = process.StandardOutput;
+        var stderrReader = process.StandardError;
+
+        var stdout = Task.Run(async () =>
+        {
+            while (await stdoutReader.ReadLineAsync() is { } line)
+            {
+                await TestContext.Progress.WriteLineAsync(line);
+            }
+        });
+        var stderr = Task.Run(async () =>
+        {
+            while (await stderrReader.ReadLineAsync() is { } line)
+            {
+                await TestContext.Progress.WriteLineAsync(line);
+            }
+        });
+
         await process.WaitForExitAsync();
+        await Task.WhenAll(stdout, stderr);
     }
 
     private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(2) };


### PR DESCRIPTION
## Summary
- On Ubuntu 24, child processes (e.g. wineserver) inherit and hold stdout/stderr pipes open after the main Wine process exits, blocking the output stream readers indefinitely. Close the streams after process exit to force EOF on the readers immediately — no arbitrary timeouts needed.
- Stream docker compose stdout/stderr to test progress output for CI visibility
- Add GHA cache (`cache_from`) to the docker compose build so the integration test reuses cached layers from the build job
- Add 15-minute job timeout and `--verbosity normal` to the CI integration test

## Test plan
- [x] Integration test passes locally with no-cache Docker build
- [x] CI integration test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)