### PR TITLE
Revert WA runner to Ubuntu 22.04

### DIFF
--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -28,7 +28,7 @@ FROM build AS test
 RUN dotnet test --no-restore --no-build --verbosity normal
 
 #### Runtime ####
-FROM ubuntu:22.04@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659 AS runtime
+FROM ubuntu:22.04 AS runtime
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -28,7 +28,7 @@ FROM build AS test
 RUN dotnet test --no-restore --no-build --verbosity normal
 
 #### Runtime ####
-FROM ubuntu:22.04 AS runtime
+FROM ubuntu:22.04@sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7 AS runtime
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -28,7 +28,7 @@ FROM build AS test
 RUN dotnet test --no-restore --no-build --verbosity normal
 
 #### Runtime ####
-FROM ubuntu:24.04@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b AS runtime
+FROM ubuntu:22.04@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659 AS runtime
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -44,7 +44,7 @@ RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key -O /tmp/winehq.key
 RUN apt-get update \
   && apt-get install -y software-properties-common \
   && apt-key add /tmp/winehq.key \
-  && add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ noble main' \
+  && add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ jammy main' \
   && rm /tmp/winehq.key \
   && rm -rf /var/lib/apt/lists/*
 
@@ -56,27 +56,24 @@ RUN dpkg --add-architecture i386 \
 
 # Create WINEPREFIX
 RUN WINEDLLOVERRIDES="mscoree,mshtml=" xvfb-run wineboot -i \
-  && wineserver -k \
-  && rm -f /tmp/.X*-lock
+  && wineserver -k
 
 # Copy game installation directory
 
 # Some settings for WA
-RUN xvfb-run sh -c '\
-  wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v WineCompatibilitySuggested /d 0x7FFFFFFF /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v WindowedMode /d 0x00000001 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v DetailLevel /d 0x00000005 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v WindowedMode /d 0x00000001 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v PinnedChatLines /d 0x00000007 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v InfoTransparency /d 0x00000001 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v InfoSpy /d 0x00000001 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v DisableSmoothBackgroundGradient /d 0x00000000 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v HardwareRendering /d 0x00000001 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v LargerFonts /d 0x00000000 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v AssistedVsync /d 0x00000000 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v Vsync /d 0x00000000 /f \
-  && wineserver -k' \
-  && rm -f /tmp/.X*-lock
+RUN wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v WineCompatibilitySuggested /d 0x7FFFFFFF /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v WindowedMode /d 0x00000001 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v DetailLevel /d 0x00000005 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v WindowedMode /d 0x00000001 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v PinnedChatLines /d 0x00000007 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v InfoTransparency /d 0x00000001 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v InfoSpy /d 0x00000001 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v DisableSmoothBackgroundGradient /d 0x00000000 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v HardwareRendering /d 0x00000001 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v LargerFonts /d 0x00000000 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v AssistedVsync /d 0x00000000 /f \
+  && wine reg add 'HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options' /t REG_DWORD /v Vsync /d 0x00000000 /f \
+  && wineserver -k
 
 WORKDIR /app
 COPY --from=build /app/out .

--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -28,7 +28,7 @@ FROM build AS test
 RUN dotnet test --no-restore --no-build --verbosity normal
 
 #### Runtime ####
-FROM ubuntu:22.04@sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7 AS runtime
+FROM ubuntu:22.04@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659 AS runtime
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
+++ b/src/Worms.Armageddon.Game/Linux/WormsRunner.cs
@@ -34,7 +34,7 @@ internal sealed class WormsRunner(IWormsLocator wormsLocator, IProcessRunner pro
                     {
                         FileName = "/bin/bash",
                         Arguments = $"""
-                                     -c "xvfb-run wine "{gameInfo.ExeLocation}" {args}; wineserver -k"
+                                     -c "xvfb-run wine "{gameInfo.ExeLocation}" {args}"
                                      """,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true
@@ -46,16 +46,8 @@ internal sealed class WormsRunner(IWormsLocator wormsLocator, IProcessRunner pro
                     var errors = PrintStdErr(process.StandardError);
 
                     await process.WaitForExitAsync();
+                    await Task.WhenAll(output, errors);
                     logger.Log(LogLevel.Debug, "Process exited with code: {ExitCode}", process.ExitCode);
-
-                    // On Ubuntu 24, child processes (e.g. wineserver) can hold stdout/stderr
-                    // pipes open after the main process exits. Wait briefly for output to
-                    // drain, then move on rather than hanging indefinitely.
-                    var readComplete = Task.WhenAll(output, errors);
-                    if (await Task.WhenAny(readComplete, Task.Delay(TimeSpan.FromSeconds(10))) != readComplete)
-                    {
-                        logger.Log(LogLevel.Warning, "Timed out waiting for process output streams to close");
-                    }
 
                     return Task.CompletedTask;
                 });


### PR DESCRIPTION
## Summary
- Reverts the WA runner Dockerfile from Ubuntu 24.04 back to 22.04 (`noble` -> `jammy`)
- Removes Ubuntu 24-specific workarounds (X lock file cleanup, xvfb-run wrapper for wine reg, wineserver -k in WormsRunner)
- Restores the simpler WormsRunner process output handling that worked reliably on 22.04

## Context
The Ubuntu 24.04 upgrade (`07c81f16`) introduced Wine/xvfb compatibility issues. Multiple fix attempts (`a115858f`, `a1904646`, `871dce85`) have not fully resolved the problems. This rolls back to the last known-good state.

## Test plan
- [ ] CI integration test passes with the Ubuntu 22.04 image
- [ ] WA runner successfully processes a replay end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)