### PR TITLE
Add GIF generation to replay processor

### DIFF
--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -42,7 +42,9 @@ jobs:
             - 'build/docker/gateway/**'
           wa-runner:
             - 'src/Worms.Hub.Armageddon.Runner/**'
+            - 'src/Worms.Armageddon.Files/**'
             - 'src/Worms.Armageddon.Game/**'
+            - 'src/Worms.Armageddon.Gifs/**'
             - 'src/Worms.Hub.Queues/**'
             - 'build/docker/wa-runner/**'
           wa-runner-test:
@@ -58,6 +60,7 @@ jobs:
             - 'src/Worms.Cli.*/**'
             - 'src/Worms.Armageddon.Files/**'
             - 'src/Worms.Armageddon.Game/**'
+            - 'src/Worms.Armageddon.Gifs/**'
             - 'src/Directory.Build.props'
             - 'build/cli/**'
             - '.github/workflows/hub-*.yml'

--- a/Worms.sln
+++ b/Worms.sln
@@ -31,6 +31,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.Armageddon.Runner.Tests", "src\Worms.Hub.Armageddon.Runner.Tests\Worms.Hub.Armageddon.Runner.Tests.csproj", "{03DA1FFD-7F36-4F68-B630-23DF642C7C6F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Armageddon.Gifs", "src\Worms.Armageddon.Gifs\Worms.Armageddon.Gifs.csproj", "{C93E055E-2254-4CB4-AFDB-90315ED7960A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -197,11 +199,24 @@ Global
 		{03DA1FFD-7F36-4F68-B630-23DF642C7C6F}.Release|x64.Build.0 = Release|Any CPU
 		{03DA1FFD-7F36-4F68-B630-23DF642C7C6F}.Release|x86.ActiveCfg = Release|Any CPU
 		{03DA1FFD-7F36-4F68-B630-23DF642C7C6F}.Release|x86.Build.0 = Release|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Debug|x86.Build.0 = Debug|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x64.Build.0 = Release|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x86.ActiveCfg = Release|Any CPU
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{03DA1FFD-7F36-4F68-B630-23DF642C7C6F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C93E055E-2254-4CB4-AFDB-90315ED7960A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -4,12 +4,16 @@ WORKDIR /app
 
 COPY Directory.Build.props .
 COPY .editorconfig .
+COPY src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj ./src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
 COPY src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj ./src/Worms.Armageddon.Game/Worms.Armageddon.Game.csproj
+COPY src/Worms.Armageddon.Gifs/Worms.Armageddon.Gifs.csproj ./src/Worms.Armageddon.Gifs/Worms.Armageddon.Gifs.csproj
 COPY src/Worms.Hub.Queues/Worms.Hub.Queues.csproj ./src/Worms.Hub.Queues/Worms.Hub.Queues.csproj
 COPY src/Worms.Hub.Armageddon.Runner/Worms.Hub.Armageddon.Runner.csproj ./src/Worms.Hub.Armageddon.Runner/Worms.Hub.Armageddon.Runner.csproj
 RUN dotnet restore src/Worms.Hub.Armageddon.Runner/Worms.Hub.Armageddon.Runner.csproj -r linux-x64
 
+COPY src/Worms.Armageddon.Files ./src/Worms.Armageddon.Files
 COPY src/Worms.Armageddon.Game ./src/Worms.Armageddon.Game
+COPY src/Worms.Armageddon.Gifs ./src/Worms.Armageddon.Gifs
 COPY src/Worms.Hub.Queues ./src/Worms.Hub.Queues
 COPY src/Worms.Hub.Armageddon.Runner ./src/Worms.Hub.Armageddon.Runner
 ARG VERSION=0.0.1

--- a/src/Worms.Armageddon.Files/Replays/ReplayResource.cs
+++ b/src/Worms.Armageddon.Files/Replays/ReplayResource.cs
@@ -38,7 +38,7 @@ public record Turn(
     IReadOnlyCollection<Damage> Damage);
 
 [PublicAPI]
-public record Weapon(string Name, uint? Fuse, string? Modifier);
+public record Weapon(string Name, TimeSpan Timestamp, uint? Fuse, string? Modifier);
 
 [PublicAPI]
 public record Damage(Team Team, uint HealthLost, uint WormsKilled);

--- a/src/Worms.Armageddon.Files/Replays/Text/Parsers/WeaponUsedParser.cs
+++ b/src/Worms.Armageddon.Files/Replays/Text/Parsers/WeaponUsedParser.cs
@@ -35,31 +35,38 @@ internal sealed partial class WeaponUsedParser : IReplayLineParser
 
         if (weaponUsedWithFuseAndModifier.Success)
         {
+            var timestamp = TimeSpan.Parse(weaponUsedWithFuseAndModifier.Groups[1].Value, CultureInfo.CurrentCulture);
             _ = builder.CurrentTurn.WithWeapon(
                 new Weapon(
                     weaponUsedWithFuseAndModifier.Groups[4].Value.Trim(),
+                    timestamp,
                     uint.Parse(weaponUsedWithFuseAndModifier.Groups[5].Value, CultureInfo.CurrentCulture),
                     weaponUsedWithFuseAndModifier.Groups[6].Value));
         }
         else if (weaponUsedWithFuse.Success)
         {
+            var timestamp = TimeSpan.Parse(weaponUsedWithFuse.Groups[1].Value, CultureInfo.CurrentCulture);
             _ = builder.CurrentTurn.WithWeapon(
                 new Weapon(
                     weaponUsedWithFuse.Groups[4].Value.Trim(),
+                    timestamp,
                     uint.Parse(weaponUsedWithFuse.Groups[5].Value, CultureInfo.CurrentCulture),
                     null));
         }
         else if (weaponUsedWithModifier.Success)
         {
+            var timestamp = TimeSpan.Parse(weaponUsedWithModifier.Groups[1].Value, CultureInfo.CurrentCulture);
             _ = builder.CurrentTurn.WithWeapon(
                 new Weapon(
                     weaponUsedWithModifier.Groups[4].Value.Trim(),
+                    timestamp,
                     null,
                     weaponUsedWithModifier.Groups[5].Value));
         }
         else if (weaponUsed.Success)
         {
-            _ = builder.CurrentTurn.WithWeapon(new Weapon(weaponUsed.Groups[4].Value.Trim(), null, null));
+            var timestamp = TimeSpan.Parse(weaponUsed.Groups[1].Value, CultureInfo.CurrentCulture);
+            _ = builder.CurrentTurn.WithWeapon(new Weapon(weaponUsed.Groups[4].Value.Trim(), timestamp, null, null));
         }
     }
 }

--- a/src/Worms.Armageddon.Gifs/GifCreator.cs
+++ b/src/Worms.Armageddon.Gifs/GifCreator.cs
@@ -1,0 +1,72 @@
+using System.IO.Abstractions;
+using ImageMagick;
+using JetBrains.Annotations;
+using Worms.Armageddon.Game;
+
+namespace Worms.Armageddon.Gifs;
+
+[PublicAPI]
+public sealed class GifCreator(IWormsArmageddon wormsArmageddon, IFileSystem fileSystem)
+{
+    public async Task<string> CreateGif(
+        string replayPath,
+        TimeSpan turnStart,
+        TimeSpan turnEnd,
+        int turnNumber,
+        string outputFolder,
+        uint framesPerSecond = 5,
+        uint speedMultiplier = 2,
+        TimeSpan? startOffset = null,
+        TimeSpan? endOffset = null)
+    {
+        var replayName = fileSystem.Path.GetFileNameWithoutExtension(replayPath);
+        var worms = wormsArmageddon.FindInstallation();
+        var framesFolder = fileSystem.Path.Combine(worms.CaptureFolder, replayName);
+        var gifFileName = $"{replayName} - {turnNumber}.gif";
+        var outputFilePath = fileSystem.Path.Combine(outputFolder, gifFileName);
+
+        var animationDelay = 100 / framesPerSecond / speedMultiplier;
+        var start = turnStart + (startOffset ?? TimeSpan.Zero);
+        var end = turnEnd - (endOffset ?? TimeSpan.Zero);
+
+        DeleteFrames(framesFolder);
+        await wormsArmageddon.ExtractReplayFrames(replayPath, framesPerSecond, start, end);
+        CreateGifFromFiles(framesFolder, outputFilePath, animationDelay, 640, 480);
+        DeleteFrames(framesFolder);
+
+        return gifFileName;
+    }
+
+    private void DeleteFrames(string framesFolder)
+    {
+        if (fileSystem.Directory.Exists(framesFolder))
+        {
+            fileSystem.Directory.Delete(framesFolder, true);
+        }
+    }
+
+    private void CreateGifFromFiles(
+        string framesFolder,
+        string outputFile,
+        uint animationDelay,
+        uint width,
+        uint height)
+    {
+        var frames = fileSystem.Directory.GetFiles(framesFolder, "*.png");
+
+        using var collection = new MagickImageCollection();
+        foreach (var file in frames)
+        {
+            var image = new MagickImage(file);
+            image.Resize(width, height);
+            image.AnimationDelay = animationDelay;
+            collection.Add(image);
+        }
+
+        var settings = new QuantizeSettings { Colors = 256 };
+
+        _ = collection.Quantize(settings);
+        collection.OptimizeTransparency();
+        collection.Write(outputFile);
+    }
+}

--- a/src/Worms.Armageddon.Gifs/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Gifs/ServiceRegistration.cs
@@ -1,0 +1,11 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Worms.Armageddon.Gifs;
+
+[PublicAPI]
+public static class ServiceRegistration
+{
+    public static IServiceCollection AddWormsArmageddonGifsServices(this IServiceCollection builder) =>
+        builder.AddScoped<GifCreator>();
+}

--- a/src/Worms.Armageddon.Gifs/Worms.Armageddon.Gifs.csproj
+++ b/src/Worms.Armageddon.Gifs/Worms.Armageddon.Gifs.csproj
@@ -7,16 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0"/>
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.12.0"/>
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1"/>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7"/>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7"/>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Worms.Armageddon.Game\Worms.Armageddon.Game.csproj"/>
-    <ProjectReference Include="..\Worms.Armageddon.Files\Worms.Armageddon.Files.csproj"/>
-    <ProjectReference Include="..\Worms.Armageddon.Gifs\Worms.Armageddon.Gifs.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
+++ b/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
@@ -23,6 +23,6 @@ internal sealed class LocalGifCreator(GifCreator gifCreator, IWormsArmageddon wo
             parameters.StartOffset,
             parameters.EndOffset);
 
-        return new LocalGif(System.IO.Path.Combine(outputFolder, gifFileName));
+        return new LocalGif(Path.Combine(outputFolder, gifFileName));
     }
 }

--- a/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
+++ b/src/Worms.Cli.Resources/Local/Gifs/LocalGifCreator.cs
@@ -1,68 +1,28 @@
-using System.IO.Abstractions;
-using ImageMagick;
 using Worms.Armageddon.Game;
+using Worms.Armageddon.Gifs;
 
 namespace Worms.Cli.Resources.Local.Gifs;
 
-internal sealed class LocalGifCreator(IWormsArmageddon wormsArmageddon, IFileSystem fileSystem)
+internal sealed class LocalGifCreator(GifCreator gifCreator, IWormsArmageddon wormsArmageddon)
     : IResourceCreator<LocalGif, LocalGifCreateParameters>
 {
     public async Task<LocalGif> Create(LocalGifCreateParameters parameters, CancellationToken cancellationToken)
     {
         var replayPath = parameters.Replay.Paths.WAgamePath;
         var turn = parameters.Replay.Details.Turns.ElementAt((int) parameters.Turn - 1);
+        var outputFolder = wormsArmageddon.FindInstallation().CaptureFolder;
 
-        var replayName = fileSystem.Path.GetFileNameWithoutExtension(replayPath);
-        var worms = wormsArmageddon.FindInstallation();
-        var framesFolder = fileSystem.Path.Combine(worms.CaptureFolder, replayName);
-        var outputFileName = fileSystem.Path.Combine(
-            worms.CaptureFolder,
-            replayName + " - " + parameters.Turn + ".gif");
-
-        var animationDelay = 100 / parameters.FramesPerSecond / parameters.SpeedMultiplier;
-
-        DeleteFrames(framesFolder);
-        await wormsArmageddon.ExtractReplayFrames(
+        var gifFileName = await gifCreator.CreateGif(
             replayPath,
+            turn.Start,
+            turn.End,
+            (int) parameters.Turn,
+            outputFolder,
             parameters.FramesPerSecond,
-            turn.Start + parameters.StartOffset,
-            turn.End - parameters.EndOffset);
-        CreateGifFromFiles(framesFolder, outputFileName, animationDelay, 640, 480);
-        DeleteFrames(framesFolder);
+            parameters.SpeedMultiplier,
+            parameters.StartOffset,
+            parameters.EndOffset);
 
-        return new LocalGif(outputFileName);
-    }
-
-    private void DeleteFrames(string framesFolder)
-    {
-        if (fileSystem.Directory.Exists(framesFolder))
-        {
-            fileSystem.Directory.Delete(framesFolder, true);
-        }
-    }
-
-    private void CreateGifFromFiles(
-        string framesFolder,
-        string outputFile,
-        uint animationDelay,
-        uint width,
-        uint height)
-    {
-        var frames = fileSystem.Directory.GetFiles(framesFolder, "*.png");
-
-        using var collection = new MagickImageCollection();
-        foreach (var file in frames)
-        {
-            var image = new MagickImage(file);
-            image.Resize(width, height);
-            image.AnimationDelay = animationDelay;
-            collection.Add(image);
-        }
-
-        var settings = new QuantizeSettings { Colors = 256 };
-
-        _ = collection.Quantize(settings);
-        collection.OptimizeTransparency();
-        collection.Write(outputFile);
+        return new LocalGif(System.IO.Path.Combine(outputFolder, gifFileName));
     }
 }

--- a/src/Worms.Cli/Program.cs
+++ b/src/Worms.Cli/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Worms.Armageddon.Files;
 using Worms.Armageddon.Game;
+using Worms.Armageddon.Gifs;
 using Worms.Cli.Logging;
 using Worms.Cli.Resources;
 
@@ -30,6 +31,7 @@ internal static class Program
             .AddWormsCliLogging(GetLogLevel(args))
             .AddWormsArmageddonFilesServices()
             .AddWormsArmageddonGameServices()
+            .AddWormsArmageddonGifsServices()
             .AddWormsCliResourcesServices()
             .AddWormsCliServices()
             .AddSingleton<IConfiguration>(configuration);

--- a/src/Worms.Cli/Resources/Replays/ReplayTextPrinter.cs
+++ b/src/Worms.Cli/Resources/Replays/ReplayTextPrinter.cs
@@ -75,7 +75,7 @@ internal sealed class ReplayTextPrinter : IResourcePrinter<LocalReplay>
     private static string GetWeaponText(Weapon weapon)
     {
         var details = "";
-        var (name, fuse, modifier) = weapon;
+        var (name, _, fuse, modifier) = weapon;
         if (fuse != null && modifier != null)
         {
             details = $" ({fuse} sec, {modifier})";

--- a/src/Worms.Cli/Worms.Cli.csproj
+++ b/src/Worms.Cli/Worms.Cli.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Worms.Armageddon.Game\Worms.Armageddon.Game.csproj"/>
     <ProjectReference Include="..\Worms.Armageddon.Files\Worms.Armageddon.Files.csproj"/>
+    <ProjectReference Include="..\Worms.Armageddon.Gifs\Worms.Armageddon.Gifs.csproj"/>
     <ProjectReference Include="..\Worms.Cli.Resources\Worms.Cli.Resources.csproj"/>
   </ItemGroup>
 

--- a/src/Worms.Hub.Armageddon.Runner.Tests/ProcessReplayShould.cs
+++ b/src/Worms.Hub.Armageddon.Runner.Tests/ProcessReplayShould.cs
@@ -102,18 +102,18 @@ internal sealed class ProcessReplayShould
         logContent.ShouldContain("Exported with Version:");
         logContent.ShouldContain("Game Started at");
 
-        await TestContext.Progress.WriteLineAsync("Waiting for output queue message (GIF generation takes ~1 min per turn via Wine)...");
-        await PollUntil(async () => await _outputQueue.HasPendingMessage(), TimeSpan.FromMinutes(20));
+        await TestContext.Progress.WriteLineAsync("Waiting for output queue message (GIF generation for best turn via Wine)...");
+        await PollUntil(async () => await _outputQueue.HasPendingMessage(), TimeSpan.FromMinutes(5));
 
         var (outputMessage, _, _) = await _outputQueue.DequeueMessage();
         outputMessage.ShouldNotBeNull();
         outputMessage.ReplayFileName.ShouldBe(ReplayFileName);
 
-        // Verify GIFs were generated
+        // Verify GIF was generated for the best turn (most damage)
         outputMessage.TurnGifs.ShouldNotBeNull();
-        outputMessage.TurnGifs.ShouldNotBeEmpty();
+        outputMessage.TurnGifs.Count.ShouldBe(1);
 
-        await TestContext.Progress.WriteLineAsync($"Generated {outputMessage.TurnGifs.Count} turn GIFs.");
+        await TestContext.Progress.WriteLineAsync($"Generated GIF for turn {outputMessage.TurnGifs[0].TurnNumber}.");
 
         foreach (var turnGif in outputMessage.TurnGifs)
         {

--- a/src/Worms.Hub.Armageddon.Runner.Tests/ProcessReplayShould.cs
+++ b/src/Worms.Hub.Armageddon.Runner.Tests/ProcessReplayShould.cs
@@ -55,17 +55,25 @@ internal sealed class ProcessReplayShould
     }
 
     [SetUp]
-    public void CleanUpLogFile()
+    public void CleanUpGeneratedFiles()
     {
-        var logFile = Path.Combine(_replayFolder, Path.GetFileNameWithoutExtension(ReplayFileName) + ".log");
+        var replayName = Path.GetFileNameWithoutExtension(ReplayFileName);
+
+        var logFile = Path.Combine(_replayFolder, replayName + ".log");
         if (File.Exists(logFile))
         {
             File.Delete(logFile);
         }
+
+        // Clean up any generated GIF files
+        foreach (var gif in Directory.GetFiles(_replayFolder, "*.gif"))
+        {
+            File.Delete(gif);
+        }
     }
 
     [TearDown]
-    public void CleanUpLogFileAfter() => CleanUpLogFile();
+    public void CleanUpGeneratedFilesAfter() => CleanUpGeneratedFiles();
 
     [OneTimeTearDown]
     public async Task StopServices()
@@ -94,12 +102,33 @@ internal sealed class ProcessReplayShould
         logContent.ShouldContain("Exported with Version:");
         logContent.ShouldContain("Game Started at");
 
-        await TestContext.Progress.WriteLineAsync("Waiting for output queue message...");
-        await PollUntil(async () => await _outputQueue.HasPendingMessage(), TimeSpan.FromSeconds(10));
+        await TestContext.Progress.WriteLineAsync("Waiting for output queue message (GIF generation takes ~1 min per turn via Wine)...");
+        await PollUntil(async () => await _outputQueue.HasPendingMessage(), TimeSpan.FromMinutes(20));
 
         var (outputMessage, _, _) = await _outputQueue.DequeueMessage();
         outputMessage.ShouldNotBeNull();
         outputMessage.ReplayFileName.ShouldBe(ReplayFileName);
+
+        // Verify GIFs were generated
+        outputMessage.TurnGifs.ShouldNotBeNull();
+        outputMessage.TurnGifs.ShouldNotBeEmpty();
+
+        await TestContext.Progress.WriteLineAsync($"Generated {outputMessage.TurnGifs.Count} turn GIFs.");
+
+        foreach (var turnGif in outputMessage.TurnGifs)
+        {
+            turnGif.TurnNumber.ShouldBeGreaterThan(0);
+            turnGif.GifFileName.ShouldNotBeNullOrWhiteSpace();
+
+            var gifPath = Path.Combine(_replayFolder, turnGif.GifFileName);
+            File.Exists(gifPath).ShouldBeTrue($"GIF file should exist: {gifPath}");
+
+            var gifSize = new FileInfo(gifPath).Length;
+            gifSize.ShouldBeGreaterThan(1024, $"GIF for turn {turnGif.TurnNumber} should be larger than 1KB (was {gifSize} bytes)");
+
+            await TestContext.Progress.WriteLineAsync(
+                $"Turn {turnGif.TurnNumber}: {turnGif.GifFileName} ({gifSize / 1024}KB)");
+        }
     }
 
     private static string FindRepoRoot()

--- a/src/Worms.Hub.Armageddon.Runner/Processor.cs
+++ b/src/Worms.Hub.Armageddon.Runner/Processor.cs
@@ -88,34 +88,25 @@ internal sealed class Processor(
         var turnGifs = new List<TurnGif>();
         var replayFolder = GetReplayFolderPath();
         var turns = replayResource.Turns.ToList();
+        var bestTurn = turns
+            .Select((turn, index) => (Turn: turn, Index: index))
+            .MaxBy(x => x.Turn.Damage.Sum(d => d.HealthLost));
 
-        if (turns.Count > 0)
+        if (bestTurn != default)
         {
-            var bestTurnIndex = 0;
-            var bestDamage = 0u;
-            for (var i = 0; i < turns.Count; i++)
-            {
-                var totalDamage = turns[i].Damage.Aggregate(0u, (sum, d) => sum + d.HealthLost);
-                if (totalDamage > bestDamage)
-                {
-                    bestDamage = totalDamage;
-                    bestTurnIndex = i;
-                }
-            }
-
-            var turnNumber = bestTurnIndex + 1;
-            var bestTurn = turns[bestTurnIndex];
+            var turnNumber = bestTurn.Index + 1;
+            var totalDamage = bestTurn.Turn.Damage.Sum(d => d.HealthLost);
             logger.LogInformation(
                 "Selected turn {TurnNumber} for GIF generation ({Damage} total damage)",
                 turnNumber,
-                bestDamage);
+                totalDamage);
 
             try
             {
                 var gifFileName = await gifCreator.CreateGif(
                     replayPath,
-                    bestTurn.Start,
-                    bestTurn.End,
+                    bestTurn.Turn.Start,
+                    bestTurn.Turn.End,
                     turnNumber,
                     replayFolder);
 

--- a/src/Worms.Hub.Armageddon.Runner/Processor.cs
+++ b/src/Worms.Hub.Armageddon.Runner/Processor.cs
@@ -96,16 +96,28 @@ internal sealed class Processor(
         {
             var turnNumber = bestTurn.Index + 1;
             var totalDamage = bestTurn.Turn.Damage.Sum(d => d.HealthLost);
+
+            // Start the GIF 3 seconds before the first weapon was fired
+            var firstWeapon = bestTurn.Turn.Weapons.MinBy(w => w.Timestamp);
+            var gifStart = firstWeapon is not null
+                ? firstWeapon.Timestamp - TimeSpan.FromSeconds(3)
+                : bestTurn.Turn.Start;
+            if (gifStart < bestTurn.Turn.Start)
+            {
+                gifStart = bestTurn.Turn.Start;
+            }
+
             logger.LogInformation(
-                "Selected turn {TurnNumber} for GIF generation ({Damage} total damage)",
+                "Selected turn {TurnNumber} for GIF generation ({Damage} total damage, starting at {Start})",
                 turnNumber,
-                totalDamage);
+                totalDamage,
+                gifStart);
 
             try
             {
                 var gifFileName = await gifCreator.CreateGif(
                     replayPath,
-                    bestTurn.Turn.Start,
+                    gifStart,
                     bestTurn.Turn.End,
                     turnNumber,
                     replayFolder);

--- a/src/Worms.Hub.Armageddon.Runner/Processor.cs
+++ b/src/Worms.Hub.Armageddon.Runner/Processor.cs
@@ -84,19 +84,38 @@ internal sealed class Processor(
         var logText = await File.ReadAllTextAsync(logPath);
         var replayResource = replayTextReader.GetModel(logText);
 
-        // Generate GIFs for each turn
+        // Find the turn with the most total damage
         var turnGifs = new List<TurnGif>();
         var replayFolder = GetReplayFolderPath();
-        var turnNumber = 0;
-        foreach (var turn in replayResource.Turns)
+        var turns = replayResource.Turns.ToList();
+
+        if (turns.Count > 0)
         {
-            turnNumber++;
+            var bestTurnIndex = 0;
+            var bestDamage = 0u;
+            for (var i = 0; i < turns.Count; i++)
+            {
+                var totalDamage = turns[i].Damage.Aggregate(0u, (sum, d) => sum + d.HealthLost);
+                if (totalDamage > bestDamage)
+                {
+                    bestDamage = totalDamage;
+                    bestTurnIndex = i;
+                }
+            }
+
+            var turnNumber = bestTurnIndex + 1;
+            var bestTurn = turns[bestTurnIndex];
+            logger.LogInformation(
+                "Selected turn {TurnNumber} for GIF generation ({Damage} total damage)",
+                turnNumber,
+                bestDamage);
+
             try
             {
                 var gifFileName = await gifCreator.CreateGif(
                     replayPath,
-                    turn.Start,
-                    turn.End,
+                    bestTurn.Start,
+                    bestTurn.End,
                     turnNumber,
                     replayFolder);
 

--- a/src/Worms.Hub.Armageddon.Runner/Processor.cs
+++ b/src/Worms.Hub.Armageddon.Runner/Processor.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Worms.Armageddon.Files.Replays.Text;
 using Worms.Armageddon.Game;
+using Worms.Armageddon.Gifs;
 using Worms.Hub.Queues;
 
 namespace Worms.Hub.Armageddon.Runner;
@@ -8,9 +11,12 @@ internal sealed class Processor(
     IMessageQueue<ReplayToProcessMessage> inputQueue,
     IMessageQueue<ReplayToUpdateMessage> outputQueue,
     IWormsArmageddon wormsArmageddon,
+    IReplayTextReader replayTextReader,
+    GifCreator gifCreator,
     IConfiguration configuration,
     ILogger<Processor> logger)
 {
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types")]
     public async Task ProcessReplay()
     {
         logger.LogInformation("Starting replay processor...");
@@ -74,13 +80,42 @@ internal sealed class Processor(
             return;
         }
 
+        // Parse the log to get turn timings
+        var logText = await File.ReadAllTextAsync(logPath);
+        var replayResource = replayTextReader.GetModel(logText);
+
+        // Generate GIFs for each turn
+        var turnGifs = new List<TurnGif>();
+        var replayFolder = GetReplayFolderPath();
+        var turnNumber = 0;
+        foreach (var turn in replayResource.Turns)
+        {
+            turnNumber++;
+            try
+            {
+                var gifFileName = await gifCreator.CreateGif(
+                    replayPath,
+                    turn.Start,
+                    turn.End,
+                    turnNumber,
+                    replayFolder);
+
+                turnGifs.Add(new TurnGif(turnNumber, gifFileName));
+                logger.LogInformation("Generated GIF for turn {TurnNumber}: {GifFileName}", turnNumber, gifFileName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to generate GIF for turn {TurnNumber}", turnNumber);
+            }
+        }
+
         // Send a message to the replay updater queue
-        await outputQueue.EnqueueMessage(new ReplayToUpdateMessage(message.ReplayFileName));
+        await outputQueue.EnqueueMessage(new ReplayToUpdateMessage(message.ReplayFileName, turnGifs));
 
         // Delete the message from the queue
         await inputQueue.DeleteMessage(token);
 
-        logger.LogInformation("Replay processor finished.");
+        logger.LogInformation("Replay processor finished. Generated {GifCount} GIFs.", turnGifs.Count);
     }
 
     private bool GameIsInstalled()

--- a/src/Worms.Hub.Armageddon.Runner/ServiceRegistration.cs
+++ b/src/Worms.Hub.Armageddon.Runner/ServiceRegistration.cs
@@ -1,4 +1,6 @@
+using Worms.Armageddon.Files;
 using Worms.Armageddon.Game;
+using Worms.Armageddon.Gifs;
 using Worms.Hub.Queues;
 
 namespace Worms.Hub.Armageddon.Runner;
@@ -6,5 +8,9 @@ namespace Worms.Hub.Armageddon.Runner;
 internal static class ServiceRegistration
 {
     public static IServiceCollection AddReplayProcessorServices(this IServiceCollection builder) =>
-        builder.AddWormsArmageddonGameServices().AddQueueServices().AddScoped<Processor>();
+        builder.AddWormsArmageddonGameServices()
+            .AddWormsArmageddonFilesServices()
+            .AddWormsArmageddonGifsServices()
+            .AddQueueServices()
+            .AddScoped<Processor>();
 }

--- a/src/Worms.Hub.Armageddon.Runner/Worms.Hub.Armageddon.Runner.csproj
+++ b/src/Worms.Hub.Armageddon.Runner/Worms.Hub.Armageddon.Runner.csproj
@@ -16,7 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Worms.Armageddon.Files\Worms.Armageddon.Files.csproj"/>
     <ProjectReference Include="..\Worms.Armageddon.Game\Worms.Armageddon.Game.csproj"/>
+    <ProjectReference Include="..\Worms.Armageddon.Gifs\Worms.Armageddon.Gifs.csproj"/>
     <ProjectReference Include="..\Worms.Hub.Queues\Worms.Hub.Queues.csproj"/>
   </ItemGroup>
 

--- a/src/Worms.Hub.Queues/ReplayToUpdateMessage.cs
+++ b/src/Worms.Hub.Queues/ReplayToUpdateMessage.cs
@@ -3,4 +3,7 @@ using JetBrains.Annotations;
 namespace Worms.Hub.Queues;
 
 [PublicAPI]
-public record ReplayToUpdateMessage(string ReplayFileName);
+public record ReplayToUpdateMessage(string ReplayFileName, IReadOnlyList<TurnGif>? TurnGifs = null);
+
+[PublicAPI]
+public record TurnGif(int TurnNumber, string GifFileName);


### PR DESCRIPTION
## Summary
- Extracts GIF creation logic from the CLI into a new shared `Worms.Armageddon.Gifs` project, so both the CLI and wa-runner can reuse it
- The wa-runner now generates a GIF for the most impactful turn (highest total damage) after processing a replay, starting 3 seconds before the weapon was fired
- The `ReplayToUpdateMessage` is extended with an optional `TurnGifs` list containing turn numbers and GIF file paths
- Adds `Timestamp` to the `Weapon` record from the replay log parser
- Updates CI change detection to trigger wa-runner builds when the new dependencies change
- Updates the integration test to verify GIF generation with file size checks

## Test plan
- [x] `dotnet build --warnaserror` passes
- [x] All 299 unit tests pass
- [x] Integration test passes — generates a GIF for the best turn and verifies it exists with a sensible file size (>1KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)