### PR TITLE
Add CLAUDE.md and component agent-docs for Claude Code

### DIFF
--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,54 @@
+---
+description: Refresh CLAUDE.md and the docs under .claude/docs/ to match the current codebase
+---
+
+You are auditing and updating the project's Claude-facing documentation so it reflects the current state of the code. The docs in scope:
+
+- `CLAUDE.md` — top-level orientation (what this is, build, local dev, links to other docs)
+- `.claude/docs/components/*.md` — one per component, covering the internals of that component
+- `.claude/docs/steering/architecture.md` — high-level overview of components and how they fit together
+- `.claude/docs/steering/coding-guidelines.md` — cross-cutting conventions
+- `.claude/docs/steering/testing-strategy.md` — testing tiers and what goes where
+
+## Approach
+
+Treat this as a full regeneration of the docs from the current codebase, not a diff-based update. The codebase is the source of truth — the existing docs are a hint about structure and tone, nothing more. If the docs were deleted, this command should be able to re-derive them from scratch. Do not rely on `git log` or `git diff` to decide what to check; you must inspect the actual source.
+
+## What to do
+
+1. **Survey the codebase end-to-end.** Build your own picture of what exists today before opening any doc:
+   - Enumerate every project: `src/**/*.csproj`, `deployment/**/*.csproj`, plus the solution file.
+   - For each project, identify its purpose by reading the entry points and public surface (`Program.cs`, `ServiceRegistration.cs`, top-level public types).
+   - Map the inter-project dependency graph from `<ProjectReference>` entries.
+   - Read `Directory.Build.props`, `.editorconfig`, `Worms.sln`, and every root-level `*.props` / `*.targets` / `global.json` that influences build behaviour.
+   - Read every `makefile` under `build/` and every `Dockerfile` / `docker-bake.hcl` / `docker-compose*.yml`.
+   - Read every `appsettings*.json` and capture the config keys / connection strings / env-var bindings each component reads.
+   - Identify all queues, message types, HTTP routes, CLI verbs, and external integrations (Slack, Auth0/JWT authority, Azure services, Cloudflare, Pulumi providers).
+   - Identify the test projects, their categories, and what infrastructure their integration tests stand up.
+
+2. **Now read the existing docs in scope** to see how the project has chosen to describe itself, then for each doc:
+   - List every concrete claim it makes.
+   - Verify the claim against your survey from step 1. Anything you can't substantiate from the current code is wrong, even if it was true once.
+   - Identify gaps: things present in the codebase that warrant mention but aren't in the doc.
+
+3. **Update each doc.** Make the smallest edit that makes the doc both accurate and complete for its tier. When something has been removed from the code, remove it from the docs — do not leave "previously this lived in X" historical notes (git is authoritative for history). When something new exists in the code, add it where it belongs based on the tier (steering vs component).
+
+4. **Sanity-check** that the set of component docs still covers all source projects, and that CLAUDE.md's component table lists each component doc exactly once.
+
+## Rules
+
+- **No file paths or line numbers in steering docs** (`architecture.md`, `coding-guidelines.md`, `testing-strategy.md`). Steering docs are high-level and must not rot when files move. Component docs may reference type names but should avoid line numbers.
+- **No version numbers in CLAUDE.md or steering docs** (no "PostgreSQL 17", no ".NET 10.0.x", no "NUnit 4.6"). Versions belong in csproj / Dockerfile / `Directory.Build.props` and the docs should defer to those. Component docs may name a major framework (e.g. "ASP.NET Core") but not a minor version.
+- **Don't duplicate content across tiers.** If something is in a component doc, the steering docs should not repeat it. If something is in the coding-guidelines, individual component docs should not repeat it. When you find duplication, keep it in the most specific applicable doc and remove it from the others.
+- **Don't reference PRs, issue numbers, or commit hashes** in any doc — they rot.
+- **Don't add docs the user didn't ask for.** Update existing files; do not create new component or steering docs unless the user explicitly requests one.
+- **Preserve voice and structure.** Match the tone of the existing docs (concise, present-tense, declarative). Don't rewrite a doc that's still accurate just to "improve" it.
+
+## Output
+
+When you're done, report:
+- A bullet list of files changed and the substantive change in each (one line per file).
+- Any drift you noticed but deliberately did NOT fix, with a one-line reason.
+- Anything ambiguous that needs the user's input before you can confidently edit.
+
+Do not commit. The user will review and commit themselves.

--- a/.claude/docs/components/armageddon-files.md
+++ b/.claude/docs/components/armageddon-files.md
@@ -1,0 +1,68 @@
+# Armageddon Files Component
+
+Project: `Worms.Armageddon.Files`
+
+Parses and writes Worms Armageddon file formats. Has no external dependencies beyond `Syroot.Worms.Armageddon` (scheme binary format) and standard .NET libraries.
+
+## Scheme files
+
+Two representations of a scheme:
+
+- **Binary (`.wsc`)** — read/written via `IWscReader` / `IWscWriter` wrapping `Syroot.Worms.Armageddon.Scheme`. Note: the upstream library has a known bug where `FiringPausesTimer` defaults to `false` for `SchemeVersion.Version1`; `WscReader` corrects this.
+- **Text** — human-readable format read/written via `ISchemeTextReader` / `ISchemeTextWriter` in `Schemes/Text/`.
+
+`IRandomSchemeGenerator` generates random scheme settings within legal bounds.
+
+## Replay parsing
+
+Replays are parsed from the WA text log (`.log` sidecar file) via a pipeline of `IReplayLineParser` implementations:
+
+| Parser | Matches |
+|---|---|
+| `StartTimeParser` | Game start date/time |
+| `TeamParser` | Team names, machines, colours |
+| `WinnerParser` | Winner announcement line |
+| `StartOfTurnParser` | Turn start timestamp |
+| `WeaponUsedParser` | Weapon fired lines |
+| `DamageParser` | Damage dealt lines |
+| `EndOfTurnParser` | Turn end timestamp |
+
+`ReplayTextReader` iterates lines, asks each registered parser `CanParse(line)`, and calls `Parse(line, builder)` on matches. Multiple parsers can match the same line.
+
+`ReplayResourceBuilder` accumulates the parsed data and builds the final `ReplayResource` record. `TurnBuilder` tracks per-turn state (`WithStartTime`, `WithEndTime`, `WithDamage`, etc.).
+
+### Adding a new parser
+
+1. Implement `IReplayLineParser` with a `[GeneratedRegex]`-based `CanParse` and a `Parse` that mutates the builder.
+2. Register it in `ServiceRegistration.AddWormsArmageddonFilesServices()` as `AddScoped<IReplayLineParser, NewParser>()`.
+
+## Domain model (Replays)
+
+```
+ReplayResource
+├── DateTime Date
+├── bool Processed
+├── IReadOnlyCollection<Team> Teams
+├── string Winner
+├── string FullLog
+└── IReadOnlyCollection<Turn> Turns
+    └── Turn
+        ├── TimeSpan Start / End
+        ├── Team Team
+        ├── IReadOnlyCollection<Weapon> Weapons
+        └── IReadOnlyCollection<Damage> Damage
+```
+
+All types are `record`s with `[PublicAPI]` (JetBrains annotation, used by ReSharper to suppress unused-member warnings since these are consumed externally).
+
+## Replay filename parsing
+
+`IReplayFilenameParser` / `ReplayFilenameParser` extracts metadata (date, player names) from the WA replay filename convention.
+
+## Regex style
+
+Parsers use C# 9+ `[GeneratedRegex]` source-generated regexes (`partial class` with `partial static Regex Xxx()` method). This avoids runtime regex compilation overhead, which matters for files processing many replay log lines.
+
+## Testing
+
+`Worms.Armageddon.Files.Tests` uses NUnit + Shouldly. Tests are round-trip tests (write then read, verify no data loss) and snapshot tests against known `TestSchemes` data. No mocking — tests use real service registrations via `new ServiceCollection().AddWormsArmageddonFilesServices()`.

--- a/.claude/docs/components/armageddon-game.md
+++ b/.claude/docs/components/armageddon-game.md
@@ -1,0 +1,57 @@
+# Armageddon Game Component
+
+Projects: `Worms.Armageddon.Game`, `Worms.Armageddon.Game.Fake`
+
+Abstracts over launching and interacting with the Worms Armageddon game process. Platform-specific implementations are selected at DI registration time.
+
+## IWormsArmageddon
+
+The primary interface consumed by the CLI and WA Runner:
+
+```csharp
+GameInfo FindInstallation();
+Task Host();
+Task GenerateReplayLog(string replayPath);
+Task PlayReplay(string replayPath);
+Task PlayReplay(string replayPath, TimeSpan startTime);
+Task ExtractReplayFrames(string replayPath, uint fps, TimeSpan start, TimeSpan end, int xRes = 640, int yRes = 480);
+```
+
+`WormsArmageddon` delegates each call to `IWormsRunner` (launches the game process with the right CLI arguments) and `IWormsLocator` (finds the game installation).
+
+## Platform split
+
+`ServiceRegistration.AddWormsArmageddonGameServices()` detects the OS at startup:
+
+- **Windows** → `WormsLocator` (reads registry via `IRegistry`), `SteamService`, and either `WormsRunner` or `WormsRunner2` (toggled by `WORMS_TOGGLE_NEW_WA_RUNNER=false`)
+- **Linux** → `Linux.WormsLocator` and `Linux.WormsRunner` (used in the Docker WA runner, runs via Wine)
+
+`IProcessRunner` / `IProcess` wrap `System.Diagnostics.Process` for testability. `IFileVersionInfo` wraps `System.Diagnostics.FileVersionInfo` similarly.
+
+## GameInfo
+
+```csharp
+record GameInfo(bool IsInstalled, string ExeLocation, string CaptureFolder)
+```
+
+`CaptureFolder` is where WA saves extracted replay frames (`.png` files). `GifCreator` reads from this path after calling `ExtractReplayFrames`.
+
+## WA command-line arguments
+
+| Operation | Args |
+|---|---|
+| Host game | `wa://` |
+| Generate replay log | `/getlog "<replayPath>" /quiet` |
+| Play replay | `/play "<replayPath>" /quiet` |
+| Play from offset | `/playat "<replayPath>" <time> /quiet` |
+| Extract frames | `/getvideo "<replayPath>" <fps> <start> <end> <w> <h> /quiet` |
+
+Time format for `/getvideo` and `/playat` is `hh\:mm\:ss\.ff`.
+
+## Worms.Armageddon.Game.Fake
+
+A test double for `IWormsArmageddon`. Used in unit tests where a real WA installation is not available. Implement any fakes here rather than using mocking libraries.
+
+## Worms.Armageddon.Game.Tests
+
+Tests for game discovery and runner logic. Run with `dotnet test src/Worms.Armageddon.Game.Tests`. Uses NUnit + NSubstitute for mocking `IRegistry` and other Windows-specific dependencies.

--- a/.claude/docs/components/armageddon-gifs.md
+++ b/.claude/docs/components/armageddon-gifs.md
@@ -1,0 +1,54 @@
+# Armageddon Gifs Component
+
+Projects: `Worms.Armageddon.Gifs`, `Worms.Armageddon.Gifs.Tests`
+
+Generates GIF animations from Worms Armageddon replays.
+
+## GifCreator
+
+```csharp
+Task<string> CreateGif(
+    string replayPath,
+    TimeSpan turnStart,
+    TimeSpan turnEnd,
+    int turnNumber,
+    string outputFolder,
+    uint framesPerSecond = 5,
+    uint speedMultiplier = 2,
+    TimeSpan? startOffset = null,
+    TimeSpan? endOffset = null)
+```
+
+Returns the filename (not the full path) of the generated GIF.
+
+### Process
+
+1. Computes `framesFolder` from `GameInfo.CaptureFolder` (where WA deposits extracted PNGs)
+2. Deletes any existing frames in that folder
+3. Calls `IWormsArmageddon.ExtractReplayFrames(...)` — this runs WA with `/getvideo` to dump PNG frames
+4. Assembles frames into a GIF using **ImageMagick** (`MagickImageCollection`)
+5. Quantises to 256 colours and optimises transparency
+6. Deletes the frame folder
+
+If WA produces no frames (no folder, or folder with zero PNGs), `GifCreator` throws `GifFrameExtractionFailedException` carrying the `ReplayPath` and `FramesFolder`. Callers (e.g. the WA Runner `Processor`) log the exception and continue — GIF generation is non-fatal to replay processing.
+
+### GIF settings
+
+- Frames are resized to 640×480
+- `animationDelay = 100 / framesPerSecond / speedMultiplier` (in hundredths of a second, ImageMagick units)
+- Default: 5 fps × 2× speed = 10 fps effective playback
+
+## Dependencies
+
+- `Magick.NET-Q8-AnyCPU` (ImageMagick .NET binding) — used for frame assembly
+- `IWormsArmageddon` — for frame extraction
+- `IFileSystem` (System.IO.Abstractions) — for testable file operations
+
+## Turn selection (in WA Runner)
+
+`GifCreator` itself only assembles a GIF from given time bounds. Turn selection logic lives in `Worms.Hub.Armageddon.Runner/Processor.cs`:
+
+- Finds the turn with the maximum total damage (`Damage.Sum(d => d.HealthLost)`)
+- GIF starts 3 seconds before the first weapon fired in that turn (clamped to turn start)
+- GIF ends at turn end
+- If GIF creation fails, the error is logged and processing continues (non-fatal)

--- a/.claude/docs/components/cli.md
+++ b/.claude/docs/components/cli.md
@@ -1,0 +1,59 @@
+# CLI Component
+
+Projects: `Worms.Cli`, `Worms.Cli.Resources`
+
+## Command structure
+
+Commands are wired in `CliStructure.BuildCommandLine()`. The structure follows a kubectl-style resource verb model:
+
+```
+worms auth
+worms host
+worms version
+worms update
+worms get <scheme|replay|game>
+worms delete <scheme|replay>
+worms create <scheme|gif>
+worms browse <scheme|replay|gif>
+worms view <replay>
+worms process <replay>
+```
+
+Each resource sub-command lives in its own file at `Commands/Resources/<ResourceType>/<Verb><ResourceType>.cs`. The file contains two types:
+
+- `<Verb><ResourceType> : Command` — declares the command name, aliases, arguments and options
+- `<Verb><ResourceType>Handler : AsynchronousCommandLineAction` — the execution logic, injected via DI
+
+Handlers are registered in `ServiceRegistration.AddWormsCliServices()` and resolved via `IServiceProvider` when the command is invoked. No handler is ever instantiated until its command runs.
+
+## Adding a new command
+
+1. Create a `Command` subclass + `AsynchronousCommandLineAction` subclass in the appropriate `Commands/Resources/<Type>/` folder.
+2. Register the handler in `Worms.Cli/ServiceRegistration.cs`.
+3. Wire it under the correct verb group in `CliStructure.BuildCommandLine()`.
+
+## Resource printing
+
+Output goes through `IResourcePrinter<T>` implementations (e.g. `SchemeTextPrinter`, `ReplayTextPrinter`, `GameTextPrinter`). Table formatting uses `TableBuilder` / `TablePrinter` in `Logging/TableOutput/`. Column widths adapt to `Console.WindowWidth` (fallback 80).
+
+## Worms.Cli.Resources
+
+Provides all HTTP-facing services used by the CLI:
+
+- `IWormsServerApi` — typed HTTP client for the hub gateway (games, replays, schemes, CLI files, league)
+- Auth via device flow: `ILoginService`, `IAccessTokenRefreshService` — tokens stored with DPAPI via `TokenStore` at `%LOCALAPPDATA%/Programs/Worms/tokens.json`
+- `IRemoteLeagueRetriever`, `IRemoteSchemeDownloader`, `ICliUpdateDownloader` for specific hub operations
+
+This project targets `EnableTrimAnalyzer`, `EnableSingleFileAnalyzer`, `EnableAotAnalyzer` because it ships inside the self-contained CLI binary. Avoid reflection-based serialisation — use `JsonContext` (source-generated `JsonSerializerContext`) for any new JSON types.
+
+## DI registration pattern
+
+Each `ServiceRegistration` extension follows the same pattern: a single `Add*Services(this IServiceCollection builder)` extension method that returns `IServiceCollection`, registered as `Scoped` unless there is a concrete reason for `Singleton`.
+
+## Logging
+
+All output goes to stderr via `ColorFormatter`. Use `ILogger<T>` in handlers; do not write to `Console` directly except for actual command output (i.e. the table of resources). Verbosity is controlled by `-v`/`-q` flags parsed in `Program.GetLogLevel()`.
+
+## Telemetry
+
+OpenTelemetry traces are started in `Program.Main` before DI setup. Each significant operation gets a span tag via `Activity.Current?.SetTag(...)`. Span names are constants in the `Telemetry` class.

--- a/.claude/docs/components/cli.md
+++ b/.claude/docs/components/cli.md
@@ -41,8 +41,9 @@ Output goes through `IResourcePrinter<T>` implementations (e.g. `SchemeTextPrint
 Provides all HTTP-facing services used by the CLI:
 
 - `IWormsServerApi` — typed HTTP client for the hub gateway (games, replays, schemes, CLI files, league)
-- Auth via device flow: `ILoginService`, `IAccessTokenRefreshService` — tokens stored with DPAPI via `TokenStore` at `%LOCALAPPDATA%/Programs/Worms/tokens.json`
-- `IRemoteLeagueRetriever`, `IRemoteSchemeDownloader`, `ICliUpdateDownloader` for specific hub operations
+- Auth via device flow: `ILoginService` (`DeviceCodeLoginService`), `IAccessTokenRefreshService`, `IUserDetailsService` — tokens are encrypted via ASP.NET Core Data Protection and persisted by `TokenStore` under `Environment.SpecialFolder.LocalApplicationData` at `Programs/Worms/tokens.json`
+- `IRemoteLeagueRetriever`, `IRemoteSchemeDownloader`, `IRemoteGameUpdater`, `ICliUpdateRetriever`, `ICliUpdateDownloader` for specific hub operations
+- A platform-specific `IFolderOpener` and `ICliUpdateDownloader` are registered at startup based on `RuntimeInformation.IsOSPlatform`
 
 This project targets `EnableTrimAnalyzer`, `EnableSingleFileAnalyzer`, `EnableAotAnalyzer` because it ships inside the self-contained CLI binary. Avoid reflection-based serialisation — use `JsonContext` (source-generated `JsonSerializerContext`) for any new JSON types.
 

--- a/.claude/docs/components/hub-gateway.md
+++ b/.claude/docs/components/hub-gateway.md
@@ -1,0 +1,73 @@
+# Hub Gateway Component
+
+Project: `Worms.Hub.Gateway`
+
+## Operating modes
+
+The single binary can run in different modes controlled by `WORMS_`-prefixed environment variables. `Program.cs` reads these at startup:
+
+| Env var | Value | Effect |
+|---|---|---|
+| `WORMS_HUB_DISTRIBUTED` | `true` | Enable distributed mode (gateway and worker run separately) |
+| `WORMS_HUB_GATEWAY` | `true` | Run the HTTP API (requires `HUB_DISTRIBUTED=true`) |
+| `WORMS_HUB_WORKER` | `true` | Run the queue consumer (requires `HUB_DISTRIBUTED=true`) |
+| `WORMS_BATCH` | `true` | Process one replay message then exit |
+
+Without `HUB_DISTRIBUTED`, both gateway and worker run in the same process (monolith).
+
+## API controllers
+
+All controllers inherit `V1ApiController` which sets:
+- `[ApiVersion("1.0")]`
+- Route: `api/v{version:apiVersion}/[controller]`
+- `[Authorize(Roles = "access")]`
+
+Controllers are declared `internal sealed`. `InternalControllerProvider` overrides `ControllerFeatureProvider.IsController()` to detect them by `[ApiController]` attribute rather than public visibility.
+
+Versioning uses `Microsoft.AspNetCore.Mvc.Versioning` (`AddApiVersioning()`).
+
+## Auth
+
+JWT Bearer (Auth0-style) via `Microsoft.AspNetCore.Authentication.JwtBearer`. The CLI authenticates against the same authority via device flow. Config keys:
+
+```
+WORMS_AUTH__AUTHORITY
+WORMS_AUTH__AUDIENCE
+WORMS_AUTH__NAMECLAIM
+WORMS_AUTH__PERMISSIONSCLAIM
+```
+
+In development (`ASPNETCORE_ENVIRONMENT=Development`), `MapControllers()` is called without the `.RequireAuthorization()` default override — but the `[Authorize]` attribute on the base controller still applies unless explicitly commented out.
+
+## Announcers
+
+`IAnnouncer` has two methods: `AnnounceGameStarting(hostName)` and `AnnounceGameComplete(winner)`. The only implementation is `SlackAnnouncer` which POSTs to a Slack incoming webhook configured as `WORMS_SLACKWEBHOOKURL`. In DEBUG builds the `<!here>` mention is stripped to avoid noisy notifications during development.
+
+## Worker (queue consumer)
+
+`CheckForMessagesService` is an `IHostedService` that polls the queue. `Processor` (in `Worms.Hub.Gateway/Worker/`) handles the `replays-to-update` queue: it reads the log file, updates the DB, announces the winner, then deletes the message.
+
+Note: there is a separate `Worms.Hub.Armageddon.Runner` project with its own `Processor` that handles `replays-to-process` — these are distinct pipelines.
+
+## Replay processing flow
+
+End-to-end flow for a replay upload:
+
+1. CLI uploads a `.WAgame` file to the gateway (`ReplaysController`)
+2. Gateway stores the file and enqueues a `ReplayToProcessMessage` on `replays-to-process`
+3. WA Runner dequeues it, runs the game to extract the log and GIFs, then enqueues a `ReplayToUpdateMessage` on `replays-to-update`
+4. Gateway worker (`CheckForMessagesService` → `Worker/Processor`) dequeues, reads the log, updates the DB, announces the winner to Slack
+
+## Service registration
+
+`ServiceRegistration` in the Gateway project provides two extension methods:
+- `AddGatewayServices()` — registers `IAnnouncer`, validators, HTTP client
+- `AddWorkerServices()` — registers its `Processor`, plus pulls in Storage, Queue, Files, and Announcer services
+
+## Configuration
+
+All config is read via `IConfiguration`. Connection strings use the `ConnectionStrings:*` section (e.g. `ConnectionStrings:Storage`, `ConnectionStrings:Database`). Storage folder paths use `Storage:*` (e.g. `Storage:TempReplayFolder`, `Storage:CliFolder`, `Storage:SchemesFolder`, `Storage:GameFolder`).
+
+## Telemetry
+
+OpenTelemetry is configured via `AddOpenTelemetryWormsHub()` (extension in `Telemetry.cs`). Spans use `ActivityKind.Server` for HTTP handling and `ActivityKind.Consumer` for queue processing.

--- a/.claude/docs/components/hub-queues.md
+++ b/.claude/docs/components/hub-queues.md
@@ -1,0 +1,49 @@
+# Hub Queues Component
+
+Project: `Worms.Hub.Queues`
+
+## IMessageQueue<T>
+
+The core abstraction for Azure Storage Queues:
+
+```csharp
+Task<bool> HasPendingMessage();
+Task EnqueueMessage(T message);
+Task<(T?, MessageDetails?, ActivityContext)> DequeueMessage();
+Task DeleteMessage(MessageDetails messageDetails);
+```
+
+`DequeueMessage` returns a tuple of `(payload, token, activityContext)`. The caller must call `DeleteMessage(token)` after successfully processing a message — this is the Azure Storage Queue visibility pattern (messages become visible again if not deleted within the visibility timeout).
+
+## Message types
+
+| Type | Queue name | Direction |
+|---|---|---|
+| `ReplayToProcessMessage(string ReplayFileName)` | `replays-to-process` | Gateway → WA Runner |
+| `ReplayToUpdateMessage(string ReplayFileName, List<TurnGif> TurnGifs)` | `replays-to-update` | WA Runner → Gateway Worker |
+
+## Adding a new message type
+
+1. Add a `record` message type in `Worms.Hub.Queues`.
+2. Create a concrete `MessageQueue<T>` subclass that passes the queue name (e.g. `internal sealed class ReplaysToUpdate(IConfiguration configuration) : MessageQueue<ReplayToUpdateMessage>("replays-to-update", configuration);`).
+3. Register the new `IMessageQueue<NewMessage>` in `ServiceRegistration.AddQueueServices()`.
+
+## Wire format
+
+Messages are serialised as JSON, wrapped in a dictionary with a `"payload"` key plus W3C trace context headers (`traceparent`, `tracestate`) for OpenTelemetry propagation. The dictionary is then JSON-serialised again and base64-encoded for Azure Storage Queue compatibility.
+
+## OpenTelemetry propagation
+
+`MessageQueue<T>` uses `TraceContextPropagator` to:
+- **Inject** the current `Activity.Context` into the message when enqueuing
+- **Extract** the parent context from the message when dequeuing, then continue the trace with `ActivityKind.Consumer`
+
+This allows distributed traces to span across queue boundaries between the gateway and the WA runner.
+
+## Connection string
+
+All queue clients use `IConfiguration.GetConnectionString("Storage")`. In local dev this points to Azurite; in production it points to Azure Storage.
+
+## Local dev
+
+Azurite emulates Azure Storage Queues locally. The queue is created automatically (`CreateIfNotExistsAsync()`) on first use — no manual setup required. Azurite runs as part of `docker compose up`.

--- a/.claude/docs/components/hub-queues.md
+++ b/.claude/docs/components/hub-queues.md
@@ -20,7 +20,9 @@ Task DeleteMessage(MessageDetails messageDetails);
 | Type | Queue name | Direction |
 |---|---|---|
 | `ReplayToProcessMessage(string ReplayFileName)` | `replays-to-process` | Gateway → WA Runner |
-| `ReplayToUpdateMessage(string ReplayFileName, List<TurnGif> TurnGifs)` | `replays-to-update` | WA Runner → Gateway Worker |
+| `ReplayToUpdateMessage(string ReplayFileName, IReadOnlyList<TurnGif>? TurnGifs = null)` | `replays-to-update` | WA Runner → Gateway Worker |
+
+`TurnGif(int TurnNumber, string GifFileName)` is defined alongside the message and identifies the GIF the runner produced for a given turn.
 
 ## Adding a new message type
 

--- a/.claude/docs/components/hub-storage.md
+++ b/.claude/docs/components/hub-storage.md
@@ -1,0 +1,53 @@
+# Hub Storage Component
+
+Project: `Worms.Hub.Storage`
+
+## Domain models
+
+Domain objects are C# `record` types in `Domain/`:
+
+- `Game(string Id, string Status, string HostMachine)`
+- `Replay(string Id, string Name, string Status, string Filename, string? FullLog)`
+- `League(...)` and `CliInfo(...)` — supporting types
+
+Records use `with` expressions for updates. IDs come from the database and are stored as strings (parsed/formatted with `CultureInfo.InvariantCulture`).
+
+## Repository pattern
+
+`IRepository<T>` provides three operations:
+
+```csharp
+IReadOnlyCollection<T> GetAll();
+T Create(T item);
+void Update(T item);
+```
+
+Implementations (`GamesRepository`, `ReplaysRepository`) use **Dapper** + **Npgsql**. Each method creates a fresh `NpgsqlConnection` from `IConfiguration.GetConnectionString("Database")` — connections are not pooled at the application level (Npgsql handles connection pooling internally).
+
+SQL is written as inline string constants. Column names match exactly between SQL and the `[PublicAPI] record XxxDb(...)` mapping type defined at the bottom of each repository file. The DB record type is separate from the domain record to avoid Dapper's column mapping interfering with the domain model.
+
+## File storage classes
+
+File abstractions in `Files/` wrap filesystem operations and derive their paths from `IConfiguration`:
+
+| Class | Config key | Purpose |
+|---|---|---|
+| `ReplayFiles` | `Storage:TempReplayFolder` | Save uploaded replays, locate `.log` sidecars |
+| `SchemeFiles` | `Storage:SchemesFolder` | Read `.wsc` scheme files from disk |
+| `CliFiles` | `Storage:CliFolder` | Serve CLI binaries |
+| `GameFiles` | `Storage:GameFolder` | Access WA game files |
+
+`ReplayFiles.SaveFileContents()` writes the incoming stream to a randomly named file (via `Path.GetRandomFileName()`), creating the folder if needed. The generated filename is stored in the DB and used to locate the file later.
+
+`ReplayFiles.GetLogPath()` looks for a `.log` sidecar alongside the replay file (same name, different extension). Returns `null` if not found.
+
+## Service registration
+
+`AddHubStorageServices()` registers all repositories and file classes as `Scoped`.
+
+## Adding a new domain object
+
+1. Add a `record` in `Domain/`.
+2. Create a `XxxRepository : IRepository<Xxx>` in `Database/`, including an internal `XxxDb` record for Dapper mapping.
+3. Register in `ServiceRegistration.AddHubStorageServices()`.
+4. Add a migration in `src/database/migrations/` (Flyway versioned migration, e.g. `V0.3__AddXxx.sql`).

--- a/.claude/docs/components/infrastructure.md
+++ b/.claude/docs/components/infrastructure.md
@@ -1,0 +1,47 @@
+# Infrastructure Component
+
+Project: `deployment/Worms.Hub.Infrastructure`
+Solution: `deployment/Infrastructure.sln`
+
+Infrastructure-as-code using **Pulumi** (C#, net10.0) targeting Azure.
+
+## Stack configuration
+
+Two stacks defined in `Pulumi.*.yaml`:
+- `Pulumi.prod.yaml` — production
+- `Pulumi.test.yaml` — test/staging
+
+Key config values:
+- `azure-native:location: northeurope`
+- `worms-hub:domain: davideadie.dev`
+- `worms-hub:gateway-image: theeadie/worms-hub-gateway:<version>`
+- `worms-hub:wa-runner-image: theeadie/worms-hub-wa-runner:<version>`
+- `worms-hub:database-version: <flyway-version>`
+
+## Pulumi providers in use
+
+- `Pulumi.AzureNative` v2 — Azure resources
+- `Pulumi.Cloudflare` — DNS / CDN
+- `Pulumi.Command` — run commands as part of stack (e.g. database migrations)
+- `Pulumi.Random` — generate passwords/secrets
+
+## Deployment workflows
+
+CI/CD is managed by GitHub Actions:
+
+- `deploy-main.yml` — deploys to production on merge to main
+- `deploy-pr.yml` — deploys to test stack on PR
+
+Releases of the hub Docker images are handled by `zz-release-hub.yml`, which calls `make gateway.release` and `make wa-runner.release`. These push to Docker Hub (`theeadie/worms-hub-gateway`, `theeadie/worms-hub-wa-runner`) then update the Pulumi stack config with the new image version. Image versions are derived from git tags via `build/version.sh`.
+
+The `release-wormshub.sh` script handles deploying a new CLI version to the hub (uploads the binary to blob storage).
+
+## Database migrations
+
+Migrations are in `src/database/migrations/` as Flyway SQL files (versioned `V<x.y>__Description.sql`). The Pulumi stack applies migrations during deployment via `Pulumi.Command` calling the Flyway Docker image.
+
+Local dev seeds live in `src/database/local-dev/` — these run automatically in `docker compose up` via the `flyway-init` service but are not applied in CI or production.
+
+## Adding a new image version
+
+Update the `worms-hub:gateway-image` or `worms-hub:wa-runner-image` value in the appropriate `Pulumi.*.yaml` and run `pulumi up`. The release workflow does this automatically when triggered.

--- a/.claude/docs/components/infrastructure.md
+++ b/.claude/docs/components/infrastructure.md
@@ -3,7 +3,7 @@
 Project: `deployment/Worms.Hub.Infrastructure`
 Solution: `deployment/Infrastructure.sln`
 
-Infrastructure-as-code using **Pulumi** (C#, net10.0) targeting Azure.
+Infrastructure-as-code using **Pulumi** (C#) targeting Azure.
 
 ## Stack configuration
 
@@ -20,7 +20,7 @@ Key config values:
 
 ## Pulumi providers in use
 
-- `Pulumi.AzureNative` v2 — Azure resources
+- `Pulumi.AzureNative` — Azure resources
 - `Pulumi.Cloudflare` — DNS / CDN
 - `Pulumi.Command` — run commands as part of stack (e.g. database migrations)
 - `Pulumi.Random` — generate passwords/secrets

--- a/.claude/docs/components/wa-runner.md
+++ b/.claude/docs/components/wa-runner.md
@@ -1,0 +1,63 @@
+# WA Runner Component
+
+Project: `Worms.Hub.Armageddon.Runner`
+
+A .NET Worker Service that runs inside a Docker container and processes replay files using Worms Armageddon via Wine.
+
+## What it does
+
+Consumes messages from the `replays-to-process` queue, runs WA to extract the replay log and generate a GIF of the best turn, then publishes results to the `replays-to-update` queue.
+
+### Processing steps (Processor.ProcessReplay)
+
+1. Dequeue a `ReplayToProcessMessage` from `replays-to-process`
+2. Verify the replay file exists in `Storage:TempReplayFolder`
+3. Check WA is installed at `/root/.wine/drive_c/WA`; if not, copy from the `/game` volume mount
+4. Call `IWormsArmageddon.GenerateReplayLog(replayPath)` — runs `WA.exe /getlog ... /quiet` via Wine
+5. Parse the log with `IReplayTextReader`
+6. Select the turn with the highest total damage
+7. Attempt to generate a GIF for that turn via `GifCreator` (failure is logged but non-fatal)
+8. Enqueue a `ReplayToUpdateMessage` to `replays-to-update`
+9. Delete the input message from the queue
+
+## Wine integration
+
+The container uses Wine to run WA on Linux. Game files are expected at `/root/.wine/drive_c/WA`. On first run, if the game is not found there, the runner copies files from the `/game` volume mount (populated at container start).
+
+The `Linux.WormsRunner` implementation runs `wine WA.exe <args>` via `IProcessRunner`.
+
+## Docker image
+
+Built from `build/docker/wa-runner/Dockerfile`. The image includes Wine, libicu-dev, and other dependencies needed to run WA. The build uses `docker buildx bake`.
+
+Make targets:
+```bash
+make wa-runner.build    # build the image
+make wa-runner.package  # push to registry
+```
+
+## Integration test
+
+`Worms.Hub.Armageddon.Runner.Tests` contains a single `[Category("Integration")]` test (`ProcessReplayShould`) that:
+- Requires WA game files at `$WA_GAME_PATH` (or `/home/eadie/games/worms` by default)
+- Requires `sample-data/replays/sample.WAGame` to exist
+- Builds the Docker image and starts `hub-wa-runner` + `azure-storage` via `docker compose`
+- Enqueues a `ReplayToProcessMessage` and polls for a log file + output queue message (up to 5 minutes)
+
+Run with:
+```bash
+dotnet test src/Worms.Hub.Armageddon.Runner.Tests --filter Category=Integration
+```
+
+The test manages service lifecycle (`[OneTimeSetUp]` / `[OneTimeTearDown]`) — do not run alongside a live `docker compose up` stack.
+
+## Configuration
+
+| Config key | Purpose |
+|---|---|
+| `ConnectionStrings:Storage` | Azurite / Azure Storage Queue |
+| `Storage:TempReplayFolder` | Shared volume path for replay files |
+
+## Telemetry
+
+Spans use `ActivityKind.Consumer` with the parent context extracted from the queue message via W3C trace propagation (see hub-queues.md).

--- a/.claude/docs/components/wa-runner.md
+++ b/.claude/docs/components/wa-runner.md
@@ -39,7 +39,7 @@ make wa-runner.package  # push to registry
 ## Integration test
 
 `Worms.Hub.Armageddon.Runner.Tests` contains a single `[Category("Integration")]` test (`ProcessReplayShould`) that:
-- Requires WA game files at `$WA_GAME_PATH` (or `/home/eadie/games/worms` by default)
+- Requires a real WA installation mounted into the wa-runner container at `/game` (the `docker-compose.yaml` `hub-wa-runner` service mounts `${WA_GAME_PATH}` there — set `WA_GAME_PATH` to a local WA install)
 - Requires `sample-data/replays/sample.WAGame` to exist
 - Builds the Docker image and starts `hub-wa-runner` + `azure-storage` via `docker compose`
 - Enqueues a `ReplayToProcessMessage` and polls for a log file + output queue message (up to 5 minutes)

--- a/.claude/docs/steering/architecture.md
+++ b/.claude/docs/steering/architecture.md
@@ -1,0 +1,65 @@
+# Architecture
+
+A high-level overview of the components in this repo and how they fit together. For component internals (types, conventions, configuration) see the per-component docs under `.claude/docs/components/`.
+
+## What the system does
+
+The Worms League consists of two user-facing surfaces:
+
+- The **CLI** (`worms`) is what players run on their own machines. It authenticates them, hosts and joins games, manages local schemes, and uploads replays.
+- The **Hub** is a server-side system that ingests those replays, runs them headlessly to extract results and animated GIFs of key moments, records everything in a database, and announces winners to Slack.
+
+## Components
+
+The codebase is organised into three groups of components.
+
+### Shared Worms-domain libraries
+
+These wrap the Worms Armageddon game itself and its on-disk file formats. They have no knowledge of the hub or the CLI and are consumed by both.
+
+- **Armageddon Files** — reads and writes the WA file formats: replays (`.WAgame`) and schemes (`.wsc`). Pure file-format code with no process or network concerns.
+- **Armageddon Game** — abstraction over the WA executable: locating an installation, launching the game, and driving it to extract logs and frames from a replay. Has a `Fake` sibling project for tests so callers can avoid spawning a real WA process.
+- **Armageddon Gifs** — assembles animated GIFs from frames produced by Armageddon Game.
+
+### CLI
+
+The CLI is a self-contained executable shipped to players.
+
+- **Worms.Cli** — command-line entry point and command/handler wiring.
+- **Worms.Cli.Resources** — the typed HTTP client over the Hub Gateway, plus auth (device-flow login and token storage).
+
+The CLI uses the shared Armageddon libraries directly when it needs to launch the game locally or work with replay files on disk.
+
+### Hub
+
+The hub is one service that can run as a monolith or be split across multiple containers, plus a separate runner that hosts the actual game.
+
+- **Hub Gateway** — the ASP.NET Core HTTP API and the queue-consuming worker. Same binary, mode chosen by environment variables. The gateway is the only inbound HTTP surface for the CLI and is the component that announces results to Slack.
+- **Hub Storage** — repositories for the Postgres database and abstractions over Azure Blob Storage / local files. Used by everything in the hub that needs to persist or read state.
+- **Hub Queues** — Azure Storage Queue abstractions for the messages that flow between the gateway and the runner. Shared by both ends.
+- **WA Runner** — a worker service that runs Worms Armageddon inside a Docker image (under Wine on Linux) to replay games headlessly. It consumes work from a queue, calls the shared Armageddon Game and Gifs libraries to extract logs and GIFs, then publishes results back via another queue.
+
+### Infrastructure
+
+- **Worms.Hub.Infrastructure** — Pulumi (C#) program that provisions the Azure resources the hub runs on, plus Cloudflare DNS and Flyway database migrations.
+
+## How they fit together
+
+At a high level:
+
+- The CLI talks to the Hub Gateway over HTTPS using the typed client in Worms.Cli.Resources. Auth is JWT bearer; the CLI obtains tokens via device flow against the same authority the gateway validates against.
+- The Hub Gateway is the only component that accepts CLI traffic. It owns the database (via Hub Storage) and decides what work needs to be done downstream.
+- Long-running game work is handed off via Hub Queues. The gateway enqueues a "replay to process" message; the WA Runner picks it up, runs the game to produce a log and GIFs, then enqueues a "replay to update" message. The gateway's worker mode consumes that, persists the results, and announces the winner to Slack.
+- The CLI and the WA Runner both depend on the shared Armageddon libraries — the runner uses them to drive a headless WA inside its container; the CLI uses them when a player runs commands locally that touch real WA files or processes.
+- Hub Storage and Hub Queues are pure infrastructure abstractions: they hide whether the backing store is Azure (in production) or Azurite/Postgres-in-Docker (in local dev) so the rest of the hub doesn't care.
+
+## Deployment topology
+
+In production:
+
+- The CLI is distributed as a self-contained binary and runs on player machines.
+- Hub Gateway is deployed twice from the same image — once as the HTTP API, once as the queue worker — both in Azure Container Apps.
+- WA Runner is deployed as its own image, scaled separately because each instance needs to spin up Wine + WA.
+- Postgres and Azure Storage (blobs + queues) are managed Azure services, provisioned by the infrastructure project.
+
+In local development a single `docker compose up` brings up Azurite, Postgres, Flyway-applied migrations, and the hub services so the whole flow can run end-to-end against a local stack.

--- a/.claude/docs/steering/coding-guidelines.md
+++ b/.claude/docs/steering/coding-guidelines.md
@@ -1,0 +1,47 @@
+# Coding Guidelines
+
+Cross-cutting conventions that apply to every project in this repo. Component-specific patterns live in the relevant doc under `.claude/docs/components/`.
+
+## Build defaults
+
+`Directory.Build.props` enables for every project:
+
+- `Nullable=enable`, `ImplicitUsings=enable`
+- `AnalysisLevel=latest-All` plus `Roslynator.Analyzers`
+- `JetBrains.Annotations` (with `PrivateAssets="All"` — annotations only, no runtime dep)
+
+Treat warnings as errors. CI builds with `--warnaserror`; if a warning surfaces locally, fix it rather than suppressing it.
+
+## Visibility
+
+Default to `internal sealed` for new types. Promote to `public` only when the type is actually consumed from another assembly. Mark types that look unused but are wired up reflectively (e.g. via DI, JSON, attributes) with `[PublicAPI]`.
+
+## Records and immutability
+
+Use `record` for DTOs, queue messages, and value-like types. Prefer `IReadOnlyList<T>` / `IReadOnlyDictionary<,>` over the mutable interfaces in public-facing signatures.
+
+## Dependency injection
+
+Each project exposes a single `ServiceRegistration` static class with one `Add<Project>Services(this IServiceCollection)` extension that returns `IServiceCollection` to allow chaining. Register services as `Scoped` unless there is a specific reason to use `Singleton` or `Transient`. Higher-level projects pull in the `Add*Services` of the projects they depend on.
+
+## File system access
+
+Take a dependency on `System.IO.Abstractions` (`IFileSystem`) rather than calling `File`/`Directory` statics directly. This keeps file-touching code unit-testable with `MockFileSystem`.
+
+## Testing
+
+- Test projects are named `<ProjectUnderTest>.Tests` and use **NUnit**.
+- Test classes are named `<TypeUnderTest>Should` (e.g. `GifCreatorShould`, `ReplayTextReaderShould`); test methods describe a behaviour (e.g. `ThrowWhenNoFramesAreProduced`).
+- Tests that require external infrastructure (Docker, a real WA install, etc.) are tagged `[Category("Integration")]`. Unit runs use `--filter "Category!=Integration"`; integration runs use `--filter Category=Integration`.
+
+## Telemetry
+
+OpenTelemetry is used across the hub. New code that performs a meaningful unit of work should start an `Activity` from the project's `Telemetry.Source` and tag it with relevant identifiers (`Activity.Current?.SetTag(...)`) rather than logging the same data ad-hoc.
+
+## Formatting
+
+Enforced by `.editorconfig`:
+- 4-space indent, UTF-8, LF, trim trailing whitespace
+- 120-character line length
+- `using` directives sorted, `System.*` first, no blank line between groups
+- Allman braces (new line before `{`, `catch`, `else`, `finally`)

--- a/.claude/docs/steering/testing-strategy.md
+++ b/.claude/docs/steering/testing-strategy.md
@@ -8,13 +8,15 @@ We have two test tiers, separated by NUnit category:
 
 ### Unit tests (default)
 
-Fast, in-process tests with no external dependencies. They cover:
+Fast, in-process tests with no external dependencies. The test projects that exist today cover:
 
 - File-format parsing and serialisation in the Armageddon Files library
-- Pure logic in the CLI, gateway, and queue/storage abstractions
+- Game-discovery and runner logic in the Armageddon Game library (with `NSubstitute` for OS-specific seams like the registry)
 - The Armageddon Gifs assembly logic, exercised against fixtures
 
 Unit tests use **NUnit** with **Shouldly** for assertions. They are the default `dotnet test` run and gate every PR via `make cli.test.unit` / equivalent.
+
+The CLI, hub gateway, queues, and storage projects do not currently have dedicated unit-test projects — behaviour at those layers is exercised indirectly via the integration tier and the libraries above. When adding meaningful logic at those layers, prefer adding a new `<Project>.Tests` rather than retrofitting the integration test.
 
 External dependencies are abstracted at the seam, not mocked at the call site:
 - File-system access goes through `System.IO.Abstractions` so unit tests use `MockFileSystem` instead of touching disk.

--- a/.claude/docs/steering/testing-strategy.md
+++ b/.claude/docs/steering/testing-strategy.md
@@ -1,0 +1,54 @@
+# Testing Strategy
+
+How tests are organised in this repo and what each tier is for. For naming and category conventions see [coding-guidelines.md](coding-guidelines.md); this doc covers the *strategy* — what we test, where, and why.
+
+## Tiers
+
+We have two test tiers, separated by NUnit category:
+
+### Unit tests (default)
+
+Fast, in-process tests with no external dependencies. They cover:
+
+- File-format parsing and serialisation in the Armageddon Files library
+- Pure logic in the CLI, gateway, and queue/storage abstractions
+- The Armageddon Gifs assembly logic, exercised against fixtures
+
+Unit tests use **NUnit** with **Shouldly** for assertions. They are the default `dotnet test` run and gate every PR via `make cli.test.unit` / equivalent.
+
+External dependencies are abstracted at the seam, not mocked at the call site:
+- File-system access goes through `System.IO.Abstractions` so unit tests use `MockFileSystem` instead of touching disk.
+- The Worms Armageddon process is abstracted by the Armageddon Game library, with a dedicated `Worms.Armageddon.Game.Fake` project providing a deterministic test double — units that orchestrate WA depend on the abstraction and are wired up against the fake in tests.
+
+### Integration tests (`Category=Integration`)
+
+These exercise real infrastructure end-to-end. They are excluded from the default unit run and selected with `--filter Category=Integration`. Currently the main one is the WA Runner integration test, which:
+
+- Builds the wa-runner Docker image
+- Starts Azurite via `docker compose`
+- Enqueues a real replay message
+- Waits for the runner to process the replay and produce an output message
+- Asserts on the resulting log/GIFs
+
+Integration tests have prerequisites (Docker available; in some cases a real Worms Armageddon installation on the host) and are slower than unit tests, so they are not part of the default local loop. They are intentionally not mocked — the value of the tier comes from running real Docker, real Azurite queues, and the real WA binary under Wine.
+
+The database is in the same bucket: prefer integration tests against a real Postgres (the one from `docker compose`) over mocking repositories. Mocks of the data layer have historically diverged from production behaviour and hidden migration bugs.
+
+## What to write where
+
+When adding a feature, default to **unit tests** for everything that can be exercised through abstractions. Reach for an **integration test** when:
+
+- The behaviour only exists when the real infrastructure is present (e.g. a queue message round-trips, a replay actually runs through Wine + WA, a migration applies cleanly to Postgres).
+- A unit test would require mocking so much that the test is really just asserting the mock setup.
+- You're verifying behaviour at a deployment boundary (image starts, env vars are read correctly, services compose).
+
+Don't duplicate: if a behaviour is meaningfully covered by a unit test, you don't owe it an integration test as well.
+
+## CI vs local
+
+- **CI** runs unit tests on every PR. Integration tests that need Docker/WA run on machines provisioned for it — don't add an integration test that only the author can run.
+- **Locally**, `dotnet test` (or the make targets) runs the unit suite. Integration tests are opt-in via the category filter so you don't accidentally pay the Docker startup cost on every change.
+
+## Fixtures and sample data
+
+Sample replays and schemes live under `sample-data/` and are committed to the repo. Tests should reference fixtures from that folder rather than generating ad-hoc binary blobs inline. Add a new fixture when the existing ones genuinely don't cover the case — don't fork an existing one for a one-character variation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Tooling and server infrastructure for a Worms Armageddon league. It consists of two main deliverables:
+
+- **`worms` CLI** — a cross-platform command-line tool players use to authenticate, host games, manage schemes and replays
+- **Worms Hub** — a server-side system (ASP.NET Core gateway + background worker + WA runner) that manages games, stores replays, and announces results to Slack
+
+## Build System
+
+The project uses `make` with separate makefiles per component included at the root level. There is no single root `Makefile` — targets come from `build/cli/makefile` and `build/docker/makefile`.
+
+### CLI
+
+```bash
+make cli.build          # dotnet build Worms.Cli
+make cli.test.unit      # dotnet test --filter "Category!=Integration"
+make cli.package.windows
+make cli.package.linux
+make cli.package.docker
+```
+
+Run a single test project directly:
+
+```bash
+dotnet test src/Worms.Armageddon.Files.Tests
+dotnet test src/Worms.Armageddon.Game.Tests
+dotnet test src/Worms.Hub.Armageddon.Runner.Tests --filter Category=Integration
+```
+
+### Hub (Docker)
+
+```bash
+make gateway.build      # docker buildx bake the gateway image
+make gateway.package
+make wa-runner.build
+make wa-runner.package
+```
+
+### Local Development Stack
+
+Docker Compose brings up: Azurite (Azure Storage emulator), PostgreSQL, Flyway migrations, hub-gateway, hub-worker, and hub-wa-runner.
+
+```bash
+docker compose up
+```
+
+Config is via `WORMS_`-prefixed environment variables (e.g. `WORMS_CONNECTIONSTRINGS__DATABASE`). Set `WA_GAME_PATH` to point at a local Worms Armageddon installation.
+
+Database migrations live in `src/database/migrations/` (Flyway). Local-dev seed data is in `src/database/local-dev/`.
+
+## Architecture
+
+For a high-level overview of the components and how they relate, see [.claude/docs/steering/architecture.md](.claude/docs/steering/architecture.md).
+
+## Coding Guidelines
+
+Cross-cutting conventions (visibility, DI, testing, telemetry, formatting) are documented in [.claude/docs/steering/coding-guidelines.md](.claude/docs/steering/coding-guidelines.md). Follow these for any new code.
+
+## Testing Strategy
+
+How the unit and integration tiers are organised, what to put where, and how they run in CI vs locally is covered in [.claude/docs/steering/testing-strategy.md](.claude/docs/steering/testing-strategy.md).
+
+## Component Docs
+
+Detailed practices for each component are in `.claude/docs/components/`. Load the relevant doc when working in that area:
+
+| Component | Doc | Projects |
+|---|---|---|
+| CLI | [.claude/docs/components/cli.md](.claude/docs/components/cli.md) | `Worms.Cli`, `Worms.Cli.Resources` |
+| Hub Gateway | [.claude/docs/components/hub-gateway.md](.claude/docs/components/hub-gateway.md) | `Worms.Hub.Gateway` |
+| Hub Storage | [.claude/docs/components/hub-storage.md](.claude/docs/components/hub-storage.md) | `Worms.Hub.Storage` |
+| Hub Queues | [.claude/docs/components/hub-queues.md](.claude/docs/components/hub-queues.md) | `Worms.Hub.Queues` |
+| WA Runner | [.claude/docs/components/wa-runner.md](.claude/docs/components/wa-runner.md) | `Worms.Hub.Armageddon.Runner` |
+| Armageddon Files | [.claude/docs/components/armageddon-files.md](.claude/docs/components/armageddon-files.md) | `Worms.Armageddon.Files` |
+| Armageddon Game | [.claude/docs/components/armageddon-game.md](.claude/docs/components/armageddon-game.md) | `Worms.Armageddon.Game`, `*.Fake` |
+| Armageddon Gifs | [.claude/docs/components/armageddon-gifs.md](.claude/docs/components/armageddon-gifs.md) | `Worms.Armageddon.Gifs` |
+| Infrastructure | [.claude/docs/components/infrastructure.md](.claude/docs/components/infrastructure.md) | `deployment/Worms.Hub.Infrastructure` |
+


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root as the orientation entry point for Claude Code (what this is, build commands, local dev stack, links to the rest)
- Adds a `.claude/docs/` tree split into **steering** (cross-cutting) and **components** (per-project)
- Adds a `/update-docs` slash command that audits and regenerates the docs from the codebase

## Layout

```
.claude/
  commands/
    update-docs.md             — slash command to refresh the docs from source
  docs/
    steering/
      architecture.md          — high-level component overview and how they relate
      coding-guidelines.md     — cross-cutting conventions (DI, visibility, tests, formatting)
      testing-strategy.md      — unit vs integration tiers, what goes where
    components/
      cli.md                   — Worms.Cli, Worms.Cli.Resources
      hub-gateway.md           — Worms.Hub.Gateway (HTTP API + worker)
      hub-storage.md           — Worms.Hub.Storage (Postgres, Blob, files)
      hub-queues.md            — Worms.Hub.Queues
      wa-runner.md             — Worms.Hub.Armageddon.Runner
      armageddon-files.md      — Worms.Armageddon.Files
      armageddon-game.md       — Worms.Armageddon.Game (+ Fake)
      armageddon-gifs.md       — Worms.Armageddon.Gifs
      infrastructure.md        — deployment/Worms.Hub.Infrastructure
CLAUDE.md                      — orientation + table of links into the above
```

## Doc rules established

- No version numbers in `CLAUDE.md` or steering docs (defer to csproj / Dockerfile / `Directory.Build.props`)
- No file paths or line numbers in steering docs — they must not rot when files move
- No PR / issue / commit references in any doc
- No duplication across tiers — each fact lives in its most specific applicable doc

The `/update-docs` command codifies these rules and treats the codebase as the source of truth, so the docs folder is reproducible from scratch.

## Test plan

- [ ] Open a fresh Claude Code session in this repo and confirm `CLAUDE.md` is picked up
- [ ] Run `/update-docs` against the current branch and confirm it makes no changes (docs already match the code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)