### PR TITLE
Fix wa-runner GIF generation failing with no frames

### DIFF
--- a/Worms.sln
+++ b/Worms.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.Armageddon.Runner
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Armageddon.Gifs", "src\Worms.Armageddon.Gifs\Worms.Armageddon.Gifs.csproj", "{C93E055E-2254-4CB4-AFDB-90315ED7960A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Armageddon.Gifs.Tests", "src\Worms.Armageddon.Gifs.Tests\Worms.Armageddon.Gifs.Tests.csproj", "{49C6C918-F9CE-4E18-9A07-426448C00F57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,18 @@ Global
 		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x64.Build.0 = Release|Any CPU
 		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x86.ActiveCfg = Release|Any CPU
 		{C93E055E-2254-4CB4-AFDB-90315ED7960A}.Release|x86.Build.0 = Release|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Debug|x64.Build.0 = Debug|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Debug|x86.Build.0 = Debug|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Release|x64.ActiveCfg = Release|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Release|x64.Build.0 = Release|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Release|x86.ActiveCfg = Release|Any CPU
+		{49C6C918-F9CE-4E18-9A07-426448C00F57}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -218,5 +232,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{03DA1FFD-7F36-4F68-B630-23DF642C7C6F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C93E055E-2254-4CB4-AFDB-90315ED7960A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{49C6C918-F9CE-4E18-9A07-426448C00F57} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -71,7 +71,7 @@ RUN xvfb-run sh -c '\
   && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v InfoTransparency /d 0x00000001 /f \
   && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v InfoSpy /d 0x00000001 /f \
   && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v DisableSmoothBackgroundGradient /d 0x00000000 /f \
-  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v HardwareRendering /d 0x00000001 /f \
+  && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v HardwareRendering /d 0x00000000 /f \
   && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v LargerFonts /d 0x00000000 /f \
   && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v AssistedVsync /d 0x00000000 /f \
   && wine reg add "HKEY_CURRENT_USER\Software\Team17SoftwareLTD\WormsArmageddon\Options" /t REG_DWORD /v Vsync /d 0x00000000 /f \

--- a/src/Worms.Armageddon.Gifs.Tests/GifCreatorShould.cs
+++ b/src/Worms.Armageddon.Gifs.Tests/GifCreatorShould.cs
@@ -1,0 +1,65 @@
+using System.IO.Abstractions.TestingHelpers;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Armageddon.Game;
+
+namespace Worms.Armageddon.Gifs.Tests;
+
+internal sealed class GifCreatorShould
+{
+    [Test]
+    public async Task ThrowFrameExtractionFailedWhenFramesFolderMissing()
+    {
+        var fileSystem = new MockFileSystem();
+        const string captureFolder = "/wa/Capture";
+        fileSystem.AddDirectory(captureFolder);
+
+        var wormsArmageddon = Substitute.For<IWormsArmageddon>();
+        wormsArmageddon.FindInstallation().Returns(GameInfoFor(captureFolder));
+
+        var gifCreator = new GifCreator(wormsArmageddon, fileSystem);
+
+        var exception = await Should.ThrowAsync<GifFrameExtractionFailedException>(
+            gifCreator.CreateGif(
+                "/storage/replay.gjb",
+                TimeSpan.FromSeconds(0),
+                TimeSpan.FromSeconds(10),
+                1,
+                "/storage/output"));
+
+        exception.ReplayPath.ShouldBe("/storage/replay.gjb");
+        exception.FramesFolder.ShouldBe("/wa/Capture/replay");
+    }
+
+    [Test]
+    public async Task ThrowFrameExtractionFailedWhenFramesFolderEmpty()
+    {
+        var fileSystem = new MockFileSystem();
+        const string framesFolder = "/wa/Capture/replay";
+        fileSystem.AddDirectory(framesFolder);
+
+        var wormsArmageddon = Substitute.For<IWormsArmageddon>();
+        wormsArmageddon.FindInstallation().Returns(GameInfoFor("/wa/Capture"));
+
+        var gifCreator = new GifCreator(wormsArmageddon, fileSystem);
+
+        await Should.ThrowAsync<GifFrameExtractionFailedException>(
+            gifCreator.CreateGif(
+                "/storage/replay.gjb",
+                TimeSpan.FromSeconds(0),
+                TimeSpan.FromSeconds(10),
+                1,
+                "/storage/output"));
+    }
+
+    private static GameInfo GameInfoFor(string captureFolder) =>
+        new(
+            true,
+            "/wa/WA.exe",
+            "WA",
+            new Version(3, 8),
+            "/wa/Schemes",
+            "/wa/Replays",
+            captureFolder);
+}

--- a/src/Worms.Armageddon.Gifs.Tests/Worms.Armageddon.Gifs.Tests.csproj
+++ b/src/Worms.Armageddon.Gifs.Tests/Worms.Armageddon.Gifs.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="5.3.0"/>
+    <PackageReference Include="NUnit" Version="4.5.1"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+    <PackageReference Include="Shouldly" Version="4.3.0"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Worms.Armageddon.Gifs\Worms.Armageddon.Gifs.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Worms.Armageddon.Gifs/GifCreator.cs
+++ b/src/Worms.Armageddon.Gifs/GifCreator.cs
@@ -31,7 +31,9 @@ public sealed class GifCreator(IWormsArmageddon wormsArmageddon, IFileSystem fil
 
         DeleteFrames(framesFolder);
         await wormsArmageddon.ExtractReplayFrames(replayPath, framesPerSecond, start, end);
-        CreateGifFromFiles(framesFolder, outputFilePath, animationDelay, 640, 480);
+
+        var frames = GetExtractedFrames(replayPath, framesFolder);
+        CreateGifFromFiles(frames, outputFilePath, animationDelay, 640, 480);
         DeleteFrames(framesFolder);
 
         return gifFileName;
@@ -45,15 +47,29 @@ public sealed class GifCreator(IWormsArmageddon wormsArmageddon, IFileSystem fil
         }
     }
 
-    private void CreateGifFromFiles(
-        string framesFolder,
+    private string[] GetExtractedFrames(string replayPath, string framesFolder)
+    {
+        if (!fileSystem.Directory.Exists(framesFolder))
+        {
+            throw new GifFrameExtractionFailedException(replayPath, framesFolder);
+        }
+
+        var frames = fileSystem.Directory.GetFiles(framesFolder, "*.png");
+        if (frames.Length == 0)
+        {
+            throw new GifFrameExtractionFailedException(replayPath, framesFolder);
+        }
+
+        return frames;
+    }
+
+    private static void CreateGifFromFiles(
+        string[] frames,
         string outputFile,
         uint animationDelay,
         uint width,
         uint height)
     {
-        var frames = fileSystem.Directory.GetFiles(framesFolder, "*.png");
-
         using var collection = new MagickImageCollection();
         foreach (var file in frames)
         {

--- a/src/Worms.Armageddon.Gifs/GifFrameExtractionFailedException.cs
+++ b/src/Worms.Armageddon.Gifs/GifFrameExtractionFailedException.cs
@@ -1,0 +1,33 @@
+namespace Worms.Armageddon.Gifs;
+
+public sealed class GifFrameExtractionFailedException : Exception
+{
+    public GifFrameExtractionFailedException()
+    {
+    }
+
+    public GifFrameExtractionFailedException(string message)
+        : base(message)
+    {
+    }
+
+    public GifFrameExtractionFailedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public GifFrameExtractionFailedException(string replayPath, string framesFolder)
+        : base(BuildMessage(replayPath, framesFolder))
+    {
+        ReplayPath = replayPath;
+        FramesFolder = framesFolder;
+    }
+
+    public string? ReplayPath { get; }
+
+    public string? FramesFolder { get; }
+
+    private static string BuildMessage(string replayPath, string framesFolder) =>
+        $"Worms Armageddon did not produce any frames in '{framesFolder}' for replay '{replayPath}'. "
+        + "Check the wa-runner logs for wine/WA stderr.";
+}

--- a/src/Worms.Armageddon.Gifs/GifFrameExtractionFailedException.cs
+++ b/src/Worms.Armageddon.Gifs/GifFrameExtractionFailedException.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace Worms.Armageddon.Gifs;
 
+[PublicAPI]
 public sealed class GifFrameExtractionFailedException : Exception
 {
     public GifFrameExtractionFailedException()


### PR DESCRIPTION
## Summary

First production run of wa-runner's GIF generator failed with `System.IO.DirectoryNotFoundException` from `GifCreator.CreateGifFromFiles` — WA.exe exited code 0 but didn't create the `Capture/<replay>` folder.

Wine logs showed `Failed to load libEGL.so.1` and a fallback to `llvmpipe`. The Dockerfile sets `HardwareRendering=1`, but the runtime image has no GPU/EGL stack — so WA's hardware path fails silently and produces no frames.

- **Root cause**: set `HardwareRendering=0` in `build/docker/wa-runner/Dockerfile` so WA uses software rendering (which is all the container can offer anyway).
- **Defensive**: `GifCreator` now validates the frames folder after `ExtractReplayFrames` and throws a dedicated `GifFrameExtractionFailedException` carrying the replay path + folder, instead of letting `Directory.GetFiles` throw a confusing I/O exception. The `Processor` catch-all already logs it.
- New `Worms.Armageddon.Gifs.Tests` project with unit tests covering the missing/empty frames folder cases.

## Test plan

- [x] `dotnet build --warnaserror` passes for `Worms.Armageddon.Gifs`, `Worms.Armageddon.Gifs.Tests`, `Worms.Hub.Armageddon.Runner`
- [x] New unit tests pass (2/2)
- [x] Existing integration test `ProcessReplayShould` still produces a >1KB GIF against a freshly built Docker image
- [ ] Re-run the failing replay (`fa4c545w.gjb`) through wa-runner in production and confirm a GIF for turn 2 is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)