### PR TITLE
Add EGL/Mesa libs to wa-runner image

### DIFF
--- a/build/docker/wa-runner/Dockerfile
+++ b/build/docker/wa-runner/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update \
   wget \
   gnupg \
   libicu-dev \
+  libegl1 \
+  libgl1-mesa-dri \
   && rm -rf /var/lib/apt/lists/*
 
 # Add Wine repo key and source


### PR DESCRIPTION
## Summary
- Install `libegl1` and `libgl1-mesa-dri` in the `wa-runner` runtime image so Wine's d3d path can initialise an OpenGL context during `/getvideo`.

## Why
GIF generation failed today with `GifFrameExtractionFailedException` — same symptom as #cd0f8659 (WA exits 0, zero frames). Stderr shows:

```
wgl:egl_init Failed to load libEGL.so.1: cannot open shared object file
```

`HardwareRendering=0` reduced GL usage but `/getvideo` still goes through Wine's d3d shim. With no EGL provider in the 26.04 runtime image (wine32 was dropped in d40b6654, removing the transitive Mesa libs), `/getvideo` silently produces no frames.

## Test plan
- [ ] Build the wa-runner image and confirm `libEGL.so.1` resolves: `docker run --rm <image> ldconfig -p | grep -i egl`
- [ ] Run a real replay through the worker and confirm frames are written to `/root/.wine/drive_c/WA/User/Capture/<replay>/`
- [ ] Confirm a GIF is produced end-to-end and announced to Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)