### PR TITLE
Add /epic slash command

### DIFF
--- a/.claude/commands/epic.md
+++ b/.claude/commands/epic.md
@@ -1,0 +1,220 @@
+---
+description: Turn a large feature description into a high-level epic spec with a sliced PR breakdown
+model: opus
+---
+
+Your task is to collaborate with the user to produce two high-level epic documents in the current project:
+
+- `.claude/specs/<epic-slug>/spec.md` — the project-level specification (purpose, scope, capabilities, shape).
+- `.claude/specs/<epic-slug>/plan.md` — the ordered, PR-sized slice breakdown derived from the spec.
+
+Neither document prescribes implementation detail. They are companion files: the spec describes *what the epic is*, and the plan describes *how it will be delivered as a sequence of PR-sized slices*.
+
+This is a multi-phase, conversational process. You and the user will iterate on the document together. Do not rush to a final draft; the value is in the conversation.
+
+Multiple epics may live in the same repo. Each epic gets its own sub-folder under `.claude/specs/`.
+
+## Scope and tone
+
+Keep both documents strictly high level.
+
+`spec.md` is concerned with:
+
+- What the epic is and why it exists
+- The major capabilities and behaviours it provides
+- The shape of the system at a conceptual level (major components, external integrations, data the system deals with)
+- Constraints, assumptions, and non-goals
+
+`plan.md` is concerned with:
+
+- An ordered list of vertical slices, each small enough to be a single PR, described at a "what is delivered" level
+
+Neither file is concerned with:
+
+- Implementation details (class names, function signatures, file paths, code structure, libraries, frameworks unless the user has explicitly anchored on one)
+- Edge cases, error handling specifics, validation rules
+- Concerns that will naturally be refined when individual slices are picked up
+- Target users / personas — deliberately omitted from this command
+
+When in doubt, defer detail to the slice-implementation stage. Better to leave something coarse than to over-specify.
+
+## YOU DO NOT IMPLEMENT THE EPIC
+
+Your only outputs are `.claude/specs/<epic-slug>/spec.md` and `.claude/specs/<epic-slug>/plan.md`. Do not write source code, scaffolding, configuration, or any other artifact during this command.
+
+---
+
+## Phase 0 — Choose epic slug and create folder
+
+If the user invoked the command with a description in the args, use it. Otherwise ask them for a one-paragraph description of the epic.
+
+Propose a short, lowercase, hyphenated slug derived from the description — typically one or two words, no spaces (e.g. "Audit Secret Masking" → `audit-masking`, "Databricks Support for RgCompare" → `databricks`). Show the proposed slug and ask the user to confirm or supply an alternative.
+
+Once the slug is agreed:
+
+- If `.claude/specs/<slug>/spec.md` or `.claude/specs/<slug>/plan.md` already exists, stop and ask whether to resume editing them or pick a different slug. Do not clobber existing files.
+- Otherwise create `.claude/specs/<slug>/` (the parent `.claude/specs/` may need creating too). The `spec.md` and `plan.md` files will be created in later phases.
+
+## Phase 1 — Elicit the initial description
+
+Ask the user to describe the epic they want to build, with prompts like:
+
+- What is the epic, in a sentence or two?
+- What problem does it solve?
+- Is there an existing system, repo, or document this builds on or replaces?
+- Are there any links, issues, or reference materials you should read first?
+
+Listen. Do not start probing for detail yet. The goal is to get the user's framing into the conversation.
+
+## Phase 2 — Research and orient
+
+Read whatever you need to understand the context. Depending on the user's answers, this may include:
+
+- Files in the current working directory (`CLAUDE.md`, `README.md`, any existing specs under `.claude/specs/` or `specs/`)
+- Source files, if the epic extends or relates to existing code
+- GitHub issues, linked documents, or external references the user pointed to
+
+Do NOT speculate beyond what the user said and what you can verify. If you find nothing relevant, say so.
+
+When research is done, summarise back to the user in 3–6 bullets: your current understanding of what the epic is and any anchors (existing systems, constraints) you have picked up. Ask them to correct any misunderstanding before continuing.
+
+## Phase 3 — Create the initial draft early
+
+Before deep interrogation, populate `.claude/specs/<slug>/spec.md` with a first-pass draft using the template below. Fill in what you confidently know from Phases 1 and 2. For sections you cannot yet fill, write `_TBD — to be resolved in Phase 4_` rather than guessing.
+
+Creating the file early is deliberate: it gives both you and the user a shared artifact to read, point at, and update incrementally. Do not hold the spec in your head and dump it at the end.
+
+Tell the user the file has been populated and invite them to read through it before the interrogation phase begins.
+
+## Phase 4 — Deep interrogation
+
+This is the main body of the command. Work through the spec section by section with the user, asking the kinds of questions that surface the high-level shape of the epic. Examples:
+
+- **Purpose:** What is the epic for? What does success look like?
+- **Capabilities:** What are the major things the system must do? What are the things it deliberately will not do?
+- **Inputs and outputs:** What does the system consume? What does it produce? Where do those come from and go to?
+- **System shape:** At a conceptual level, what are the major components or surfaces (e.g. a CLI, a service, a data pipeline, a UI)? What external systems does it talk to?
+- **Data:** What are the core entities or domain concepts the system reasons about?
+- **Constraints and assumptions:** Are there fixed technologies, environments, performance characteristics, security requirements, or organisational constraints?
+- **Non-goals:** What is explicitly out of scope — not just for v1, but altogether?
+- **Done-ness:** How will the user know the epic is in a usable state? What is the smallest viable version?
+
+Do **not** ask about target users / personas — that section is intentionally omitted.
+
+Ask one focused area at a time. After each answer, update the relevant section of `spec.md` immediately (using the Edit tool) so the document tracks the conversation. Then move to the next area.
+
+Apply the following discipline throughout:
+
+- If the user gives an answer that drifts into implementation detail or edge cases, gently steer back to the high-level intent and note the detail as something for the slice stage.
+- If an answer expands scope, surface the expansion explicitly and ask whether it belongs in this epic or a later one.
+- If you cannot resolve an ambiguity in conversation, capture it under "Open Questions" rather than guessing.
+- Default to the simplest framing. If the user volunteers complexity that is not strictly required to describe the epic, ask whether it can be deferred.
+
+Continue until the user agrees every section is in a state they are happy with, or has explicitly chosen to leave a question open.
+
+## Phase 5 — Slice breakdown (plan.md)
+
+Once `spec.md` is stable, create `.claude/specs/<slug>/plan.md` and derive the ordered slice checklist from the Major Capabilities. Apply these principles:
+
+- **Granularity:** each slice should be small enough to be developed and shipped as a single PR. If a capability is large, split it.
+- **Ordering:** sequence slices by dependency, and prefer vertical slices over horizontal layers. Foundational scaffolding comes first; after that, group work so a single coherent capability can be completed before the next begins. Only break this rule when a true cross-cutting dependency forces it.
+- **High-level only:** describe each slice in one short sentence that captures *what* it delivers, not *how* it works. No class names, file paths, method signatures, or implementation details.
+- **Complete coverage:** every capability described in the spec must be reachable by following the list. Do not omit capabilities or silently defer them.
+- **Respect non-goals:** do not include slices the spec explicitly excludes.
+
+Before writing into the file, present the proposed slice list to the user as a numbered list and ask:
+
+1. Is the ordering correct?
+2. Are any slices missing, or should any be merged or split?
+3. Are any slices out of scope (i.e. described in the spec's non-goals)?
+
+Incorporate their feedback, then write the agreed list into `plan.md` using the plan template below.
+
+## Phase 6 — Final review
+
+When the user signals they are done iterating:
+
+1. Read both `spec.md` and `plan.md` end-to-end.
+2. Check `spec.md` for internal consistency (e.g. a capability mentioned in one section is not contradicted in another), unfilled `_TBD_` markers, and any sections that still drift into implementation detail.
+3. Confirm every Major Capability in `spec.md` is reachable from the slice list in `plan.md`, and that no slice in `plan.md` introduces capabilities not described in `spec.md`.
+4. Surface any issues to the user and offer to fix them, or accept them as deliberate.
+5. Do NOT commit, branch, or open a PR automatically. Tell the user the spec and plan are ready and let them decide what to do with them.
+
+---
+
+## Spec file template (`spec.md`)
+
+Use this structure when creating `.claude/specs/<slug>/spec.md`. Section headings are fixed; content under each is filled in collaboratively.
+
+```markdown
+# [Epic Name]
+
+## Overview
+
+[2–4 sentences: what the epic is and what problem it solves.]
+
+## Goals
+
+[Bulleted list of the outcomes this epic is trying to achieve. Written from the user/business perspective, not technical.]
+
+## Non-Goals
+
+[Bulleted list of things this epic deliberately does not aim to do. As important as Goals — prevents scope drift.]
+
+## Major Capabilities
+
+[Bulleted list of the main things the system can do, at a high level. Each item should be a coherent capability, not a single screen or function. Detail belongs in the slices.]
+
+## System Shape
+
+[Conceptual description of the major components, surfaces, and external integrations. No implementation detail — just the shape: e.g. "a CLI tool that reads from X and writes to Y", "a web UI backed by a service that talks to a database and an LLM provider".]
+
+## Core Domain Concepts
+
+[The primary entities, objects, or concepts the system reasons about. One line each.]
+
+## Constraints and Assumptions
+
+[Fixed technologies, environments, performance expectations, security/compliance requirements, organisational constraints, or assumptions the epic depends on.]
+
+## Definition of Done
+
+[What does it mean for this epic to be in a usable / shippable state? What is the smallest viable version?]
+
+## Open Questions
+
+[Unresolved items the user has chosen to defer. Omit the section if none.]
+```
+
+## Plan file template (`plan.md`)
+
+Use this structure when creating `.claude/specs/<slug>/plan.md`. The plan is intentionally minimal: a short pointer back to the spec, then the ordered slice checklist.
+
+```markdown
+# [Epic Name] — Delivery Plan
+
+Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a single PR and described at a "what is delivered" level only — not how it is built.
+
+## Slices
+
+- [ ] **[short name]** — [one sentence describing what is delivered]
+- [ ] **[short name]** — [one sentence describing what is delivered]
+```
+
+## Rules for spec content
+
+- Stay high-level. If you find yourself describing how something is built, stop and rewrite at the level of what it does.
+- Never invent detail the user did not give you. If a section cannot be filled, mark it `_TBD_` and resolve it through conversation.
+- Do not include implementation details, library choices, code structure, or edge-case handling.
+- Do not include time estimates, milestones, or roadmaps unless the user explicitly asks for them.
+- Every Major Capability should be self-contained enough that a future feature spec could be written against it.
+- Update the file as the conversation progresses. Do not let the file drift behind the conversation.
+
+## Rules for plan.md
+
+- The slice list is an ordered checklist. Items at the top must be completable before items below them.
+- Each entry is one line: a checkbox, a bolded short name, an em dash, and a single sentence.
+- The short name should be meaningful enough that the user can identify the slice at a glance (e.g. "CLI scaffolding", "Seeded RNG", "T-SQL script output").
+- No section headings, sub-lists, or commentary beyond the pointer back to `spec.md` and the checklist itself.
+- Do not add slices not derivable from `spec.md`.
+- Mark a slice `[x]` only if `spec.md` explicitly states that capability already exists.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,0 +1,120 @@
+---
+description: Turn one slice from an epic plan into a focused, implementable spec
+model: opus
+---
+
+Your task is to create a slice specification file from a user's request. This spec will be reviewed by a colleague (human or AI) before implementation, so it must be unambiguous and complete.
+
+YOU DO NOT IMPLEMENT THE USER'S REQUEST. Only create the required spec file.
+
+## Step 1 — Understand the request
+
+If the user has already named a slice or supplied a GitHub Issue, use that. If they have a GitHub Issue, fetch the issue description to learn what is needed.
+
+Otherwise, propose the next slice from an epic plan:
+
+1. List the epics under `.claude/specs/`. If none exist, stop and ask the user to run `/epic` first. If exactly one exists, use it. If more than one exists, ask the user which epic this slice belongs to.
+2. Read the chosen epic's `.claude/specs/<epic-slug>/plan.md` and find the first unchecked (`- [ ]`) slice whose dependencies (any earlier slices it relies on) are all checked (`- [x]`).
+3. Present that slice to the user as the suggested next one, including its short name and one-line description from the plan.
+4. Ask the user to confirm, pick a different slice from the plan, or describe something else entirely (including a GitHub Issue).
+
+Do not proceed until the user has confirmed which slice the spec is for.
+
+A slice is intended to be a small, deliverable chunk that ships as a single PR — not a large epic. If it seems too big, challenge the user to break it down and begin with a smaller first step. See "If the slice is too large" below.
+
+## Step 2 — Learn the epic and codebase context
+
+Before writing anything, read the following to understand how the slice fits the wider work and the existing system:
+
+- `.claude/specs/<epic-slug>/spec.md` — the epic's purpose, goals, non-goals, major capabilities, system shape, constraints, and definition of done. The slice must sit consistently within this scope.
+- `.claude/specs/<epic-slug>/plan.md` — the ordered slice list. Locate this slice in the plan, note which earlier slices it depends on (and may assume are complete), and which later slices it must NOT pre-empt.
+- The root `CLAUDE.md` — repo-wide conventions and pointers.
+- The relevant component doc(s) under `.claude/docs/components/` — load whichever match the area this slice touches (e.g. `cli.md`, `hub-gateway.md`, `armageddon-files.md`). The mapping is in the root `CLAUDE.md`.
+- Any source files directly relevant to the slice area.
+
+This ensures the spec accurately reflects the epic's intent, the system's boundaries, and existing behaviour. If the user's request appears to contradict the epic spec or to skip ahead in the plan, raise that with them before writing the slice spec.
+
+## Step 3 — Establish the simplest viable approach
+
+The default position is always the simplest thing that meets the stated need.
+
+Before probing for detail, identify the simplest version of the slice and present it to the user. Then identify any aspects of the request that could be implemented in a more complex or robust way — things like validation, error handling, configuration options, edge case coverage, or extensibility. For each of these, ask the user whether they want it included. Do not assume more is better.
+
+If the user's initial request already contains complexity that isn't strictly necessary to deliver the slice, surface that and ask whether it can be simplified or deferred to a later slice.
+
+## Step 4 — Resolve ambiguities
+
+Probe for the kinds of ambiguity that most commonly cause misunderstanding between author and reviewer. Ask the user about anything that is unclear, including:
+
+- Which components or projects are affected
+- Error cases and how they should be handled
+- Any configuration or inputs required
+- How this interacts with existing features
+- Edge cases the user has considered
+
+Do not proceed to write the spec until you have enough detail to fill every section completely. Keep asking until there are no open questions remaining, or until the user explicitly decides to leave something unresolved.
+
+## Step 5 — Create the spec file
+
+1. Create a numbered subdirectory under `.claude/specs/<epic-slug>/slices/`. Determine the next number by finding the highest-numbered folder currently in that `slices/` directory and incrementing by one, zero-padded to two digits (e.g. if the highest is `02-event-log`, the new folder is `03-audit-export/`). If the `slices/` directory does not yet exist or contains no numbered folders, start at `01`.
+2. Derive the slug from the slice's short name in `plan.md` (lowercase, hyphenated). If the user is specifying a slice not in the plan, agree a slug with them.
+3. Create `spec.md` inside that folder using the template below.
+
+### Spec file template
+
+```markdown
+# [Slice Name]
+
+## Overview
+
+[One or two sentences describing what is delivered and why.]
+
+## Requirements
+
+[Bulleted list of capabilities and behaviours that must exist. Written from the user/requirements perspective — what the system must do, not how it does it.]
+
+## Out of Scope
+
+[Explicit list of related things this slice does NOT include. This is as important as the requirements — it prevents reviewers from making different assumptions about scope.]
+
+## Acceptance Criteria
+
+[Bulleted list of conditions that must be true for the slice to be considered complete. Written as observable outcomes: "Given X, when Y, then Z." Each requirement above should map to at least one criterion here.]
+
+## Open Questions
+
+[Any unresolved ambiguities the user has chosen to defer. Leave this section empty (or omit it) if all questions were resolved.]
+```
+
+### Rules for the spec content
+
+- Focus on WHAT is needed, not HOW to build it
+- Never add anything the user didn't explicitly ask for
+- Default to the simplest approach — only include complexity the user explicitly agreed to in Step 3
+- Do not include implementation details such as class names, function signatures, interfaces, or code structure — those belong in the implementation plan
+- Do not prescribe the technical approach
+- Every requirement must have at least one acceptance criterion
+
+## Step 6 — Hand off
+
+After creating the spec file, tell the user where it lives and that it is ready for review or implementation. Do not commit, branch, or open a PR — the existing `/pr` skill handles that once code changes exist. Do not tick the slice off in `plan.md` — that happens at delivery time, not spec time.
+
+## If the slice is too large
+
+If the slice is too large to be a single PR-sized deliverable, you MUST suggest breaking it into multiple smaller sub-slices. Propose a concrete breakdown and wait for the user to agree before creating any files.
+
+Once agreed, create the parent numbered subdirectory under `.claude/specs/<epic-slug>/slices/` (e.g. `03-audit-export/`), then numbered sub-subdirectories inside it for each sub-slice (using the format `01-`, `02-`, etc. so ordering is unambiguous). Each sub-subdirectory gets its own `spec.md`.
+
+Example structure:
+
+```
+.claude/specs/audit-masking/
+  spec.md
+  plan.md
+  slices/
+    03-audit-export/
+      01-csv-download/
+        spec.md
+      02-scheduled-email/
+        spec.md
+```


### PR DESCRIPTION
## Summary
- Adds a new `/epic` slash command at `.claude/commands/epic.md` that turns a large feature description into a high-level epic spec with a sliced PR breakdown.

## Test plan
- [ ] Invoke `/epic` in Claude Code and confirm it loads and runs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)