### PR TITLE
Add /plan-spec and /implement slash commands

### DIFF
--- a/.claude/commands/epic.md
+++ b/.claude/commands/epic.md
@@ -1,6 +1,5 @@
 ---
 description: Turn a large feature description into a high-level epic spec with a sliced PR breakdown
-model: opus
 ---
 
 Your task is to collaborate with the user to produce two high-level epic documents in the current project:

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,95 @@
+---
+description: Implement a slice from its plan.md, recording anything surprising or missing in learnings.md
+model: opus
+---
+
+Your task is to implement a slice by following its `plan.md` precisely, tracking progress with tasks, and recording anything the plan missed or got wrong in `learnings.md`.
+
+## Step 1 — Identify the slice
+
+If the user has named a specific slice or path, use that.
+
+Otherwise, find the next slice that is ready to implement:
+
+1. List the epics under `.claude/specs/`. If more than one exists, ask which epic to work on.
+2. Read the epic's `plan.md`. Find the first unchecked (`- [ ]`) slice.
+3. Check whether `.claude/specs/<epic-slug>/slices/<slice-dir>/plan.md` exists. If it does not, stop and tell the user to run `/plan-spec` first to generate the implementation plan.
+4. Present the slice to the user and ask them to confirm or pick a different one.
+
+Do not proceed until the user has confirmed the target slice.
+
+## Step 2 — Read the plan and context
+
+Read everything before touching any files:
+
+- The slice's `plan.md` — the authoritative implementation guide
+- The slice's `spec.md` — acceptance criteria you will verify against at the end
+- The root `CLAUDE.md` — repo-wide conventions
+- Relevant component docs under `.claude/docs/components/` for the areas touched
+- Any `learnings.md` files from earlier slices in the same epic — they capture caveats that may apply here too
+
+## Step 3 — Create tasks
+
+Use TaskCreate to break the plan into discrete tasks before starting any work — one task per major section of the plan's implementation details. This gives the user a live view of progress. Mark each task `in_progress` immediately before starting it and `completed` immediately after finishing it. Do not batch completions.
+
+## Step 4 — Implement
+
+Follow the plan exactly. For each task:
+
+1. Mark the task `in_progress`.
+2. Make the changes the plan describes.
+3. Run any verification steps the plan specifies for this section.
+4. Mark the task `completed`.
+
+If the plan is silent on something you need to decide, make the simplest reasonable choice and record it as a learning (see below).
+
+If a verification step fails, diagnose the root cause rather than retrying the same action. If the fix requires a significant deviation from the plan, note it as a learning.
+
+### What to record as a learning
+
+Keep a running mental note of anything that warrants recording. Capture a learning when:
+
+- The plan omits something you had to discover yourself (a missing dependency, a required lockfile, a package not listed, a config key the plan didn't mention)
+- A tool call fails in a non-obvious way and needs a workaround
+- You loop on a problem more than once before resolving it
+- You make a decision the plan did not cover
+- An assumption in the plan turns out to be wrong
+- Something in the codebase behaves differently from what the plan implied
+
+Do not record learnings for steps that went exactly as planned.
+
+## Step 5 — Write learnings.md
+
+After all implementation tasks are complete, write `learnings.md` in the same directory as the slice's `plan.md`.
+
+Write it even if there are no learnings — its presence signals the slice has been implemented. If there is nothing to record, say so briefly.
+
+### Learnings file template
+
+```markdown
+# Learnings: [Slice Name]
+
+## Implementation Notes
+
+[One heading per learning. Each entry should describe:
+- What the plan said or assumed (or what it omitted)
+- What actually happened
+- What had to be done differently or added
+
+Keep entries factual and specific — the goal is to improve the plan template and
+component docs in a future /update-docs pass.]
+
+## Files Added (not in plan)
+
+[List any files created that the plan did not mention, with a brief reason.
+Omit this section if there are none.]
+```
+
+## Step 6 — Hand off
+
+Tell the user:
+- The implementation is complete
+- Where `learnings.md` was written and a one-line summary of the most significant learning (if any)
+- That the slice is ready for review and PR creation with `/pr`
+
+Do not commit, push, or open a PR — the user triggers that.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,6 +1,5 @@
 ---
 description: Implement a slice from its plan.md, recording anything surprising or missing in learnings.md
-model: opus
 ---
 
 Your task is to implement a slice by following its `plan.md` precisely, tracking progress with tasks, and recording anything the plan missed or got wrong in `learnings.md`.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -58,9 +58,13 @@ Keep a running mental note of anything that warrants recording. Capture a learni
 
 Do not record learnings for steps that went exactly as planned.
 
-## Step 5 — Write learnings.md
+## Step 5 — Tick the slice in the epic plan
 
-After all implementation tasks are complete, write `learnings.md` in the same directory as the slice's `plan.md`.
+After all implementation tasks are complete, mark the slice as done in the epic's top-level `plan.md` by changing its checkbox from `- [ ]` to `- [x]`.
+
+## Step 6 — Write learnings.md
+
+After ticking the epic plan, write `learnings.md` in the same directory as the slice's `plan.md`.
 
 Write it even if there are no learnings — its presence signals the slice has been implemented. If there is nothing to record, say so briefly.
 
@@ -85,7 +89,7 @@ component docs in a future /update-docs pass.]
 Omit this section if there are none.]
 ```
 
-## Step 6 — Hand off
+## Step 7 — Hand off
 
 Tell the user:
 - The implementation is complete

--- a/.claude/commands/plan-spec.md
+++ b/.claude/commands/plan-spec.md
@@ -1,0 +1,96 @@
+---
+description: Generate a detailed implementation plan for the next spec slice, written to plan.md alongside spec.md
+model: opus
+---
+
+Your task is to produce a detailed implementation plan for a slice and write it to `plan.md` next to the slice's `spec.md`. This plan is the direct input to `/implement`, so it must be precise enough for an agent to execute without further clarification.
+
+YOU DO NOT IMPLEMENT THE SLICE. Only create the `plan.md` file.
+
+## Step 1 — Identify the slice
+
+If the user has named a specific slice or path, use that.
+
+Otherwise, find the next slice that has a `spec.md` but no `plan.md`:
+
+1. List the epics under `.claude/specs/`. If none exist, stop and ask the user to run `/epic` first. If more than one exists, ask which epic to work on.
+2. For the chosen epic, read `plan.md` at the epic level to understand the intended sequence. Then scan `.claude/specs/<epic-slug>/slices/` (and any sub-slice directories) in numbered order, looking for the first directory that contains a `spec.md` but no `plan.md`.
+3. Present that slice to the user — its name and one-line description — and ask them to confirm or pick a different one.
+
+Do not proceed until the user has confirmed the target slice.
+
+## Step 2 — Read all context
+
+Read everything needed to produce an accurate, codebase-consistent plan:
+
+- The slice's `spec.md` — requirements, out of scope, acceptance criteria
+- The epic's `spec.md` and `plan.md` — scope boundaries, what earlier slices have already delivered
+- The root `CLAUDE.md` — repo-wide conventions and pointers to component docs
+- The relevant component docs under `.claude/docs/components/` for the areas this slice touches
+- The source files the slice will most likely create or modify
+- Any `learnings.md` files from earlier slices in the same epic — they capture known caveats from prior implementation
+
+## Step 3 — Plan in plan mode
+
+Use the EnterPlanMode tool to enter plan mode. Think through the full implementation before committing to any file content:
+
+- Which files need to be created, modified, or deleted, and exactly what each change entails
+- The right sequence to make those changes (what depends on what)
+- Non-obvious decisions left open by the spec: library versions, build system wiring, CI job names, config keys, DI registration — resolve them here
+- How to verify each piece of work is correct once done
+- Any risks or caveats the plan should call out explicitly
+
+Use the ExitPlanMode tool to exit plan mode before writing any files.
+
+## Step 4 — Write plan.md
+
+Write `plan.md` in the same directory as the slice's `spec.md`. Be concrete: file paths, exact dependency versions, make target names, CI job names, config values. An agent following this plan should not need to make decisions — all decisions are resolved here.
+
+### Plan file template
+
+```markdown
+# Plan: [Slice Name]
+
+## Context
+
+[One paragraph: what this slice delivers and how it fits the wider system. Call out which earlier slices it builds on and what they have already put in place.]
+
+## Files to Create / Modify
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `path/to/file` | What it does |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `path/to/file` | What changes and why |
+
+---
+
+## Implementation Details
+
+### 1. [Major concern]
+
+[Detailed guidance: exact file contents or structure where it matters, specific values
+(dependency versions, config keys, env var names), non-obvious wiring (DI registration,
+makefile includes, CI job ordering), any known caveats from the codebase.]
+
+### 2. [Next concern]
+
+[...]
+
+---
+
+## Verification
+
+1. [Command or action that confirms a specific piece of work is correct]
+2. [Observable outcome that confirms end-to-end correctness]
+```
+
+## Step 5 — Hand off
+
+Tell the user where `plan.md` was written and that it is ready for review or implementation with `/implement`. Do not commit, branch, or open a PR.

--- a/.claude/commands/plan-spec.md
+++ b/.claude/commands/plan-spec.md
@@ -1,6 +1,5 @@
 ---
 description: Generate a detailed implementation plan for the next spec slice, written to plan.md alongside spec.md
-model: opus
 ---
 
 Your task is to produce a detailed implementation plan for a slice and write it to `plan.md` next to the slice's `spec.md`. This plan is the direct input to `/implement`, so it must be precise enough for an agent to execute without further clarification.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,158 @@
+---
+description: Review an implementation against its spec, plan, and repo quality standards, producing an advisory report
+model: opus
+---
+
+You review the changes made for a slice against the spec, plan, and repo quality standards. You produce a `review.md` report. You do NOT make code changes, commit, or modify the branch.
+
+Your review is advisory. The user will read it and decide which items to act on. Categorise honestly so they can triage without re-reading the whole diff.
+
+## Step 1 — Identify the slice
+
+If the user has named a specific slice or branch, use that.
+
+Otherwise, infer from context:
+
+1. Check the current branch name for an epic/slice hint (e.g. `feature/some-slug`).
+2. Look under `.claude/specs/` for a slice directory containing a `plan.md` and `learnings.md` — the presence of `learnings.md` means it has been implemented and is ready for review.
+3. If more than one candidate exists, list them and ask the user which to review.
+
+Do not proceed until the slice is confirmed.
+
+## Step 2 — Read all inputs
+
+Read, in order:
+
+- The slice's `spec.md` — the acceptance criteria you will check against
+- The slice's `plan.md` — the intended files changed and implementation approach
+- The slice's `learnings.md` — implementer notes on deviations and surprises
+- The epic's `spec.md` — scope and non-goals
+- The root `CLAUDE.md` — repo conventions and component doc pointers
+- `.claude/docs/steering/coding-guidelines.md`
+- `.claude/docs/steering/testing-strategy.md`
+- The relevant component doc(s) under `.claude/docs/components/` for the areas touched
+
+## Step 3 — Get the diff
+
+Determine the base branch (default `main`). Run:
+
+```
+git diff <base>...<current-branch>
+```
+
+Read the full diff. Note every file added, modified, or deleted.
+
+## Step 4 — Run quality checks
+
+Run the build and lint for every component touched by the diff. Use the make targets:
+
+- `.NET` code present: `dotnet build` the affected solution/project — must exit clean. The repo sets `TreatWarningsAsErrors` and runs Roslynator; any warning is a **Blocker**.
+- Web code present (`src/Worms.Hub.Web/`): `make web.lint` — ESLint and `tsc --noEmit` must both pass. Any error is a **Blocker**.
+
+Record the exact output of any failing command as evidence for the finding.
+
+## Step 5 — Review the diff
+
+### 5a — Acceptance criteria
+
+For each acceptance criterion in the slice's `spec.md`, determine whether the diff satisfies it. Cite the relevant file and line as evidence. Mark each criterion MET, PARTIAL, or NOT MET.
+
+### 5b — Scope
+
+Compare the diff against the plan's "Files to Create / Modify" table.
+
+- Flag files changed that are not in the plan.
+- Flag planned files that are absent from the diff.
+- Flag changes that go beyond what the plan describes for a file.
+
+Changes not in the plan are not automatically wrong — but they need a reason. Check `learnings.md` first; if the deviation is explained there, note it as resolved. If it is unexplained, raise it as a finding.
+
+### 5c — Coding guidelines
+
+Check the diff for violations of `.claude/docs/steering/coding-guidelines.md`:
+
+- **Build defaults:** nullable enabled, no suppressed warnings, no `#pragma warning disable` without justification
+- **Visibility:** new types default to `internal sealed`; only `public` when consumed cross-assembly
+- **Immutability:** DTOs and value types use `record`; public signatures prefer `IReadOnlyList<T>` / `IReadOnlyDictionary<,>`
+- **DI:** new projects expose a `ServiceRegistration` class; services registered `Scoped` by default
+- **File system:** no `File`/`Directory` static calls — use `IFileSystem`
+- **Telemetry:** meaningful units of work in hub code start an `Activity` from `Telemetry.Source`
+- **Formatting:** 4-space indent, 120-char line length, Allman braces, sorted usings
+
+For web code, check against the ESLint config and Prettier settings in `src/Worms.Hub.Web/`.
+
+### 5d — Tests
+
+Check the diff against `.claude/docs/steering/testing-strategy.md`:
+
+- Is new logic covered at the right tier (unit vs. integration)?
+- Are there **padding tests** — tests that exist only to look thorough? Examples: assertions like "didn't throw", trivial round-trips, mock-heavy tests that just re-state the implementation. Raise these as findings.
+- Are new integration tests gated with `[Category("Integration")]`?
+- Do test classes follow the `<TypeUnderTest>Should` / `<BehaviourDescription>` naming convention?
+- Are file-system seams exercised via `MockFileSystem` rather than touching disk?
+
+## Step 6 — Write review.md
+
+Write `review.md` in the same directory as the slice's `spec.md` and `plan.md`, using the template below.
+
+```markdown
+# Review — [Slice Name]
+
+## Verdict
+
+[One paragraph. Does the implementation satisfy the spec? Any blockers the user must address before merging?]
+
+## Acceptance Criteria
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| [criterion from spec] | MET / PARTIAL / NOT MET | file:line or explanation |
+
+## Scope
+
+[Does the diff match the plan's Files to Create / Modify table? List anything outside scope, with a note on whether learnings.md explains it.]
+
+## Blockers
+
+[Zero or more entries, numbered B1, B2, … Use the finding format below.]
+
+## Suggestions
+
+[Zero or more entries, numbered S1, S2, … Same format.]
+
+## Nitpicks
+
+[Zero or more entries, numbered N1, N2, … Same format.]
+
+### Finding format
+
+#### B1 — [short title]
+
+- **File:** `path/to/file:line`
+- **Issue:** One sentence describing what is wrong.
+- **Fix:** Short direction for the fix.
+- **Decision:** — *(pending)*
+
+## Tests
+
+[What test coverage was added or changed. Any coverage gaps. Any padding tests that should be removed or rewritten. Any fragile patterns.]
+
+## Recommended Actions
+
+[For every finding, state your recommended action and a one-line reason:]
+
+- **B1** — Accept — [why the fix is clearly right]
+- **S1** — Decline — [why it's not worth it or out of scope]
+- **N1** — Accept — [reason]
+
+Valid actions: `Accept` or `Decline`. Cover every finding.
+```
+
+## Rules
+
+- Write only `review.md`. Do not edit code, commit, or touch the branch.
+- Stay in scope: review only files in the diff. Do not audit the rest of the repo.
+- Ignore process files in the diff (`learnings.md`, `plan.md`, `spec.md`, `review.md`) — these are workflow artefacts, not feature code.
+- Be specific. "Error handling could be improved" is not useful; "`GifCreator.cs:42` does not handle the case where `frames` is empty" is.
+- Match the bar the spec set. Do not raise production-grade concerns (HA, exhaustive logging, observability) the spec did not ask for.
+- Categorise honestly. A Blocker genuinely breaks a spec criterion or the build. A Suggestion is meaningful improvement. A Nitpick is style. Do not inflate severity.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -69,27 +69,13 @@ Changes not in the plan are not automatically wrong — but they need a reason. 
 
 ### 5c — Coding guidelines
 
-Check the diff for violations of `.claude/docs/steering/coding-guidelines.md`:
-
-- **Build defaults:** nullable enabled, no suppressed warnings, no `#pragma warning disable` without justification
-- **Visibility:** new types default to `internal sealed`; only `public` when consumed cross-assembly
-- **Immutability:** DTOs and value types use `record`; public signatures prefer `IReadOnlyList<T>` / `IReadOnlyDictionary<,>`
-- **DI:** new projects expose a `ServiceRegistration` class; services registered `Scoped` by default
-- **File system:** no `File`/`Directory` static calls — use `IFileSystem`
-- **Telemetry:** meaningful units of work in hub code start an `Activity` from `Telemetry.Source`
-- **Formatting:** 4-space indent, 120-char line length, Allman braces, sorted usings
+Check the diff for violations of `.claude/docs/steering/coding-guidelines.md`
 
 For web code, check against the ESLint config and Prettier settings in `src/Worms.Hub.Web/`.
 
 ### 5d — Tests
 
 Check the diff against `.claude/docs/steering/testing-strategy.md`:
-
-- Is new logic covered at the right tier (unit vs. integration)?
-- Are there **padding tests** — tests that exist only to look thorough? Examples: assertions like "didn't throw", trivial round-trips, mock-heavy tests that just re-state the implementation. Raise these as findings.
-- Are new integration tests gated with `[Category("Integration")]`?
-- Do test classes follow the `<TypeUnderTest>Should` / `<BehaviourDescription>` naming convention?
-- Are file-system seams exercised via `MockFileSystem` rather than touching disk?
 
 ## Step 6 — Write review.md
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,6 +1,5 @@
 ---
 description: Review an implementation against its spec, plan, and repo quality standards, producing an advisory report
-model: opus
 ---
 
 You review the changes made for a slice against the spec, plan, and repo quality standards. You produce a `review.md` report. You do NOT make code changes, commit, or modify the branch.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,6 +1,5 @@
 ---
 description: Turn one slice from an epic plan into a focused, implementable spec
-model: opus
 ---
 
 Your task is to create a slice specification file from a user's request. This spec will be reviewed by a colleague (human or AI) before implementation, so it must be unambiguous and complete.


### PR DESCRIPTION
## Summary

- Adds `/plan-spec`: finds the next slice with a `spec.md` but no `plan.md`, enters plan mode to think through the full implementation, then writes a detailed `plan.md` covering files to create/modify, implementation details, and verification steps
- Adds `/implement`: finds the next unimplemented slice (first unchecked entry in the epic plan with a `plan.md`), uses tasks for live progress tracking, implements the slice, and writes a `learnings.md` capturing anything the plan missed, got wrong, or required a workaround for

These two commands complete the slice workflow chain: `/epic` → `/spec` → `/plan-spec` → `/implement` → `/pr`

## Test plan

- [ ] Run `/plan-spec` against a slice that has a `spec.md` but no `plan.md` — confirms it enters plan mode and writes `plan.md` in the correct directory
- [ ] Run `/plan-spec` with no args on a repo with a single epic — confirms it auto-selects the next unplanned slice and asks for confirmation
- [ ] Run `/implement` against a slice with a `plan.md` — confirms tasks are created, implementation proceeds step by step, and `learnings.md` is written at the end
- [ ] Run `/implement` against a slice with no `plan.md` — confirms it stops and directs the user to `/plan-spec`
- [ ] Run `/implement` with no args — confirms it defaults to the first unchecked slice in the epic plan that has a `plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)