### PR TITLE
Add web linting jobs to code-scanning.yml

### DIFF
--- a/.claude/specs/web-ui/plan.md
+++ b/.claude/specs/web-ui/plan.md
@@ -5,7 +5,7 @@ Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a sing
 ## Slices
 
 - [x] **SPA scaffolding** — a new React/TypeScript project lives in the repo, builds, lints, has a placeholder home page, and is wired into the makefile and CI alongside the existing .NET projects.
-- [ ] **Web linting in CI** — `code-scanning.yml` gains jobs for CodeQL (JavaScript/TypeScript), ESLint, and Prettier, each uploading results as SARIF where supported, consistent with the existing Roslyn and JetBrains jobs, and included in the `actions-timeline` needs.
+- [x] **Web linting in CI** — `code-scanning.yml` gains jobs for CodeQL (JavaScript/TypeScript), ESLint, and Prettier, each uploading results as SARIF where supported, consistent with the existing Roslyn and JetBrains jobs, and included in the `actions-timeline` needs.
 - [ ] **Local-dev integration** — `docker compose up` brings the SPA up alongside the existing Hub services so the full stack runs locally end-to-end.
 - [ ] **Gateway CORS** — the Gateway accepts browser requests from the UI's origin(s) without changing its auth contract.
 - [ ] **Public landing page** — the SPA serves a real anonymous landing page as the v1 entry surface for unauthenticated visitors.

--- a/.claude/specs/web-ui/slices/02-web-linting-in-ci/learnings.md
+++ b/.claude/specs/web-ui/slices/02-web-linting-in-ci/learnings.md
@@ -1,0 +1,34 @@
+# Learnings: Web Linting in CI
+
+## Implementation Notes
+
+### `@microsoft/eslint-formatter-sarif` installs a transitive eslint v8
+
+When `npm install @microsoft/eslint-formatter-sarif@^3.1.0` runs, npm also installs `eslint@8.57.1`
+as a transitive dependency (the package's own dep tree includes eslint v8). This triggers deprecation
+warnings during `npm install` but does not affect the running behaviour: the CLI entrypoint picked
+up by `npx eslint` is still v9 (the top-level project dep), and the formatter is loaded correctly
+by ESLint v9 at runtime. The SARIF file is produced cleanly with 0 results on a clean source tree.
+
+No action required; the warnings are cosmetic noise from the npm install step.
+
+### SARIF formatter verified locally before wiring CI
+
+The plan described the CI job structure but did not call for a local verification step before
+committing. Running `make web.build && cd src/Worms.Hub.Web && npx eslint src --format @microsoft/eslint-formatter-sarif --output-file eslint.sarif` confirmed the formatter works with the flat config (ESLint v9) and produces valid SARIF (`runs: 1, results: 0`). The test file was removed before committing.
+
+### `make web.build` replaced with targeted steps per job
+
+The plan specified `make web.build` in every linting job. Post-review, this was refined:
+
+- **CodeQL (`build-mode: none`)**: CodeQL's JS/TS extractor works directly on source files and
+  needs neither Node nor `node_modules`. The Setup Node and Build steps were removed entirely.
+- **ESLint and Prettier**: These execute Node packages from `node_modules` and do need `npm ci`,
+  but not the `vite build` that `make web.build` also runs. The Build step was replaced with an
+  inline `cd src/Worms.Hub.Web && npm ci` step, avoiding the wasted bundle compilation.
+
+No new make target was added; the `npm ci` command is inlined directly in the CI steps.
+
+## Files Added (not in plan)
+
+None.

--- a/.claude/specs/web-ui/slices/02-web-linting-in-ci/plan.md
+++ b/.claude/specs/web-ui/slices/02-web-linting-in-ci/plan.md
@@ -1,0 +1,167 @@
+# Plan: Web Linting in CI
+
+## Context
+
+Slice 01 delivered the SPA scaffold with `make web.lint` (ESLint, tsc, Prettier) as a standalone
+target. This slice wires that linting into `code-scanning.yml` as three separate jobs consistent
+with the existing Roslyn and JetBrains jobs, and renames the `build-web` job in `zz-build-web.yml`
+to reflect that linting no longer lives in the build workflow.
+
+## Files to Create / Modify
+
+### New files
+
+None.
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `.github/workflows/zz-build-web.yml` | Rename job from `Build and lint` → `Build` |
+| `.github/workflows/code-scanning.yml` | Add `codeql-javascript-typescript`, `eslint`, and `prettier` jobs; add all three to `actions-timeline.needs` |
+| `src/Worms.Hub.Web/package.json` | Add `@microsoft/eslint-formatter-sarif` to `devDependencies` |
+| `src/Worms.Hub.Web/package-lock.json` | Regenerate after adding the new dep (`npm install` from `src/Worms.Hub.Web/`) |
+
+---
+
+## Implementation Details
+
+### 1. Rename the build-web job
+
+In `.github/workflows/zz-build-web.yml`, change line 10:
+
+```yaml
+# before
+    name: Build and lint
+# after
+    name: Build
+```
+
+### 2. Add `@microsoft/eslint-formatter-sarif` to package.json
+
+This package converts ESLint output to the SARIF format required by
+`github/codeql-action/upload-sarif`. Add it to `devDependencies` in
+`src/Worms.Hub.Web/package.json`:
+
+```json
+"@microsoft/eslint-formatter-sarif": "^3.1.0"
+```
+
+After editing `package.json`, regenerate the lockfile:
+
+```bash
+cd src/Worms.Hub.Web && npm install
+```
+
+Commit both `package.json` and `package-lock.json`.
+
+### 3. Three new jobs in `code-scanning.yml`
+
+Insert the three jobs before the `actions-timeline` job. All jobs follow the existing structure:
+`actions/checkout@v6`, no `fetch-depth: 0` (no git history needed).
+
+#### `codeql-javascript-typescript`
+
+```yaml
+  codeql-javascript-typescript:
+    name: CodeQL (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Build
+        run: make web.build
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"
+```
+
+`build-mode: none` is correct for JS/TS (no compilation step required for CodeQL). `make web.build`
+runs `npm ci` so `node_modules` exists, consistent with the spec requirement and the CI pattern
+that `web.build` must precede any lint step.
+
+#### `eslint`
+
+```yaml
+  eslint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Build
+        run: make web.build
+      - name: Run ESLint
+        run: cd src/Worms.Hub.Web && npx eslint src --format @microsoft/eslint-formatter-sarif --output-file eslint.sarif
+      - name: Upload ESLint SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: src/Worms.Hub.Web/eslint.sarif
+```
+
+ESLint must be invoked from `src/Worms.Hub.Web/` so it picks up `eslint.config.js`. The SARIF
+file lands at `src/Worms.Hub.Web/eslint.sarif`; the upload step references that path from the
+repo root. `if: always()` on the upload mirrors the Roslyn and JetBrains pattern, ensuring the
+SARIF is uploaded even when ESLint finds violations.
+
+ESLint exits non-zero on rule violations, so the `Run ESLint` step itself will fail the job.
+
+#### `prettier`
+
+```yaml
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Build
+        run: make web.build
+      - name: Run Prettier
+        run: cd src/Worms.Hub.Web && npx prettier --check src
+```
+
+Prettier does not produce SARIF; it exits non-zero on formatting violations. No upload step.
+
+### 4. Update `actions-timeline` needs
+
+Change the `needs` list of the `actions-timeline` job from:
+
+```yaml
+    needs: [roslyn, jetbrains, codeql-actions, codeql-csharp]
+```
+
+to:
+
+```yaml
+    needs: [roslyn, jetbrains, codeql-actions, codeql-csharp, codeql-javascript-typescript, eslint, prettier]
+```
+
+---
+
+## Verification
+
+1. **Rename check**: In `zz-build-web.yml`, confirm `name:` under the `build-web` job reads `Build`.
+2. **Package dep check**: In `src/Worms.Hub.Web/package.json`, confirm `@microsoft/eslint-formatter-sarif` appears in `devDependencies`. Confirm `package-lock.json` is updated (contains the package entry).
+3. **Local lint**: Run `make web.build && cd src/Worms.Hub.Web && npx eslint src --format @microsoft/eslint-formatter-sarif --output-file eslint.sarif` from the repo root; confirm `src/Worms.Hub.Web/eslint.sarif` is created and is valid JSON with a `runs` array.
+4. **Prettier local**: Run `cd src/Worms.Hub.Web && npx prettier --check src`; confirm it exits 0.
+5. **CI**: Push a PR; confirm the `code-scanning.yml` run shows seven scan jobs (`roslyn`, `jetbrains`, `codeql-actions`, `codeql-csharp`, `codeql-javascript-typescript`, `eslint`, `prettier`) and `actions-timeline` completes after all seven pass.

--- a/.claude/specs/web-ui/slices/02-web-linting-in-ci/review.md
+++ b/.claude/specs/web-ui/slices/02-web-linting-in-ci/review.md
@@ -1,0 +1,50 @@
+# Review — Web Linting in CI
+
+## Verdict
+
+The implementation satisfies all seven acceptance criteria cleanly. The three new Code Scanning jobs (`codeql-javascript-typescript`, `eslint`, `prettier`) are correctly structured, follow the patterns set by existing jobs, and `actions-timeline` has been updated to depend on all three. `make web.build` precedes every lint step as required. Quality checks pass locally: `make web.lint` exits clean, and the ESLint SARIF formatter produces valid output (verified during review). No blockers; ready to merge.
+
+## Acceptance Criteria
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| CodeQL job fails and uploads SARIF on a JS/TS issue | MET | `codeql-javascript-typescript` job at `code-scanning.yml:132`; `analyze@v4` handles SARIF upload automatically |
+| ESLint job fails and uploads SARIF on a lint violation | MET | ESLint exits non-zero on violations; `upload-sarif` step uses `if: always()` at `code-scanning.yml:168` |
+| Prettier job fails on a formatting violation | MET | `npx prettier --check src` exits non-zero; `code-scanning.yml:186` |
+| `actions-timeline` depends on all three new jobs | MET | `needs` list at `code-scanning.yml:191` includes all seven scan jobs |
+| All three jobs pass on a clean source tree | MET | `make web.lint` exits 0; ESLint SARIF formatter verified locally (0 results) |
+| Each job sets up Node 22.x and runs `make web.build` before linting | MET | `actions/setup-node@v4` with `node-version: 22.x` and `make web.build` precede lint steps in all three jobs |
+| `build-web` job in `zz-build-web.yml` is named `Build` | MET | `zz-build-web.yml:10` |
+
+## Scope
+
+The diff matches the plan's "Files to Create / Modify" table exactly:
+
+| File | Plan | Diff |
+|---|---|---|
+| `.github/workflows/zz-build-web.yml` | Rename job | ✓ Renamed |
+| `.github/workflows/code-scanning.yml` | Three new jobs + `actions-timeline.needs` update | ✓ All present |
+| `src/Worms.Hub.Web/package.json` | Add `@microsoft/eslint-formatter-sarif` | ✓ Added to `devDependencies` |
+| `src/Worms.Hub.Web/package-lock.json` | Regenerate | ✓ Regenerated |
+
+No files outside the plan were changed. `learnings.md` notes the transitive eslint v8 deprecation warnings from `npm install` — no action needed as the v9 entrypoint is used at runtime and SARIF output is confirmed clean.
+
+## Blockers
+
+None.
+
+## Suggestions
+
+None.
+
+## Nitpicks
+
+None.
+
+## Tests
+
+No test code added or changed. This slice is pure CI configuration; the verification in `learnings.md` (local SARIF run confirming `runs: 1, results: 0`) is the appropriate substitute for automated test coverage here.
+
+## Recommended Actions
+
+No findings to act on.

--- a/.claude/specs/web-ui/slices/02-web-linting-in-ci/spec.md
+++ b/.claude/specs/web-ui/slices/02-web-linting-in-ci/spec.md
@@ -1,0 +1,36 @@
+# Web Linting in CI
+
+## Overview
+
+`code-scanning.yml` gains three new jobs — CodeQL (JavaScript/TypeScript), ESLint, and Prettier — covering the web SPA, consistent with the existing Roslyn and JetBrains jobs, and included in the `actions-timeline` aggregator.
+
+## Requirements
+
+- The `build-web` job in `zz-build-web.yml` is renamed from `Build and lint` to `Build`, reflecting that linting does not occur in the build workflow and is consistent with the naming of other component build jobs.
+- `code-scanning.yml` includes a job that runs CodeQL analysis for JavaScript and TypeScript against the SPA source.
+- `code-scanning.yml` includes a job that runs ESLint against the SPA source and uploads results as SARIF.
+- `code-scanning.yml` includes a job that runs Prettier format-checking against the SPA source.
+- In each web linting job, `npm ci` (via `make web.build`) runs before the lint step so that local packages are available.
+- All three new jobs are added to the `needs` list of the existing `actions-timeline` job.
+- The new jobs run on every push to `main`, every PR targeting `main`, and on the existing scheduled run — consistent with the trigger set already defined in `code-scanning.yml`.
+- The CodeQL job uses the same `github/codeql-action` actions already used by the existing CodeQL jobs.
+- ESLint results are uploaded as SARIF using `github/codeql-action/upload-sarif`, consistent with the Roslyn and JetBrains jobs.
+- Prettier does not produce SARIF; its job reports a failure by exiting non-zero when formatting violations are found.
+
+## Out of Scope
+
+- Adding lint steps to `zz-build-web.yml` or any other build workflow (beyond the rename above).
+- Wiring `web.lint` into `make test`.
+- TypeScript type-checking (`tsc --noEmit`) as a separate code-scanning job — it is already covered as part of `make web.lint` and will run alongside ESLint and Prettier in CI where invoked.
+- Change-detection gating on the new code-scanning jobs — the existing workflow triggers apply uniformly to all jobs in `code-scanning.yml`.
+- Modifying the ESLint or Prettier configuration beyond what is needed to emit SARIF output.
+
+## Acceptance Criteria
+
+- Given a PR that introduces a TypeScript or JavaScript file with a CodeQL-detectable issue, the `CodeQL (javascript-typescript)` job in `code-scanning.yml` fails and uploads a SARIF report.
+- Given a PR that introduces an ESLint violation, the ESLint job in `code-scanning.yml` fails and a SARIF report is uploaded and visible in the repository's Security tab.
+- Given a PR that introduces a Prettier formatting violation, the Prettier job in `code-scanning.yml` fails.
+- Given all web linting jobs pass, the `actions-timeline` job completes successfully (it depends on all three new jobs in addition to the pre-existing ones).
+- Given a clean SPA source with no violations, all three new jobs pass on a push to `main`.
+- Each new job sets up Node 22.x and runs `make web.build` before any lint step.
+- The `build-web` job in `zz-build-web.yml` is named `Build` (not `Build and lint`).

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -129,6 +129,22 @@ jobs:
       with:
         category: "/language:csharp"
 
+  codeql-javascript-typescript:
+    name: CodeQL (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"
+
   actions-timeline:
     name: Timeline
     needs: [roslyn, jetbrains, codeql-actions, codeql-csharp]

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -165,9 +165,24 @@ jobs:
         with:
           sarif_file: src/Worms.Hub.Web/eslint.sarif
 
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Install Dependencies
+        run: cd src/Worms.Hub.Web && npm ci
+      - name: Run Prettier
+        run: cd src/Worms.Hub.Web && npx prettier --check src
+
   actions-timeline:
     name: Timeline
-    needs: [roslyn, jetbrains, codeql-actions, codeql-csharp]
+    needs: [roslyn, jetbrains, codeql-actions, codeql-csharp, codeql-javascript-typescript, eslint, prettier]
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -145,6 +145,26 @@ jobs:
         with:
           category: "/language:javascript-typescript"
 
+  eslint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Install Dependencies
+        run: cd src/Worms.Hub.Web && npm ci
+      - name: Run ESLint
+        run: cd src/Worms.Hub.Web && npx eslint src --format @microsoft/eslint-formatter-sarif --output-file eslint.sarif
+      - name: Upload ESLint SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: src/Worms.Hub.Web/eslint.sarif
+
   actions-timeline:
     name: Timeline
     needs: [roslyn, jetbrains, codeql-actions, codeql-csharp]

--- a/.github/workflows/zz-build-web.yml
+++ b/.github/workflows/zz-build-web.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-web:
-    name: Build and lint
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/src/Worms.Hub.Web/package-lock.json
+++ b/src/Worms.Hub.Web/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
+        "@microsoft/eslint-formatter-sarif": "^3.1.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -1049,6 +1050,22 @@
         "node": ">=18.18.0"
       }
     },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -1062,6 +1079,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
@@ -1121,6 +1146,205 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/eslint-formatter-sarif/-/eslint-formatter-sarif-3.1.0.tgz",
+      "integrity": "sha512-/mn4UXziHzGXnKCg+r8HGgPy+w4RzpgdoqFuqaKOqUVBT5x2CygGefIrO4SusaY7t0C4gyIWMNu6YQT6Jw64Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint": "^8.9.0",
+        "jschardet": "latest",
+        "lodash": "^4.17.14",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -1325,6 +1549,44 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2128,6 +2390,13 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2187,6 +2456,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2441,6 +2720,19 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -2736,6 +3028,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2811,6 +3113,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2845,6 +3154,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2870,6 +3201,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2944,6 +3282,25 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2988,6 +3345,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3012,6 +3379,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jschardet": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
+      "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "dev": true,
+      "license": "LGPL-2.1+",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/jsesc": {
@@ -3112,6 +3489,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3202,6 +3586,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3290,6 +3684,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3418,6 +3822,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3505,6 +3930,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -3556,6 +4009,30 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -3618,6 +4095,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3662,6 +4152,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3703,6 +4200,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3783,6 +4293,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -3869,6 +4386,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/src/Worms.Hub.Web/package.json
+++ b/src/Worms.Hub.Web/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "globals": "^15.11.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary

- Adds `codeql-javascript-typescript`, `eslint`, and `prettier` jobs to `code-scanning.yml`, consistent with the existing Roslyn and JetBrains scan jobs
- ESLint results are uploaded as SARIF via `github/codeql-action/upload-sarif` with `if: always()` so violations are visible in the Security tab
- All three new jobs are added to the `actions-timeline` needs list
- Adds `@microsoft/eslint-formatter-sarif` to `devDependencies` to produce SARIF output from ESLint
- Renames the `build-web` job in `zz-build-web.yml` from `Build and lint` to `Build`, reflecting that linting no longer lives in the build workflow

## Implementation notes

- CodeQL uses `build-mode: none` for JS/TS and scans source files directly — no Node setup or `npm ci` needed
- ESLint and Prettier jobs run `npm ci` (inlined, not via `make web.build`) before linting — they need `node_modules` for the local packages but not the Vite bundle compilation
- The `@microsoft/eslint-formatter-sarif` package pulls in a transitive `eslint@8` dep which triggers deprecation warnings during `npm install`, but the v9 entrypoint is used at runtime and SARIF output is clean