### PR TITLE
Add CORS support to Gateway for web UI origins

### DIFF
--- a/.claude/specs/web-ui/plan.md
+++ b/.claude/specs/web-ui/plan.md
@@ -7,7 +7,7 @@ Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a sing
 - [x] **SPA scaffolding** — a new React/TypeScript project lives in the repo, builds, lints, has a placeholder home page, and is wired into the makefile and CI alongside the existing .NET projects.
 - [x] **Web linting in CI** — `code-scanning.yml` gains jobs for CodeQL (JavaScript/TypeScript), ESLint, and Prettier, each uploading results as SARIF where supported, consistent with the existing Roslyn and JetBrains jobs, and included in the `actions-timeline` needs.
 - [x] **Local-dev integration** — `docker compose up` brings the SPA up alongside the existing Hub services so the full stack runs locally end-to-end.
-- [ ] **Gateway CORS** — the Gateway accepts browser requests from the UI's origin(s) without changing its auth contract.
+- [x] **Gateway CORS** — the Gateway accepts browser requests from the UI's origin(s) without changing its auth contract.
 - [ ] **Public landing page** — the SPA serves a real anonymous landing page as the v1 entry surface for unauthenticated visitors.
 - [ ] **Browser sign-in** — a new SPA OIDC client is registered in the authority, the UI implements the interactive sign-in flow, and authenticated calls to the Gateway succeed with a bearer token.
 - [ ] **Authenticated route gate** — every page other than the landing page requires a signed-in league member; signed-out visitors are redirected to sign in.

--- a/.claude/specs/web-ui/slices/04-gateway-cors/learnings.md
+++ b/.claude/specs/web-ui/slices/04-gateway-cors/learnings.md
@@ -1,0 +1,15 @@
+# Learnings: Gateway CORS
+
+## Implementation Notes
+
+### `corsPolicyName` and `allowedOrigins` declared outside the `if (runGateway)` block
+
+The plan called for declaring `const string corsPolicyName` inside the `if (runGateway)` service-registration block and noted that it must be "naturally in scope" for the later `app` configuration block. In practice, `corsPolicyName` is used in both the `builder.Services.AddCors(...)` call and the `app.UseCors(corsPolicyName)` call. Both calls are inside `if (runGateway)` blocks, but they are separate blocks (the first before `builder.Build()`, the second after). To keep the variable in scope for both without introducing a field or repeating the string literal, it was declared at the top-level before the first `if (runGateway)` block — alongside the `allowedOrigins` read. This matches the plan's intent and is the simplest correct placement.
+
+### `UseRouting()` was already present in Program.cs
+
+The plan noted that the current code "does not call `UseRouting()` explicitly" and described adding it. In fact, `UseRouting()` was already present in `Program.cs` immediately before `UseAuthentication()`. `UseCors(corsPolicyName)` was inserted between the existing `UseRouting()` and `UseAuthentication()` calls with no other change needed. The plan's instruction to add explicit `UseRouting` was not required.
+
+### Everything else went exactly as planned
+
+The three file edits (Program.cs, appsettings.json, appsettings.Development.json) matched the plan exactly. The Gateway built cleanly on the first attempt with no warnings or errors.

--- a/.claude/specs/web-ui/slices/04-gateway-cors/plan.md
+++ b/.claude/specs/web-ui/slices/04-gateway-cors/plan.md
@@ -1,0 +1,232 @@
+# Plan: Gateway CORS
+
+## Context
+
+This slice adds CORS support to the Hub Gateway so that the React SPA (delivered in slices 01–03)
+can make browser requests to the existing JSON API. Slices 01–03 put the SPA in place and wired it
+into local dev via `docker compose`; this slice is the first change to a .NET project in the epic.
+
+No new packages are required — CORS middleware ships with `Microsoft.AspNetCore`. The change is
+limited to three existing files in `Worms.Hub.Gateway`: `Program.cs` and the two appsettings files.
+No controllers, DTOs, auth configuration, or other Gateway logic are touched.
+
+---
+
+## Files to Create / Modify
+
+### New files
+
+None.
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/Worms.Hub.Gateway/Program.cs` | Add `AddCors` in the service-registration block and `UseCors` in the middleware pipeline |
+| `src/Worms.Hub.Gateway/appsettings.json` | Add an empty `Cors.AllowedOrigins` array — no hardcoded origins |
+| `src/Worms.Hub.Gateway/appsettings.Development.json` | Add the two local-dev origins to `Cors.AllowedOrigins` |
+
+---
+
+## Implementation Details
+
+### 1. Configuration binding
+
+The config key path is `Cors:AllowedOrigins`. The `AddEnvironmentVariables("WORMS_")` call in
+`Program.cs` already strips the `WORMS_` prefix and converts `__` to `:`, so the env var
+`WORMS_CORS__ALLOWEDORIGINS__0`, `WORMS_CORS__ALLOWEDORIGINS__1`, etc. maps correctly to the
+`Cors:AllowedOrigins` array section. (For production, the deployment slice sets env vars using
+this indexed notation.)
+
+Read the value with:
+
+```csharp
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+```
+
+This works with both a JSON array in `appsettings*.json` and with indexed environment variables
+(`__0`, `__1`). When the section is absent or empty, the result is an empty array — no CORS
+headers are emitted.
+
+### 2. appsettings.json — base config (no hardcoded origins)
+
+Add an empty array under `Cors`. The file currently has no `Cors` section. Insert after the
+`AllowedHosts` entry:
+
+```json
+{
+  "Logging": { ... },
+  "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": []
+  },
+  "Auth": { ... },
+  "ConnectionStrings": { ... }
+}
+```
+
+An empty array means `.WithOrigins()` is called with no origins, so the policy matches nothing
+and no `Access-Control-Allow-Origin` header is emitted. This satisfies the acceptance criterion
+that the base config emits no CORS headers.
+
+### 3. appsettings.Development.json — local-dev origins
+
+Add the two Vite/docker-compose origins. The file currently has only `Logging` and `Storage`
+sections. Insert after `Logging`:
+
+```json
+{
+  "Logging": { ... },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "http://localhost:5173"
+    ]
+  },
+  "Storage": { ... }
+}
+```
+
+`http://localhost:3000` is the nginx container exposed by `docker compose up` (the `web` service,
+mapped to host port 3000). `http://localhost:5173` is the default Vite dev server port for
+running `npm run dev` directly on the host.
+
+The `hub-gateway` container already sets `ASPNETCORE_ENVIRONMENT=Development` in
+`docker-compose.yaml`, so this file is picked up automatically — no change to `docker-compose.yaml`
+is needed.
+
+### 4. Program.cs — service registration
+
+Inside the `if (runGateway)` block, read the allowed origins from configuration and register a
+named CORS policy called `"WormsWebUi"`. Add this **before** the `AddControllers` call (ordering
+within the builder phase does not matter functionally, but placing it first groups infrastructure
+middleware together):
+
+```csharp
+const string corsPolicyName = "WormsWebUi";
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+_ = builder.Services.AddCors(options =>
+    options.AddPolicy(corsPolicyName, policy =>
+        policy.WithOrigins(allowedOrigins)
+              .WithMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+              .WithHeaders("Authorization", "Content-Type")));
+```
+
+`AllowCredentials()` is explicitly omitted — the UI authenticates via JWT bearer in the
+`Authorization` header, not cookies.
+
+### 5. Program.cs — middleware pipeline
+
+Inside the `if (runGateway)` block that configures the `WebApplication`, insert `app.UseCors()`
+**after** `UseRouting` and **before** `UseAuthentication`. The correct ASP.NET Core middleware
+order for CORS is:
+
+```
+UseHttpsRedirection
+UseRouting
+UseCors          ← insert here
+UseAuthentication
+UseAuthorization
+MapControllers / UseRequestLogging
+```
+
+The current code in `Program.cs` does not call `UseRouting()` explicitly (it is implicit in
+`MapControllers()`). With implicit routing, CORS middleware must still appear before
+`UseAuthentication`. The safe position is immediately before `UseAuthentication`:
+
+```csharp
+_ = app.UseHttpsRedirection();
+_ = app.UseRouting();           // add explicit UseRouting call
+_ = app.UseCors(corsPolicyName);
+_ = app.UseAuthentication();
+_ = app.UseAuthorization();
+```
+
+Note: `corsPolicyName` must be in scope at the point `app` is configured. Because `var
+corsPolicyName` is declared before `builder.Build()`, it is naturally in scope for both the
+`builder.Services` and `app` configuration sections.
+
+The `UseCors()` call must appear in **both** the `if (app.Environment.IsDevelopment())` branch
+and the `else` branch — or, more cleanly, before the `if`/`else` split entirely, since CORS
+applies in all environments:
+
+```csharp
+_ = app.UseHttpsRedirection();
+_ = app.UseRouting();
+_ = app.UseCors(corsPolicyName);
+_ = app.UseAuthentication();
+_ = app.UseAuthorization();
+
+if (app.Environment.IsDevelopment())
+{
+    _ = app.UseDeveloperExceptionPage();
+    _ = app.MapControllers();
+}
+else
+{
+    _ = app.MapControllers();
+}
+
+_ = app.UseRequestLogging();
+```
+
+### 6. Formatting constraints
+
+The file uses 4-space indentation, Allman braces, and 120-character line length (enforced by
+`.editorconfig`). The `AddCors` lambda chain should be formatted to stay within 120 characters.
+The `_ =` discard pattern is used consistently in this file for `IApplicationBuilder` return
+values — continue that pattern.
+
+### 7. No test changes
+
+There is no dedicated unit-test project for `Worms.Hub.Gateway`. The testing strategy notes that
+Gateway behaviour is exercised via integration tests and smoke testing. CORS behaviour requires a
+running HTTP stack (the behaviour is in middleware, not in application logic), so it is not
+amenable to pure unit testing. Verification is via `curl` against the local dev stack (see
+Verification section below).
+
+---
+
+## Verification
+
+1. Build the Gateway to confirm no compiler errors:
+   ```
+   make gateway.build
+   ```
+
+2. Start the local dev stack:
+   ```
+   docker compose up
+   ```
+
+3. Check a simple CORS preflight from the `http://localhost:3000` origin — confirm the gateway
+   returns a 204 with `Access-Control-Allow-Origin: http://localhost:3000` and
+   `Access-Control-Allow-Headers` includes `Authorization`:
+   ```
+   curl -s -o /dev/null -D - \
+     -X OPTIONS http://localhost:5005/api/v1/leagues \
+     -H "Origin: http://localhost:3000" \
+     -H "Access-Control-Request-Method: GET" \
+     -H "Access-Control-Request-Headers: Authorization"
+   ```
+   Expected response headers:
+   - `access-control-allow-origin: http://localhost:3000`
+   - `access-control-allow-headers: Authorization`
+   - HTTP status 204
+
+4. Repeat the same request with `Origin: http://localhost:5173` and confirm the same headers are
+   returned.
+
+5. Send the same preflight with an unlisted origin (e.g., `http://localhost:9999`) and confirm
+   there is no `access-control-allow-origin` header in the response.
+
+6. Send an actual `GET` request with a valid bearer token and `Origin: http://localhost:3000`
+   and confirm the API responds normally (auth behaviour unchanged):
+   ```
+   curl -s -o /dev/null -D - \
+     -H "Authorization: Bearer <token>" \
+     -H "Origin: http://localhost:3000" \
+     http://localhost:5005/api/v1/leagues
+   ```
+   Expected: HTTP 200 (or 401/403 if the token is invalid — the point is CORS headers are
+   present and the request is not rejected by CORS middleware).

--- a/.claude/specs/web-ui/slices/04-gateway-cors/review.md
+++ b/.claude/specs/web-ui/slices/04-gateway-cors/review.md
@@ -1,0 +1,50 @@
+# Review — Gateway CORS
+
+## Verdict
+
+The implementation fully satisfies the spec. All three planned files are modified exactly as described, the build exits clean with zero warnings (confirmed via `dotnet build --warnaserror`), and every acceptance criterion is met. There is one minor note on the `corsPolicyName`/`allowedOrigins` placement relative to the plan, which `learnings.md` already explains. No blockers. Ready to merge.
+
+## Acceptance Criteria
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Requests from `http://localhost:3000` or `http://localhost:5173` receive `Access-Control-Allow-Origin` in Development | MET | `appsettings.Development.json` lists both origins; `Program.cs` registers and applies the policy |
+| Preflight `OPTIONS` with `Authorization` in `Access-Control-Request-Headers` → 204 with `Authorization` in `Access-Control-Allow-Headers` | MET | `Program.cs:34` — `.WithHeaders("Authorization", "Content-Type")` |
+| Request from an unlisted origin does not receive `Access-Control-Allow-Origin` | MET | `appsettings.json:10-12` — base config has an empty `AllowedOrigins` array; no fallback |
+| `WORMS_CORS__ALLOWEDORIGINS` env var drives the allowed origins at runtime | MET | `Program.cs:26` — `builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()` reads from the merged config; `AddEnvironmentVariables("WORMS_")` is already wired and maps `__` to `:` |
+| Base `appsettings.json` with no env var override emits no CORS headers | MET | `appsettings.json:10-12` — `"AllowedOrigins": []`; `.WithOrigins()` called with empty array → policy matches nothing |
+| Existing authenticated API calls (JWT bearer from CLI) continue to succeed | MET | Auth, authorization, and controller registration are untouched; `UseCors` is inserted between `UseRouting` and `UseAuthentication`, which is the correct ASP.NET Core order and does not affect the auth pipeline |
+
+## Scope
+
+The diff touches exactly the three files listed in the plan's "Files to Create / Modify" table:
+
+- `src/Worms.Hub.Gateway/Program.cs`
+- `src/Worms.Hub.Gateway/appsettings.json`
+- `src/Worms.Hub.Gateway/appsettings.Development.json`
+
+No new files were created. No files outside the plan were modified.
+
+One deviation from the plan is documented in `learnings.md`: `corsPolicyName` and `allowedOrigins` are declared at the top level before the first `if (runGateway)` block rather than inside it. The plan acknowledged they needed to be in scope for both the service-registration and app-configuration blocks; the implementation chose the simplest correct placement. This is resolved — no issue.
+
+A second deviation is also documented: the plan described adding an explicit `UseRouting()` call, noting the existing code lacked one. In fact `UseRouting()` was already present, so only `UseCors(corsPolicyName)` was inserted between it and `UseAuthentication()`. This is resolved — no issue.
+
+## Blockers
+
+None.
+
+## Suggestions
+
+None.
+
+## Nitpicks
+
+None.
+
+## Tests
+
+No tests were added. The plan and `learnings.md` both note this is intentional: CORS behaviour lives in ASP.NET Core middleware and requires a running HTTP stack, making pure unit testing impractical. The testing strategy doc confirms that Gateway behaviour is exercised via integration tests and smoke testing. Verification is via `curl` against the local dev stack as described in the plan's Verification section. This is appropriate for the scope of the change.
+
+## Recommended Actions
+
+No findings to act on.

--- a/.claude/specs/web-ui/slices/04-gateway-cors/spec.md
+++ b/.claude/specs/web-ui/slices/04-gateway-cors/spec.md
@@ -1,0 +1,31 @@
+# Gateway CORS
+
+## Overview
+
+The Hub Gateway is configured to accept cross-origin browser requests from the web UI's origin(s), enabling the SPA to call the existing API without changing the Gateway's auth contract.
+
+## Requirements
+
+- The Gateway applies a CORS policy globally to all API endpoints.
+- The allowed origins are driven by configuration (`WORMS_CORS__ALLOWEDORIGINS`) so the list can differ between local dev and production without code changes.
+- The standard HTTP methods used by the API (GET, POST, PUT, DELETE, PATCH) are permitted by the policy.
+- The `Authorization` and `Content-Type` headers are permitted, so that JWT bearer tokens and JSON request bodies are accepted.
+- The local dev configuration (`appsettings.Development.json`) includes both `http://localhost:3000` (docker-compose web container) and `http://localhost:5173` (Vite dev server) as allowed origins.
+- The base `appsettings.json` contains no hardcoded origins; the production value is supplied via environment variable at deploy time.
+- The existing auth contract is unchanged: `[Authorize]` attributes, JWT bearer validation, and all existing authentication/authorization behaviour remain exactly as they are.
+
+## Out of Scope
+
+- Production origin configuration — the production URL is not yet known and is wired up in the production deployment slice.
+- Per-endpoint CORS policies — a single global policy is sufficient.
+- Credential-mode cookies — the UI authenticates via JWT bearer in the `Authorization` header; `AllowCredentials()` is not required.
+- Any changes to existing controllers, DTOs, or other Gateway logic.
+
+## Acceptance Criteria
+
+- Given a request from `http://localhost:3000` or `http://localhost:5173` arrives at the Gateway in the Development environment, the response includes the appropriate `Access-Control-Allow-Origin` header.
+- Given a preflight `OPTIONS` request from either local-dev origin with `Authorization` in `Access-Control-Request-Headers`, the Gateway responds with a 204 and includes `Authorization` in `Access-Control-Allow-Headers`.
+- Given a request from an origin not in the configured list, the Gateway does not include `Access-Control-Allow-Origin` in the response.
+- Given the `WORMS_CORS__ALLOWEDORIGINS` environment variable is set to a list of origins, those origins are used as the allowed origins at runtime.
+- Given the base `appsettings.json` (no env var override), the allowed origins list is empty and no CORS headers are emitted — confirming there is no hardcoded fallback.
+- Existing authenticated API calls (JWT bearer from the CLI) continue to succeed without any change in behaviour.

--- a/src/Worms.Hub.Gateway/Program.cs
+++ b/src/Worms.Hub.Gateway/Program.cs
@@ -22,8 +22,16 @@ var builder = WebApplication.CreateBuilder(args);
 _ = builder.Logging.AddSimpleConsole(options => options.SingleLine = true);
 builder.Configuration.AddConfiguration(configuration);
 
+const string corsPolicyName = "WormsWebUi";
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+
 if (runGateway)
 {
+    _ = builder.Services.AddCors(options =>
+        options.AddPolicy(corsPolicyName, policy =>
+            policy.WithOrigins(allowedOrigins)
+                  .WithMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+                  .WithHeaders("Authorization", "Content-Type")));
     _ = builder.Services.AddControllers()
         .ConfigureApplicationPartManager(manager => manager.FeatureProviders.Add(new InternalControllerProvider()));
     _ = builder.Services.AddApiVersioning();
@@ -54,6 +62,7 @@ if (runGateway)
 {
     _ = app.UseHttpsRedirection();
     _ = app.UseRouting();
+    _ = app.UseCors(corsPolicyName);
     _ = app.UseAuthentication();
     _ = app.UseAuthorization();
 

--- a/src/Worms.Hub.Gateway/appsettings.Development.json
+++ b/src/Worms.Hub.Gateway/appsettings.Development.json
@@ -6,6 +6,12 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "http://localhost:5173"
+    ]
+  },
   "Storage": {
     "TempReplayFolder": "C:\\Temp\\Replay",
     "CliFolder": "C:\\Temp\\Cli",

--- a/src/Worms.Hub.Gateway/appsettings.json
+++ b/src/Worms.Hub.Gateway/appsettings.json
@@ -7,6 +7,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": []
+  },
   "Auth": {
     "Authority": "https://eadie.eu.auth0.com/",
     "Audience": "worms.davideadie.dev",


### PR DESCRIPTION
## Summary

- Registers a `WormsWebUi` CORS policy in the Gateway that allows the configured origins with standard HTTP methods and `Authorization`/`Content-Type` headers
- Adds `Cors:AllowedOrigins` to `appsettings.json` (empty by default) and `appsettings.Development.json` (`localhost:3000` and `localhost:5173`)
- Places `UseCors` between `UseRouting` and `UseAuthentication` so it applies in all environments without touching the auth contract

## Test plan

- [x] `make gateway.build` passes (Docker build, `dotnet build --warnaserror`)
- [ ] `docker compose up` — `curl -H "Origin: http://localhost:3000" -I http://localhost:<gateway-port>/...` returns `Access-Control-Allow-Origin: http://localhost:3000`
- [ ] A request from an origin not in `AllowedOrigins` receives no CORS headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)