### PR TITLE
feat: degrade gracefully when DB schema is behind gateway version

### DIFF
--- a/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Worms.Hub.Gateway.API.DTOs;
+using Worms.Hub.Gateway.FeatureFlags;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Files;
 
@@ -8,14 +9,12 @@ namespace Worms.Hub.Gateway.API.Controllers;
 internal sealed class LeaguesController(
     SchemeFiles schemeFiles,
     LeaguesRepository leaguesRepository,
-    DatabaseSchemaVersion schemaVersion) : V1ApiController
+    IFeatureFlags featureFlags) : V1ApiController
 {
-    private static readonly Version LeaguesMinVersion = new(0, 3);
-
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<LeagueDto>>> GetAll()
     {
-        if (!await SchemaSupportsLeagues())
+        if (!await featureFlags.IsLeaguesEnabledAsync())
         {
             return NotFound();
         }
@@ -37,7 +36,7 @@ internal sealed class LeaguesController(
     [HttpGet("{id}")]
     public async Task<ActionResult<LeagueDto>> Get(string id)
     {
-        if (!await SchemaSupportsLeagues())
+        if (!await featureFlags.IsLeaguesEnabledAsync())
         {
             var filesystemDetails = await schemeFiles.GetLatestDetails(id);
             if (filesystemDetails is null)
@@ -65,9 +64,4 @@ internal sealed class LeaguesController(
             new Uri(Url.Action(action: "Get", controller: "SchemeFiles", values: new { id })!, UriKind.Relative));
     }
 
-    private async Task<bool> SchemaSupportsLeagues()
-    {
-        var current = await schemaVersion.GetCurrentVersionAsync();
-        return current is not null && current >= LeaguesMinVersion;
-    }
 }

--- a/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
@@ -5,11 +5,19 @@ using Worms.Hub.Storage.Files;
 
 namespace Worms.Hub.Gateway.API.Controllers;
 
-internal sealed class LeaguesController(SchemeFiles schemeFiles, LeaguesRepository leaguesRepository) : V1ApiController
+internal sealed class LeaguesController(
+    SchemeFiles schemeFiles,
+    LeaguesRepository leaguesRepository,
+    DatabaseSchemaVersion schemaVersion) : V1ApiController
 {
+    private static readonly Version LeaguesMinVersion = new(0, 3);
+
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<LeagueDto>>> GetAll()
     {
+        if (!await SchemaSupportsLeagues())
+            return NotFound();
+
         var dbLeagues = leaguesRepository.GetAll();
         var tasks = dbLeagues.Select(async dbLeague =>
         {
@@ -27,6 +35,18 @@ internal sealed class LeaguesController(SchemeFiles schemeFiles, LeaguesReposito
     [HttpGet("{id}")]
     public async Task<ActionResult<LeagueDto>> Get(string id)
     {
+        if (!await SchemaSupportsLeagues())
+        {
+            var filesystemDetails = await schemeFiles.GetLatestDetails(id);
+            if (filesystemDetails is null)
+                return NotFound();
+            return LeagueDto.FromDomain(
+                filesystemDetails.Id,
+                filesystemDetails.Name,
+                filesystemDetails,
+                new Uri(Url.Action(action: "Get", controller: "SchemeFiles", values: new { id })!, UriKind.Relative));
+        }
+
         var dbLeague = leaguesRepository.GetById(id);
         if (dbLeague is null)
         {
@@ -39,5 +59,11 @@ internal sealed class LeaguesController(SchemeFiles schemeFiles, LeaguesReposito
             dbLeague.Name,
             latestDetails,
             new Uri(Url.Action(action: "Get", controller: "SchemeFiles", values: new { id })!, UriKind.Relative));
+    }
+
+    private async Task<bool> SchemaSupportsLeagues()
+    {
+        var current = await schemaVersion.GetCurrentVersionAsync();
+        return current is not null && current >= LeaguesMinVersion;
     }
 }

--- a/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
@@ -16,7 +16,9 @@ internal sealed class LeaguesController(
     public async Task<ActionResult<IReadOnlyList<LeagueDto>>> GetAll()
     {
         if (!await SchemaSupportsLeagues())
+        {
             return NotFound();
+        }
 
         var dbLeagues = leaguesRepository.GetAll();
         var tasks = dbLeagues.Select(async dbLeague =>
@@ -39,7 +41,9 @@ internal sealed class LeaguesController(
         {
             var filesystemDetails = await schemeFiles.GetLatestDetails(id);
             if (filesystemDetails is null)
+            {
                 return NotFound();
+            }
             return LeagueDto.FromDomain(
                 filesystemDetails.Id,
                 filesystemDetails.Name,

--- a/src/Worms.Hub.Gateway/FeatureFlags/FeatureFlags.cs
+++ b/src/Worms.Hub.Gateway/FeatureFlags/FeatureFlags.cs
@@ -1,0 +1,14 @@
+using Worms.Hub.Storage.Database;
+
+namespace Worms.Hub.Gateway.FeatureFlags;
+
+internal sealed class GatewayFeatureFlags(DatabaseSchemaVersion schemaVersion) : IFeatureFlags
+{
+    private static readonly Version LeaguesMinVersion = new(0, 3);
+
+    public async Task<bool> IsLeaguesEnabledAsync()
+    {
+        var current = await schemaVersion.GetCurrentVersionAsync();
+        return current is not null && current >= LeaguesMinVersion;
+    }
+}

--- a/src/Worms.Hub.Gateway/FeatureFlags/IFeatureFlags.cs
+++ b/src/Worms.Hub.Gateway/FeatureFlags/IFeatureFlags.cs
@@ -1,0 +1,6 @@
+namespace Worms.Hub.Gateway.FeatureFlags;
+
+internal interface IFeatureFlags
+{
+    Task<bool> IsLeaguesEnabledAsync();
+}

--- a/src/Worms.Hub.Gateway/ServiceRegistration.cs
+++ b/src/Worms.Hub.Gateway/ServiceRegistration.cs
@@ -2,6 +2,7 @@ using Worms.Armageddon.Files;
 using Worms.Hub.Gateway.Announcers;
 using Worms.Hub.Gateway.Announcers.Slack;
 using Worms.Hub.Gateway.API.Validators;
+using Worms.Hub.Gateway.FeatureFlags;
 using Worms.Hub.Gateway.Worker;
 using Worms.Hub.Queues;
 using Worms.Hub.Storage;
@@ -11,7 +12,7 @@ namespace Worms.Hub.Gateway;
 internal static class ServiceRegistration
 {
     public static IServiceCollection AddGatewayServices(this IServiceCollection builder) =>
-        builder.AddHttpClient().AddScoped<IAnnouncer, Announcer>().AddScoped<ReplayFileValidator>().AddScoped<CliFileValidator>();
+        builder.AddHttpClient().AddScoped<IAnnouncer, Announcer>().AddScoped<ReplayFileValidator>().AddScoped<CliFileValidator>().AddScoped<IFeatureFlags, GatewayFeatureFlags>();
 
     public static IServiceCollection AddWorkerServices(this IServiceCollection builder) =>
         builder.AddHubStorageServices()

--- a/src/Worms.Hub.Storage/Database/DatabaseSchemaVersion.cs
+++ b/src/Worms.Hub.Storage/Database/DatabaseSchemaVersion.cs
@@ -18,7 +18,9 @@ public sealed class DatabaseSchemaVersion(IConfiguration configuration)
         lock (_lock)
         {
             if (_cached is not null && DateTime.UtcNow - _cachedAt < CacheTtl)
+            {
                 return _cached;
+            }
         }
 
         var version = await FetchFromDatabase();

--- a/src/Worms.Hub.Storage/Database/DatabaseSchemaVersion.cs
+++ b/src/Worms.Hub.Storage/Database/DatabaseSchemaVersion.cs
@@ -1,0 +1,50 @@
+using Dapper;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace Worms.Hub.Storage.Database;
+
+[PublicAPI]
+public sealed class DatabaseSchemaVersion(IConfiguration configuration)
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(60);
+    private readonly Lock _lock = new();
+    private Version? _cached;
+    private DateTime _cachedAt = DateTime.MinValue;
+
+    public async Task<Version?> GetCurrentVersionAsync()
+    {
+        lock (_lock)
+        {
+            if (_cached is not null && DateTime.UtcNow - _cachedAt < CacheTtl)
+                return _cached;
+        }
+
+        var version = await FetchFromDatabase();
+
+        lock (_lock)
+        {
+            _cached = version;
+            _cachedAt = DateTime.UtcNow;
+        }
+
+        return version;
+    }
+
+    private async Task<Version?> FetchFromDatabase()
+    {
+        try
+        {
+            var connectionString = configuration.GetConnectionString("Database");
+            await using var connection = new NpgsqlConnection(connectionString);
+            var versionString = await connection.QuerySingleOrDefaultAsync<string>(
+                "SELECT version FROM flyway_schema_history WHERE success = true AND version IS NOT NULL ORDER BY installed_rank DESC LIMIT 1");
+            return versionString is null ? null : Version.Parse(versionString);
+        }
+        catch (NpgsqlException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Worms.Hub.Storage/ServiceRegistration.cs
+++ b/src/Worms.Hub.Storage/ServiceRegistration.cs
@@ -10,7 +10,8 @@ namespace Worms.Hub.Storage;
 public static class ServiceRegistration
 {
     public static IServiceCollection AddHubStorageServices(this IServiceCollection builder) =>
-        builder.AddScoped<IRepository<Game>, GamesRepository>()
+        builder.AddSingleton<DatabaseSchemaVersion>()
+            .AddScoped<IRepository<Game>, GamesRepository>()
             .AddScoped<IRepository<Replay>, ReplaysRepository>()
             .AddScoped<LeaguesRepository>()
             .AddScoped<CliFiles>()


### PR DESCRIPTION
## Summary

- Adds `DatabaseSchemaVersion` service in `Worms.Hub.Storage` that queries Flyway's `flyway_schema_history` table to determine the highest successfully applied migration version. Results are cached for 60 seconds to avoid per-request DB overhead.
- Gates both leagues endpoints on schema V0.3: `GET /api/v1/leagues` returns 404 (matching pre-PR behaviour when the route didn't exist) and `GET /api/v1/leagues/{id}` falls back to the old filesystem-only path.
- Removes the risk of deploying the gateway before the V0.3 database migration — the system degrades gracefully rather than crashing.

## Test plan

- [ ] Deploy gateway against a database still on V0.2.x — both leagues endpoints respond without crashing
- [ ] `GET /api/v1/leagues` returns 404 on old schema; returns league list once V0.3 migration has run (within 60s)
- [ ] `GET /api/v1/leagues/{id}` returns scheme file data on old schema; returns DB-enriched data once V0.3 migration has run
- [ ] All unit tests pass (`make cli.test.unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)