### PR TITLE
feat: game detail page

### DIFF
--- a/.claude/specs/web-ui/plan.md
+++ b/.claude/specs/web-ui/plan.md
@@ -15,6 +15,6 @@ Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a sing
 - [x] **Authenticated route gate** — every page other than the landing page requires a signed-in league member; signed-out visitors are redirected to sign in.
 - [x] **League list** — a signed-in member sees a list of leagues to navigate into, including any Gateway API extension needed to serve that list.
 - [x] **Per-league page** — a signed-in member can open a league and see its historic games list and the scheme it uses, including any Gateway API extension needed.
-- [ ] **Game detail page** — a signed-in member can drill into a single game and see its participants, winner, scheme, and date.
+- [x] **Game detail page** — a signed-in member can drill into a single game and see its participants, winner, scheme, and date.
 - [ ] **Replay viewer** — the game detail page renders the replay's GIF(s) and log in the browser, including any Gateway API extension needed to retrieve those artifacts.
 - [ ] **Production deployment** — the SPA is built and deployed to production alongside the rest of the Hub, with CORS and authority configuration applied to the production environment.

--- a/.claude/specs/web-ui/slices/12-game-detail-page/learnings.md
+++ b/.claude/specs/web-ui/slices/12-game-detail-page/learnings.md
@@ -1,0 +1,37 @@
+# Learnings: Game Detail Page
+
+## Implementation Notes
+
+### MUI v9 does not accept `fontWeight` or `display` as direct props on `<Typography>`
+
+The plan's code examples (taken from the design mockup) pass `fontWeight={700}` and `display="block"` as direct JSX props on `<Typography>`. In MUI v9, these are not part of the typed `TypographyProps` interface and TypeScript rejects them. The correct approach — consistent with the rest of the codebase (e.g. `LeagueDetailPage.tsx`) — is to put them inside the `sx` prop: `sx={{ fontWeight: 700 }}` and `sx={{ display: 'block', ... }}`. This applies to any scalar MUI system shorthand that was usable as a direct prop in earlier MUI versions.
+
+### `primaryTypographyProps` is removed from `<ListItemText>` in MUI v9
+
+The plan specifies `primaryTypographyProps={{ fontSize: 13, fontWeight: ... }}` on `<ListItemText>`. This prop was removed in MUI v5→v6 in favour of `slotProps`. In MUI v9 the TypeScript type has no `primaryTypographyProps` property at all and the build fails. The fix is:
+
+```tsx
+slotProps={{
+    primary: {
+        style: { fontSize: 13, fontWeight: activePanel === i ? 700 : 400 },
+    },
+}}
+```
+
+Using `style` (inline React style) inside `slotProps.primary` is safe for simple scalar overrides where `sx` is not available.
+
+### `AddWormsArmageddonFilesServices` was removed from `AddWorkerServices` and added to `Program.cs`
+
+The plan correctly identified the duplicate-registration risk. Moving the call to `Program.cs` (unconditional, outside both `AddGatewayServices` and `AddWorkerServices`) ensures exactly one registration regardless of which mode(s) are active. The `using Worms.Armageddon.Files;` import also had to be removed from `ServiceRegistration.cs` (it was no longer needed there) and added to `Program.cs`.
+
+### Prettier reformatted `GameDetailPage.tsx` after initial write
+
+The authored file had minor formatting deviations from Prettier's output (brace placement, trailing commas, line wrapping). Running `npx prettier --write src/pages/GameDetailPage.tsx` was required to pass `make web.lint`. As noted in the slice 11 learnings, Prettier must be run on any new `.tsx` file before committing.
+
+### Gateway fully qualified namespace used for `ReplayResource` in controller
+
+The controller uses `ReplayResource` from `Worms.Armageddon.Files.Replays` namespace. Rather than adding a `using` directive that could conflict with other types in scope, the fully qualified name `Worms.Armageddon.Files.Replays.ReplayResource? parsed` was used in the action method body. This is a minor style deviation from the plan snippet but avoids any ambiguity.
+
+## Files Added (not in plan)
+
+None — all files created or modified were listed in the plan.

--- a/.claude/specs/web-ui/slices/12-game-detail-page/plan.md
+++ b/.claude/specs/web-ui/slices/12-game-detail-page/plan.md
@@ -1,0 +1,417 @@
+# Plan: Game Detail Page
+
+## Context
+
+This slice adds a game detail page — the drill-down from the per-league replay list that was delivered in slice 11. It consists of two parts: a new `GET /api/v1/leagues/{id}/replays/{replayId}` endpoint in the Hub Gateway that parses the stored `full_log` on demand and returns a turn-by-turn breakdown, and a new `GameDetailPage` in the SPA that shows a hero card with stats, a breadcrumb, and a two-panel sidebar layout (Turn-by-turn and Weapons). Slice 11 already delivers `LeagueDetailPage` which navigates to `/leagues/:id/replays/:replayId` on row click, so the routing hook is already present; this slice just needs to register the route in `App.tsx` and create the page component.
+
+`IReplayTextReader` already exists in `Worms.Armageddon.Files` and is registered via `AddWormsArmageddonFilesServices()`. That registration is currently only called from `AddWorkerServices()`. The gateway HTTP pipeline does not yet call it, so it must be wired in for the gateway path before `LeaguesController` can use it.
+
+---
+
+## Files to Create / Modify
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `src/Worms.Hub.Web/src/pages/GameDetailPage.tsx` | The full game detail SPA page (hero card, breadcrumb, sidebar panels) |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs` | Add `GET {id}/replays/{replayId}` action that looks up replay, parses log, returns `ReplayDetailDto` |
+| `src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs` | Add `ReplayDetailDto`, `TurnDto`, `WeaponDto`, `DamageSummaryDto` records |
+| `src/Worms.Hub.Gateway/ServiceRegistration.cs` | Add `AddWormsArmageddonFilesServices()` call inside `AddGatewayServices()` so `IReplayTextReader` is available when the gateway runs without the worker |
+| `src/Worms.Hub.Web/src/App.tsx` | Register `/leagues/:id/replays/:replayId` route |
+| `src/database/local-dev/R__ReplaysTestData.sql` | Add one replay row whose `full_log` column contains a realistic WA log string |
+
+---
+
+## Implementation Details
+
+### 1. New DTO types in `ReplayDtos.cs`
+
+Add three new record types alongside the existing `ReplayDto` and `CreateReplayDto`:
+
+```csharp
+[PublicAPI]
+internal sealed record ReplayDetailDto(
+    string Id,
+    string Name,
+    string Status,
+    DateTime? Date,
+    string? Winner,
+    IReadOnlyList<string>? Teams,
+    IReadOnlyList<TurnDto>? Turns);
+
+[PublicAPI]
+internal sealed record TurnDto(
+    int TurnNumber,
+    string TeamName,
+    IReadOnlyList<WeaponDto> Weapons,
+    IReadOnlyList<DamageSummaryDto> Damage);
+
+[PublicAPI]
+internal sealed record WeaponDto(string Name);
+
+[PublicAPI]
+internal sealed record DamageSummaryDto(
+    string TeamName,
+    uint HealthLost,
+    uint WormsKilled);
+```
+
+`ReplayDetailDto` does not extend `ReplayDto` — it's a separate flat record to keep the JSON shape clean and explicit.
+
+Add a static factory method `ReplayDetailDto.FromDomain(Replay replay, ReplayResource? parsed)`:
+
+```csharp
+internal static ReplayDetailDto FromDomain(Replay replay, ReplayResource? parsed)
+{
+    IReadOnlyList<TurnDto>? turns = null;
+
+    if (parsed is not null)
+    {
+        var turnList = parsed.Turns.Select((t, i) => new TurnDto(
+            i + 1,
+            t.Team.Name,
+            t.Weapons.Select(w => new WeaponDto(w.Name)).ToList(),
+            t.Damage.Select(d => new DamageSummaryDto(d.Team.Name, d.HealthLost, d.WormsKilled)).ToList()
+        )).ToList();
+        turns = turnList.Count > 0 ? turnList : null;
+    }
+
+    return new ReplayDetailDto(
+        replay.Id,
+        replay.Name,
+        replay.Status,
+        replay.Date,
+        replay.Winner,
+        replay.Teams,
+        turns);
+}
+```
+
+Note: `turns` is set to `null` (not an empty list) when `parsed` has no turns, so the SPA can distinguish "no log" from "log with zero turns" using the same null check.
+
+### 2. Gateway service registration: add `IReplayTextReader` to gateway path
+
+`AddGatewayServices()` in `src/Worms.Hub.Gateway/ServiceRegistration.cs` must call `AddWormsArmageddonFilesServices()`. Currently only `AddWorkerServices()` does this. The `Worms.Armageddon.Files` project reference already exists in `Worms.Hub.Gateway.csproj` (it is used transitively by the worker build), so no new project reference is needed.
+
+Change `AddGatewayServices()`:
+
+```csharp
+public static IServiceCollection AddGatewayServices(this IServiceCollection builder) =>
+    builder.AddHttpClient()
+        .AddWormsArmageddonFilesServices()
+        .AddScoped<IAnnouncer, Announcer>()
+        .AddScoped<ReplayFileValidator>()
+        .AddScoped<CliFileValidator>()
+        .AddScoped<IFeatureFlags, GatewayFeatureFlags>();
+```
+
+This is safe because `AddWormsArmageddonFilesServices` registers with `AddScoped` and `ServiceCollection` silently ignores duplicate scoped registrations — but verify that `AddWorkerServices` also calls it for the worker path. `AddWorkerServices` already calls `AddWormsArmageddonFilesServices()` independently; if both run in the same process (monolith mode), DI will have duplicate `IReplayLineParser` registrations. Check whether `IReplayTextReader` uses `IEnumerable<IReplayLineParser>` (it does — it takes `IEnumerable<IReplayLineParser>` in its constructor). Duplicate registrations of `IReplayLineParser` would cause each parser to run twice per line. To avoid this, conditionally add only in gateway mode, or extract the check.
+
+**Safer approach**: Call `AddWormsArmageddonFilesServices()` once in `Program.cs` outside both `AddGatewayServices` and `AddWorkerServices`, only when the gateway is running — then remove it from `AddWorkerServices`. However, that restructures `Program.cs` more broadly.
+
+**Simplest safe approach**: Move the call out of both methods and into `Program.cs`, called unconditionally (it's needed by both the gateway and the worker):
+
+In `Program.cs`, on the line:
+```csharp
+_ = builder.Services.AddHubStorageServices().AddGatewayServices().AddQueueServices();
+```
+
+Change to:
+```csharp
+_ = builder.Services.AddHubStorageServices().AddGatewayServices().AddQueueServices().AddWormsArmageddonFilesServices();
+```
+
+And remove the `AddWormsArmageddonFilesServices()` call from `AddWorkerServices()` in `ServiceRegistration.cs`.
+
+This ensures there is exactly one registration regardless of which modes run.
+
+You need to add the `using Worms.Armageddon.Files;` namespace to `Program.cs`.
+
+### 3. New endpoint in `LeaguesController`
+
+Inject `IReplayTextReader replayTextReader` into `LeaguesController`'s primary constructor, alongside the existing parameters.
+
+Add a new action:
+
+```csharp
+[HttpGet("{id}/replays/{replayId}")]
+public ActionResult<ReplayDetailDto> GetReplay(string id, string replayId)
+{
+    var league = leaguesRepository.GetById(id);
+    if (league is null)
+    {
+        return NotFound();
+    }
+
+    var replay = replaysRepository.GetByLeagueId(id).FirstOrDefault(r => r.Id == replayId);
+    if (replay is null)
+    {
+        return NotFound();
+    }
+
+    ReplayResource? parsed = null;
+    if (!string.IsNullOrEmpty(replay.FullLog))
+    {
+        parsed = replayTextReader.GetModel(replay.FullLog);
+    }
+
+    return ReplayDetailDto.FromDomain(replay, parsed);
+}
+```
+
+This:
+- Returns 404 if the league doesn't exist (wrong `{id}`)
+- Returns 404 if the replay doesn't exist for that league (wrong `{replayId}`, or replay belongs to a different league)
+- Returns hero data with `turns: null` when `FullLog` is absent
+- Returns parsed turns when `FullLog` is present
+- Returns 401 for unauthenticated requests (via the inherited `[Authorize]` on `V1ApiController`)
+
+The `replayId` coming from the URL is a string; `Replay.Id` is also a string. The comparison `r.Id == replayId` is correct without parsing.
+
+### 4. Route registration in `App.tsx`
+
+Add a new import and route child entry. Place it after the `leagues/:id` route:
+
+```tsx
+import GameDetailPage from './pages/GameDetailPage'
+```
+
+```tsx
+{
+    path: 'leagues/:id/replays/:replayId',
+    element: (
+        <RequireAuth>
+            <GameDetailPage />
+        </RequireAuth>
+    ),
+},
+```
+
+### 5. `GameDetailPage.tsx` — structure and behaviour
+
+Create `src/Worms.Hub.Web/src/pages/GameDetailPage.tsx`. The page is relatively large; break it into local sub-components within the same file (no separate component files for this slice).
+
+**TypeScript interfaces** (mirrors the gateway DTOs):
+
+```ts
+interface WeaponDto {
+    name: string
+}
+
+interface DamageSummaryDto {
+    teamName: string
+    healthLost: number
+    wormsKilled: number
+}
+
+interface TurnDto {
+    turnNumber: number
+    teamName: string
+    weapons: WeaponDto[]
+    damage: DamageSummaryDto[]
+}
+
+interface ReplayDetailDto {
+    id: string
+    name: string
+    status: string
+    date: string | null
+    winner: string | null
+    teams: string[] | null
+    turns: TurnDto[] | null
+}
+
+interface LeagueDto {
+    id: string
+    name: string
+    version: string | null
+    schemeUrl: string | null
+}
+```
+
+**Data fetching**: single `useEffect` with `Promise.all` over two fetches — `GET /api/v1/leagues/{id}/replays/{replayId}` and `GET /api/v1/leagues/{id}`. Use the same pattern as `LeagueDetailPage.tsx` (check `res.status === 404` separately; rethrow non-ok responses; parse JSON; set state).
+
+**State**:
+- `replay: ReplayDetailDto | null`
+- `league: LeagueDto | null`
+- `error: string | null`
+- `notFound: boolean`
+- `activePanel: number` (0 = Turn-by-turn, 1 = Weapons)
+
+**Render logic**:
+1. If loading (both null, no error, not notFound): show `<CircularProgress />`.
+2. If `notFound`: show "Replay not found." message.
+3. If `error !== null`: show error message.
+4. If `replay !== null && replay.status !== 'Processed'`: show a "This replay is being processed. Please check back soon." message with no hero card or panels.
+5. If `replay !== null && replay.status === 'Processed'` and `league !== null`: show full page.
+
+**Breadcrumb** (when data loaded):
+```
+Leagues → {league.name} → Match #00x
+```
+- "Leagues" is `<MuiLink component={RouterLink} to="/leagues">Leagues</MuiLink>`
+- "{league.name}" is `<MuiLink component={RouterLink} to={`/leagues/${id}`}>{league.name}</MuiLink>`
+- "Match #00x" is `<Typography variant="body2" color="text.primary">Match #{replay.id.padStart(3, '0')}</Typography>`
+
+**Hero card** (a `<Paper variant="outlined" sx={{ p: 3, mb: 2 }}>`):
+
+Title row:
+- `<Typography variant="h5" fontWeight={700}>Match #{replay.id.padStart(3, '0')}</Typography>`
+- Date and time formatted with `toLocaleDateString` / `toLocaleTimeString` (same locale pattern as `LeagueDetailPage`)
+- Winner chip: `color="warning"` when winner is a team name (non-null, non-"Draw"); `color="default"` (neutral) for "Draw". Omit entirely when `replay.winner === null`.
+- Chips for participating team names from `replay.teams`.
+- Scheme version chip: `label={\`Scheme v${league.version}\`}` — omit when `league.version === null`.
+
+**Stats strip** (four `<Paper variant="outlined">` tiles in a CSS grid `repeat(4, 1fr)`):
+- Omit the entire strip when `replay.turns === null || replay.turns.length === 0`.
+- **Duration**: `turns[turns.length - 1].end - turns[0].start`. Since the Turn-by-turn data coming from the API has `TurnDto` without timestamp fields (only turn number, weapons, damage), duration **cannot** be computed client-side from the DTO as currently shaped. **Resolution**: the DTO must include timestamps. Add `startMs: number` and `endMs: number` to `TurnDto` (milliseconds from game start as a `double` in .NET, sent as a JSON number). In .NET, `TimeSpan.TotalMilliseconds` gives the double. In the SPA compute duration as `turns[n-1].endMs - turns[0].startMs` ms, then format as `mm:ss`.
+
+  Update `TurnDto` in the gateway:
+  ```csharp
+  internal sealed record TurnDto(
+      int TurnNumber,
+      string TeamName,
+      double StartMs,
+      double EndMs,
+      IReadOnlyList<WeaponDto> Weapons,
+      IReadOnlyList<DamageSummaryDto> Damage);
+  ```
+
+  And in `FromDomain`:
+  ```csharp
+  new TurnDto(
+      i + 1,
+      t.Team.Name,
+      t.Start.TotalMilliseconds,
+      t.End.TotalMilliseconds,
+      ...weapons,
+      ...damage)
+  ```
+
+  Duration helper in the SPA:
+  ```ts
+  function formatDuration(ms: number): string {
+      const totalSeconds = Math.floor(ms / 1000)
+      const minutes = Math.floor(totalSeconds / 60)
+      const seconds = totalSeconds % 60
+      return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  }
+  ```
+
+- **Turns**: `turns.length` (plain number).
+- **Max Damage**: `Math.max(...turns.map(t => t.damage.reduce((sum, d) => sum + d.healthLost, 0)))`.
+- **Kills**: `turns.reduce((sum, t) => sum + t.damage.reduce((sum2, d) => sum2 + d.wormsKilled, 0), 0)`.
+
+**Sidebar layout** — CSS grid `gridTemplateColumns: '200px 1fr'`:
+
+Left nav (`<Paper variant="outlined">` with a `<List dense>`):
+- "Turn-by-turn" (icon: `<TimelineIcon />`), selected when `activePanel === 0`
+- "Weapons" (icon: `<GpsFixedIcon />`), selected when `activePanel === 1`
+- Use `<ListItemButton selected={activePanel === i} onClick={() => setActivePanel(i)}>`
+
+Right content area: render the active panel component.
+
+**Turn-by-turn panel** (`TurnByTurnPanel` local component):
+
+- When `turns === null || turns.length === 0`: show `<Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>` with an appropriate empty-state message.
+- Otherwise: `<TableContainer component={Paper} variant="outlined">` with `<Table size="small">`.
+  - Columns: `#`, `Team`, `Weapons used`, `Damage dealt`.
+  - Turn number: `String(turn.turnNumber).padStart(2, '0')` in monospace.
+  - Team: `<Chip size="small" label={turn.teamName} />`.
+  - Weapons: if `turn.weapons.length === 0`, show `—` (em dash in `<Typography variant="caption" color="text.disabled">`). Otherwise render each weapon as a `<Chip size="small" label={w.name} variant="outlined" />` in a `<Stack direction="row" spacing={0.5}>`. The **last** weapon gets `sx={{ fontWeight: 700 }}` (bold label) to visually distinguish it.
+  - Damage: if `turn.damage.length === 0`, show `—`. Otherwise for each damage entry: `{d.teamName}: {d.healthLost}` with an optional `<Chip label={`+${d.wormsKilled} kill${d.wormsKilled > 1 ? 's' : ''}`} size="small" color="error" />` when `d.wormsKilled > 0`.
+
+**Weapons panel** (`WeaponsPanel` local component):
+
+- When `turns === null || turns.length === 0`: show empty-state message.
+- Otherwise compute per-team weapon stats purely in the component:
+  ```ts
+  type WeaponStats = { name: string; usageCount: number; attributedDamage: number }
+  type TeamWeaponMap = Map<string, WeaponStats[]>
+  ```
+  Algorithm:
+  1. For each turn, find the last weapon (`turn.weapons[turn.weapons.length - 1]`) — this is the "damaging weapon" for attributed damage.
+  2. For each turn, for each weapon in `turn.weapons`: increment `usageCount` for `(teamName, weaponName)` pair.
+  3. For each turn, sum `turn.damage.reduce((s, d) => s + d.healthLost, 0)` to get total damage for that turn; attribute it to `(teamName, lastWeapon.name)`.
+  4. Collect per team, sort entries by `attributedDamage` descending, then `usageCount` descending as tiebreaker.
+
+  Render as a `<Stack spacing={2}>` — one section per team:
+  - Team name as a `<Typography variant="subtitle2" fontWeight={700}>`.
+  - Weapon entries in a `<TableContainer component={Paper} variant="outlined"><Table size="small">` with columns: Weapon, Uses, Attributed Damage.
+
+### 6. Local-dev seed data in `R__ReplaysTestData.sql`
+
+The file already does `DELETE FROM public.replays` and re-inserts 5 rows. Add a sixth row with `full_log` set to a multi-line WA log. The log must have at least four turns with weapons and damage, a winner line, and team declarations so `IReplayTextReader` can parse it correctly.
+
+Use this canonical seed log (escape the `$` character — PostgreSQL `$$`-quoted strings work without escaping). Use a dollar-quoted string literal to avoid single-quote escaping:
+
+```sql
+INSERT INTO public.replays (name, status, filename, league_id, date, winner, teams, fulllog)
+VALUES (
+    '2024-06-01',
+    'Processed',
+    'seed_replay_withlog.WAgame',
+    'redgate',
+    '2024-06-01 19:00:00',
+    'Team Alpha',
+    ARRAY['Team Alpha', 'Team Beta'],
+    $$Game Started at 2024-06-01 19:00:00 GMT
+Red: "player1" as "Team Alpha"
+Blue: "player2" as "Team Beta"
+[00:00:05.00] ••• Team Alpha (player1) starts turn
+[00:00:08.00] ••• Team Alpha (player1) fires Shotgun
+[00:00:25.00] ••• Damage dealt: 45 to Team Beta (player2)
+[00:00:27.00] ••• Team Alpha (player1) ends turn; time used: 22.00 sec turn, 3.00 sec retreat
+[00:00:35.00] ••• Team Beta (player2) starts turn
+[00:00:40.00] ••• Team Beta (player2) fires Grenade (3 sec, min bounce)
+[00:00:58.00] ••• Damage dealt: 30 to Team Alpha (player1)
+[00:01:00.00] ••• Team Beta (player2) ends turn; time used: 25.00 sec turn, 3.00 sec retreat
+[00:01:10.00] ••• Team Alpha (player1) starts turn
+[00:01:15.00] ••• Team Alpha (player1) fires Ninja Rope
+[00:01:20.00] ••• Team Alpha (player1) fires Banana Bomb (5 sec)
+[00:01:35.00] ••• Damage dealt: 80 (1 kill) to Team Beta (player2)
+[00:01:37.00] ••• Team Alpha (player1) ends turn; time used: 27.00 sec turn, 3.00 sec retreat
+[00:01:45.00] ••• Team Beta (player2) starts turn
+[00:01:50.00] ••• Team Beta (player2) fires Bazooka
+[00:02:05.00] ••• Damage dealt: 50 to Team Alpha (player1)
+[00:02:07.00] ••• Team Beta (player2) ends turn; time used: 22.00 sec turn, 3.00 sec retreat
+Team Alpha wins the match!
+$$
+);
+```
+
+The PostgreSQL column name is `fulllog` (all lowercase) per `V0.2.2__AddFullLogToReplayTable.sql` (`ALTER TABLE public.replays ADD COLUMN fulllog text`). Dapper maps it to the C# property via the `fullLog` alias in SELECT queries. In the INSERT statement, use the lowercase column name `fulllog`.
+
+### 7. `Worms.Armageddon.Files` project reference in gateway
+
+`src/Worms.Hub.Gateway/Worms.Hub.Gateway.csproj` already contains `<ProjectReference Include="..\Worms.Armageddon.Files\Worms.Armageddon.Files.csproj"/>`. No `.csproj` change is needed.
+
+### 8. MUI icon imports
+
+The sidebar uses `TimelineIcon` and `GpsFixedIcon`. These come from `@mui/icons-material` which is already a dependency. Import them as:
+
+```tsx
+import TimelineIcon from '@mui/icons-material/Timeline'
+import GpsFixedIcon from '@mui/icons-material/GpsFixed'
+```
+
+Also needed in this page: `Box`, `Breadcrumbs`, `Chip`, `CircularProgress`, `Container`, `List`, `ListItemButton`, `ListItemIcon`, `ListItemText`, `MuiLink` (from `@mui/material/Link`), `Paper`, `Stack`, `Table`, `TableBody`, `TableCell`, `TableContainer`, `TableHead`, `TableRow`, `Typography`, `ListItemText`. Import each from its own path (`@mui/material/Box`, etc.) — consistent with the pattern in `LeagueDetailPage.tsx`.
+
+---
+
+## Verification
+
+1. `dotnet build src/Worms.Hub.Gateway --warnaserror` — must produce no warnings or errors.
+2. `make web.build && make web.lint` — must pass with no TypeScript errors, ESLint errors, or Prettier diffs.
+3. `docker compose up` — seed data applies; navigate to the Redgate league page, click the seeded replay row with `full_log`; the detail page loads with a populated hero card (title "Match #006", correct date, winner chip "Team Alpha", two team chips, no scheme version chip since "Scheme v..." depends on league having a version), a stats strip (duration ~2m02s, 4 turns, max damage 80+50=130 or per-turn max = turn 3 with 80, kills = 1), Turn-by-turn panel showing 4 rows, and Weapons panel showing per-team breakdown.
+4. Navigate to `/leagues/redgate/replays/999` — must show the not-found message.
+5. Navigate to `/leagues/redgate/replays/{id-of-pending-replay}` — must show the "processing" message with no hero card or panels.
+6. Open a browser DevTools network tab; confirm `GET /api/v1/leagues/redgate/replays/{id}` returns 200 with `turns` array present for the seeded replay.
+7. Open the page without signing in — confirm the existing `RequireAuth` wrapper redirects to `/`.
+8. Call `GET /api/v1/leagues/redgate/replays/{id}` with no `Authorization` header — must return 401.

--- a/.claude/specs/web-ui/slices/12-game-detail-page/review.md
+++ b/.claude/specs/web-ui/slices/12-game-detail-page/review.md
@@ -1,0 +1,83 @@
+# Review — Game Detail Page
+
+## Verdict
+
+The implementation satisfies the great majority of the spec. The build and lint pass clean, the SPA component is well-structured, the DTO mapping is correct, and the seed data will parse with the existing `IReplayTextReader`. There is one blocker: removing `AddWormsArmageddonFilesServices()` from `AddWorkerServices()` and placing it only inside the `if (runGateway)` block in `Program.cs` breaks the distributed worker-only deployment mode — `Processor` depends on `IReplayTextReader`, which is no longer registered when the gateway does not run. This must be fixed before merging.
+
+## Acceptance Criteria
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Signed-in user sees hero card, date/time, winner chip, team chips, scheme chip, stats strip for a processed replay | MET | `GameDetailPage.tsx:374–487` renders all elements |
+| Duration, Turns, Max Damage, Kills computed correctly from turn data | MET | `GameDetailPage.tsx:326–334`; formulas match spec |
+| Drawn game shows "Draw" chip with neutral (default) colour | MET | `GameDetailPage.tsx:411`: `color={replay.winner === 'Draw' ? 'default' : 'warning'}` |
+| Scheme version chip absent when league has no version | MET | `GameDetailPage.tsx:435`: guarded by `league.version !== null` |
+| Stats strip absent when no turn data | MET | `GameDetailPage.tsx:447`: `{hasTurns && (…)}` |
+| Breadcrumb shows Leagues → League Name → Match #00x with correct links | MET | `GameDetailPage.tsx:349–371` |
+| Turn-by-turn panel active by default; clicking Weapons switches panel | MET | `GameDetailPage.tsx:281,504–506` |
+| One row per turn in order; all turns shown including no-weapons / no-damage turns | MET | `GameDetailPage.tsx:98–173` |
+| Last weapon visually distinguished (bold) | MET | `GameDetailPage.tsx:130–134`: last weapon gets `sx={{ fontWeight: 700 }}` |
+| Turns with no weapons show "—"; turns with no damage show "—" | MET | `GameDetailPage.tsx:113–116,141–144` |
+| Weapons panel shows per-team entries with attributed damage sorted descending | MET | `GameDetailPage.tsx:197–229` |
+| No log → hero card shown but both panels show empty-state message | MET | `turns === null` paths in `TurnByTurnPanel` and `WeaponsPanel`; `turns` is `null` (not `[]`) per DTO shape |
+| Pending replay shows "processing" message with no hero card | MET | `GameDetailPage.tsx:341–344` |
+| Non-existent or cross-league replay shows not-found message | MET | `GameDetailPage.tsx:292–295` (SPA); `LeaguesController.cs:85–92` (API) |
+| Non-2xx from either API call shows error message | PARTIAL | `GameDetailPage.tsx:296–297`: error shown. However a 404 on `leagueRes` shows "Error: HTTP 404" rather than a "not found" message. This is an edge case (league must exist to navigate here) and is a pre-existing pattern in other pages. |
+| Signed-out user redirected by `RequireAuth` | MET | `App.tsx:33–38`: route wrapped in `<RequireAuth>` |
+| `GET /api/v1/leagues/{id}/replays/{replayId}` returns 401 for unauthenticated requests | MET | Inherited `[Authorize]` on `V1ApiController` |
+| `GET /api/v1/leagues/{id}/replays/{replayId}` returns 404 for non-existent/cross-league replay | MET | `LeaguesController.cs:85–92` |
+| Seeded replay shows populated stats strip and panels under `docker compose up` | MET | Seed added at `R__ReplaysTestData.sql:58–89`; log format matches parser expectations |
+| `make web.build` and `make web.lint` both pass | MET | Both pass clean — verified locally |
+
+## Scope
+
+The diff exactly matches the plan's "Files to Create / Modify" table. All five planned file touches are present and no extra files were added. `learnings.md` accounts for all deviations (MUI v9 prop API changes, `slotProps` instead of `primaryTypographyProps`, `AddWormsArmageddonFilesServices` placement, Prettier re-run).
+
+One deviation the `learnings.md` does not fully resolve: the plan's "simplest safe approach" says to call `AddWormsArmageddonFilesServices()` unconditionally in `Program.cs`. The implementation instead calls it only inside the `if (runGateway)` block. This is the source of **B1**.
+
+## Blockers
+
+#### B1 — `IReplayTextReader` not registered in distributed worker-only mode
+
+- **File:** `src/Worms.Hub.Gateway/Program.cs:51`
+- **Issue:** `AddWormsArmageddonFilesServices()` was removed from `AddWorkerServices()` and added only inside the `if (runGateway)` block. `Processor` (in `AddWorkerServices`) depends on `IReplayTextReader`. When the process runs in distributed worker-only mode (`HUB_DISTRIBUTED=true`, `HUB_WORKER=true`, `HUB_GATEWAY=false`), the gateway block is skipped and `IReplayTextReader` is never registered, causing DI resolution of `Processor` to fail at runtime.
+- **Fix:** Move the `AddWormsArmageddonFilesServices()` call outside the `if (runGateway)` block to be unconditional — exactly as the plan's "simplest safe approach" described. The call is idempotent and safe in both modes.
+- **Decision:** Accept
+
+## Suggestions
+
+#### S1 — Unit test coverage for `ReplayDetailDto.FromDomain`
+
+- **File:** `src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs`
+- **Issue:** The `FromDomain` factory method contains non-trivial logic (turn indexing, null-vs-empty-list handling for turns when parsed has zero turns). The testing strategy doc notes that logic at gateway/storage layers has no dedicated test project, but recommends adding one when meaningful logic is present.
+- **Fix:** Add a `Worms.Hub.Gateway.Tests` project (NUnit) with a `ReplayDetailDtoShould` test class covering: a replay with turns, a replay with a parsed-but-empty-turns list (should produce `null` for `Turns`), and a replay with no log (should produce `null` for `Turns`).
+- **Decision:** Decline
+
+#### S2 — `leagueRes` 404 not shown as "not found"
+
+- **File:** `src/Worms.Hub.Web/src/pages/GameDetailPage.tsx:292–297`
+- **Issue:** Only `replayRes.status === 404` sets `notFound`. If `leagueRes` returns 404, the `!leagueRes.ok` branch throws and the user sees "Error: HTTP 404" instead of a "not found" message. This is a minor UX inconsistency but the case (valid route path, invalid league ID) is unlikely in practice.
+- **Fix:** Add a check for `leagueRes.status === 404` before the `!leagueRes.ok` throw: `if (leagueRes.status === 404) { setNotFound(true); return; }`.
+- **Decision:** Decline
+
+## Nitpicks
+
+#### N1 — Fully qualified `Worms.Armageddon.Files.Replays.ReplayResource` in controller body
+
+- **File:** `src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs:97`
+- **Issue:** `Worms.Armageddon.Files.Replays.ReplayResource? parsed = null;` uses a fully qualified type name in the method body. The `ReplayDtos.cs` file already imports `using Worms.Armageddon.Files.Replays;`, and the controller has its own `using Worms.Armageddon.Files.Replays.Text;`. Adding `using Worms.Armageddon.Files.Replays;` to the controller would eliminate the qualification. The `learnings.md` notes this as intentional to avoid ambiguity, but there is no conflicting `ReplayResource` type in scope.
+- **Fix:** Add `using Worms.Armageddon.Files.Replays;` to `LeaguesController.cs` and use `ReplayResource? parsed = null;`.
+- **Decision:** Accept
+
+## Tests
+
+No new test code was added in this diff. This is consistent with the repo's current approach — the gateway and storage layers have no dedicated unit test projects and the testing strategy doc acknowledges the gap. The `ReplayDetailDto.FromDomain` logic (turn indexing, empty-turn null coercion) and the new controller action are both exercised only end-to-end under `docker compose`. See **S1** for the suggestion to add a test project.
+
+The existing `Worms.Armageddon.Files.Tests/Replays/ReplayTextReaderShould.cs` covers the upstream parsing pipeline and was not modified.
+
+## Recommended Actions
+
+- **B1** — Accept — Moving the call outside the gateway block is a one-line fix and directly restores the behaviour the plan explicitly intended. Without it, a distributed worker-only deployment fails at startup.
+- **S1** — Accept — The `FromDomain` logic is a clear unit-testable boundary; adding a minimal test class here would give early warning if the null-coercion or indexing logic is ever changed.
+- **S2** — Decline — The case (user somehow navigates to `/leagues/invalid-id/replays/123`) is not reachable via normal UI navigation and the spec does not call it out explicitly. The fix is trivial but adds noise for a case with no realistic trigger.
+- **N1** — Accept — The `learnings.md` rationale (avoid ambiguity) does not hold — there is no conflicting type. Removing the qualification aligns with the repo's standard style and the fix is trivial.

--- a/.claude/specs/web-ui/slices/12-game-detail-page/spec.md
+++ b/.claude/specs/web-ui/slices/12-game-detail-page/spec.md
@@ -1,0 +1,99 @@
+# Game Detail Page
+
+## Overview
+
+A signed-in member can navigate to `/leagues/{id}/replays/{replayId}` and see a detailed view of a single game — its participants, winner, date, scheme version, and a turn-by-turn breakdown with weapon usage stats — all driven by parsing the stored replay log on demand.
+
+## Requirements
+
+### Gateway
+
+- A new authenticated `GET /api/v1/leagues/{id}/replays/{replayId}` endpoint returns a single replay's details.
+- The response includes hero data (id, name, status, date, winner, and the list of participating team names) and, when the replay has a stored log, a parsed turns array.
+- Each turn in the turns array includes: turn number, the playing team's name, the ordered list of weapons fired that turn (name only), and the damage dealt that turn (one entry per target team: team name, health lost, worms killed).
+- The endpoint parses the stored `full_log` on demand using the existing `IReplayTextReader` pipeline; no new database tables are added.
+- Returns 404 when the replay ID does not exist, or when the replay belongs to a different league than the `{id}` in the path.
+- Returns hero data with an absent turns array when the replay has no stored log.
+- Returns 401 for unauthenticated requests, consistent with the existing `[Authorize]` contract on all Gateway endpoints.
+
+### SPA
+
+- A new `/leagues/:id/replays/:replayId` route is added to `App.tsx`, protected by the existing `RequireAuth` wrapper.
+- On load, the page fetches the single-replay endpoint and `GET /api/v1/leagues/{id}` concurrently using the signed-in user's bearer token.
+- While either fetch is in progress, a loading indicator is shown.
+- If either fetch returns a non-2xx response, an error message is shown.
+- If the replay endpoint returns 404, a not-found message is shown.
+- If the replay's status is not `Processed`, a "processing" message is shown in place of all other content.
+- For processed replays, a hero card is shown containing:
+  - Title: "Match #00x" where x is the replay's database ID zero-padded to three digits.
+  - Date and time of the game.
+  - A winner chip showing the winning team name, or "Draw" with neutral styling for drawn games. Omitted if `winner` is null.
+  - Chips for all participating team names.
+  - A scheme version chip (e.g. "Scheme v1.2"), omitted entirely if the league has no scheme version.
+  - A stats strip with four figures computed from the turns array: Duration, Turns, Max Damage, and Kills. The entire stats strip is omitted if there are no turns.
+    - **Duration**: elapsed time from the first turn's start timestamp to the last turn's end timestamp; if the last turn has no end timestamp, use the latest available timestamp from that turn's weapon or damage events, or the turn's start timestamp as a last resort.
+    - **Turns**: total number of turns.
+    - **Max Damage**: sum of `healthLost` across all damage records (including self-damage) for the single turn with the highest total damage.
+    - **Kills**: total `wormsKilled` summed across all damage records in all turns, including self-kills.
+- A breadcrumb shows: Leagues (links to `/leagues`) → {League Name} (links to `/leagues/{id}`) → Match #00x (current page, no link). The league name is sourced from the concurrent `GET /api/v1/leagues/{id}` response.
+- The page uses the sidebar layout from the design mockup: a left-hand nav panel listing the available panels, and the selected panel's content area on the right.
+
+### Turn-by-turn panel
+
+- Shown by default when the page loads.
+- Displays one row per turn, in turn order.
+- Each row shows: turn number, team name, the ordered list of weapons fired that turn, and the damage dealt that turn.
+  - The last weapon in the list is visually distinguished as the damaging weapon (e.g. bold or labelled).
+  - Turns with no weapons fired show "—" in the weapons column.
+  - Damage is shown as one entry per target team, with health lost and kill count; kills are shown only when non-zero.
+  - Turns with no damage show "—" in the damage column.
+- When the turns array is absent or empty, an appropriate empty-state message is shown in place of the table.
+
+### Weapons panel
+
+- Displays weapon usage grouped by team.
+- For each team, lists each distinct weapon that team used across all their turns.
+- Each weapon entry shows: weapon name, usage count (number of turns in which that weapon appears in the weapons list for that team), and attributed damage (sum of total damage dealt in turns where that weapon was the last weapon fired by that team).
+- Entries for each team are sorted by attributed damage descending, with usage count as a tiebreaker.
+- When the turns array is absent or empty, an appropriate empty-state message is shown.
+
+### Local-dev seed data
+
+- At least one seeded replay in `R__ReplaysTestData.sql` has its `full_log` column set to a realistic WA log string, including team declarations, at least four turns with weapons and damage records, and a winner line — giving the Turn-by-turn and Weapons panels real data to display under `docker compose`.
+
+## Out of Scope
+
+- Team colour coding on chips — deferred pending a review of how team colours are stored in the database.
+- Replay file download link — covered by the next slice (Replay viewer).
+- Damage chart panel — deferred pending a way to track remaining worm health at the point of kill.
+- Head-to-head panel — removed from scope.
+- Global error boundary — a separate future slice.
+- Pagination of the turns list.
+- Auto-refresh for unprocessed replays — the user must manually refresh the page.
+
+## Acceptance Criteria
+
+- A signed-in user navigating to `/leagues/redgate/replays/{id}` for a processed replay with turn data sees the "Match #00x" hero card, the correct date and time, the winner chip, participating team chips, the scheme version chip, and the stats strip.
+- Duration, Turns, Max Damage, and Kills in the stats strip reflect correct values computed from the replay's turn data.
+- A drawn game shows "Draw" in the winner chip with neutral (non-team) styling.
+- The scheme version chip is absent when the league has no scheme version.
+- The stats strip is absent when the replay has no turn data.
+- The breadcrumb shows Leagues → {League Name} → Match #00x; the first two items are working links, the last is plain text.
+- The Turn-by-turn panel is active and visible on first load; clicking "Weapons" in the sidebar switches the content area to the Weapons panel.
+- The Turn-by-turn panel shows one row per turn in order; every turn is shown, including turns with no weapons and turns with no damage.
+- The last weapon in a turn's weapon list is visually distinguished from earlier weapons in that turn.
+- Turns with no weapons show "—" in the weapons column; turns with no damage show "—" in the damage column.
+- The Weapons panel shows per-team weapon entries with attributed damage, sorted by attributed damage descending.
+- For a processed replay with no stored log, the hero card is shown but both Turn-by-turn and Weapons panels display an empty-state message.
+- Navigating directly to a replay with status `Pending` shows a "processing" message with no hero card or panels.
+- Navigating to a non-existent replay URL (or one belonging to a different league) shows a not-found message.
+- A non-2xx response from either concurrent API call shows an error message.
+- A signed-out user navigating to `/leagues/{id}/replays/{replayId}` is redirected to `/` by the existing `RequireAuth` wrapper.
+- `GET /api/v1/leagues/{id}/replays/{replayId}` returns 401 for unauthenticated requests.
+- `GET /api/v1/leagues/{id}/replays/{replayId}` returns 404 when the replay does not exist or its league does not match the path.
+- Under `docker compose up`, at least one seeded replay's detail page shows a hero card with a populated stats strip and populated Turn-by-turn and Weapons panels.
+- `make web.build` and `make web.lint` both pass with the changes in place.
+
+## Open Questions
+
+None.

--- a/src/Worms.Armageddon.Files/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Files/ServiceRegistration.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Worms.Armageddon.Files.Replays.Filename;
 using Worms.Armageddon.Files.Replays.Text;
 using Worms.Armageddon.Files.Replays.Text.Parsers;
@@ -12,19 +13,22 @@ namespace Worms.Armageddon.Files;
 [PublicAPI]
 public static class ServiceRegistration
 {
-    public static IServiceCollection AddWormsArmageddonFilesServices(this IServiceCollection builder) =>
-        builder.AddScoped<IWscReader, WscReader>()
-            .AddScoped<IWscWriter, WscWriter>()
-            .AddScoped<ISchemeTextReader, SchemeTextReader>()
-            .AddScoped<ISchemeTextWriter, SchemeTextWriter>()
-            .AddScoped<IReplayFilenameParser, ReplayFilenameParser>()
-            .AddScoped<IReplayTextReader, ReplayTextReader>()
-            .AddScoped<IReplayLineParser, StartTimeParser>()
-            .AddScoped<IReplayLineParser, TeamParser>()
-            .AddScoped<IReplayLineParser, WinnerParser>()
-            .AddScoped<IReplayLineParser, StartOfTurnParser>()
-            .AddScoped<IReplayLineParser, WeaponUsedParser>()
-            .AddScoped<IReplayLineParser, DamageParser>()
-            .AddScoped<IReplayLineParser, EndOfTurnParser>()
-            .AddScoped<IRandomSchemeGenerator, RandomSchemeGenerator>();
+    public static IServiceCollection AddWormsArmageddonFilesServices(this IServiceCollection services)
+    {
+        services.TryAddScoped<IWscReader, WscReader>();
+        services.TryAddScoped<IWscWriter, WscWriter>();
+        services.TryAddScoped<ISchemeTextReader, SchemeTextReader>();
+        services.TryAddScoped<ISchemeTextWriter, SchemeTextWriter>();
+        services.TryAddScoped<IReplayFilenameParser, ReplayFilenameParser>();
+        services.TryAddScoped<IReplayTextReader, ReplayTextReader>();
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, StartTimeParser>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, TeamParser>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, WinnerParser>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, StartOfTurnParser>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, WeaponUsedParser>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, DamageParser>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IReplayLineParser, EndOfTurnParser>());
+        services.TryAddScoped<IRandomSchemeGenerator, RandomSchemeGenerator>();
+        return services;
+    }
 }

--- a/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Worms.Armageddon.Files.Replays;
+using Worms.Armageddon.Files.Replays.Text;
 using Worms.Hub.Gateway.API.DTOs;
 using Worms.Hub.Gateway.FeatureFlags;
 using Worms.Hub.Storage.Database;
@@ -10,6 +12,7 @@ internal sealed class LeaguesController(
     SchemeFiles schemeFiles,
     LeaguesRepository leaguesRepository,
     IReplaysRepository replaysRepository,
+    IReplayTextReader replayTextReader,
     IFeatureFlags featureFlags) : V1ApiController
 {
     [HttpGet]
@@ -75,5 +78,29 @@ internal sealed class LeaguesController(
         }
 
         return Ok(replaysRepository.GetByLeagueId(id).Select(ReplayDto.FromDomain).ToList());
+    }
+
+    [HttpGet("{id}/replays/{replayId}")]
+    public ActionResult<ReplayDetailDto> GetReplay(string id, string replayId)
+    {
+        var league = leaguesRepository.GetById(id);
+        if (league is null)
+        {
+            return NotFound();
+        }
+
+        var replay = replaysRepository.GetByLeagueId(id).FirstOrDefault(r => r.Id == replayId);
+        if (replay is null)
+        {
+            return NotFound();
+        }
+
+        ReplayResource? parsed = null;
+        if (!string.IsNullOrEmpty(replay.FullLog))
+        {
+            parsed = replayTextReader.GetModel(replay.FullLog);
+        }
+
+        return ReplayDetailDto.FromDomain(replay, parsed);
     }
 }

--- a/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs
@@ -69,7 +69,7 @@ internal sealed class LeaguesController(
     }
 
     [HttpGet("{id}/replays")]
-    public ActionResult<IReadOnlyList<ReplayDto>> GetReplays(string id)
+    public ActionResult<IReadOnlyList<ReplayDetailDto>> GetReplays(string id)
     {
         var league = leaguesRepository.GetById(id);
         if (league is null)
@@ -77,7 +77,15 @@ internal sealed class LeaguesController(
             return NotFound();
         }
 
-        return Ok(replaysRepository.GetByLeagueId(id).Select(ReplayDto.FromDomain).ToList());
+        return Ok(replaysRepository.GetByLeagueId(id).Select(replay =>
+        {
+            ReplayResource? parsed = null;
+            if (!string.IsNullOrEmpty(replay.FullLog))
+            {
+                parsed = replayTextReader.GetModel(replay.FullLog);
+            }
+            return ReplayDetailDto.FromDomain(replay, parsed);
+        }).ToList());
     }
 
     [HttpGet("{id}/replays/{replayId}")]

--- a/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using Worms.Armageddon.Files.Replays;
 using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.API.DTOs;
@@ -18,3 +19,59 @@ internal sealed record ReplayDto(
 
 [PublicAPI]
 internal sealed record CreateReplayDto(string Name, IFormFile ReplayFile);
+
+[PublicAPI]
+internal sealed record ReplayDetailDto(
+    string Id,
+    string Name,
+    string Status,
+    DateTime? Date,
+    string? Winner,
+    IReadOnlyList<string>? Teams,
+    IReadOnlyList<TurnDto>? Turns)
+{
+    internal static ReplayDetailDto FromDomain(Replay replay, ReplayResource? parsed)
+    {
+        IReadOnlyList<TurnDto>? turns = null;
+
+        if (parsed is not null)
+        {
+            var turnList = parsed.Turns.Select(
+                (t, i) => new TurnDto(
+                    i + 1,
+                    t.Team.Name,
+                    t.Start.TotalMilliseconds,
+                    t.End.TotalMilliseconds,
+                    t.Weapons.Select(w => new WeaponDto(w.Name)).ToList(),
+                    t.Damage.Select(d => new DamageSummaryDto(d.Team.Name, d.HealthLost, d.WormsKilled)).ToList())).ToList();
+            turns = turnList.Count > 0 ? turnList : null;
+        }
+
+        return new ReplayDetailDto(
+            replay.Id,
+            replay.Name,
+            replay.Status,
+            replay.Date,
+            replay.Winner,
+            replay.Teams,
+            turns);
+    }
+}
+
+[PublicAPI]
+internal sealed record TurnDto(
+    int TurnNumber,
+    string TeamName,
+    double StartMs,
+    double EndMs,
+    IReadOnlyList<WeaponDto> Weapons,
+    IReadOnlyList<DamageSummaryDto> Damage);
+
+[PublicAPI]
+internal sealed record WeaponDto(string Name);
+
+[PublicAPI]
+internal sealed record DamageSummaryDto(
+    string TeamName,
+    uint HealthLost,
+    uint WormsKilled);

--- a/src/Worms.Hub.Gateway/Program.cs
+++ b/src/Worms.Hub.Gateway/Program.cs
@@ -1,5 +1,4 @@
 using Microsoft.IdentityModel.Tokens;
-using Worms.Armageddon.Files;
 using Worms.Hub.Gateway;
 using Worms.Hub.Gateway.API.Middleware;
 using Worms.Hub.Gateway.Worker;
@@ -51,8 +50,6 @@ if (runGateway)
     _ = builder.Services.AddHubStorageServices().AddGatewayServices().AddQueueServices();
     builder.Services.AddOpenTelemetryWormsHub();
 }
-
-_ = builder.Services.AddWormsArmageddonFilesServices();
 
 if (runWorker)
 {

--- a/src/Worms.Hub.Gateway/Program.cs
+++ b/src/Worms.Hub.Gateway/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.IdentityModel.Tokens;
+using Worms.Armageddon.Files;
 using Worms.Hub.Gateway;
 using Worms.Hub.Gateway.API.Middleware;
 using Worms.Hub.Gateway.Worker;
@@ -50,6 +51,8 @@ if (runGateway)
     _ = builder.Services.AddHubStorageServices().AddGatewayServices().AddQueueServices();
     builder.Services.AddOpenTelemetryWormsHub();
 }
+
+_ = builder.Services.AddWormsArmageddonFilesServices();
 
 if (runWorker)
 {

--- a/src/Worms.Hub.Gateway/ServiceRegistration.cs
+++ b/src/Worms.Hub.Gateway/ServiceRegistration.cs
@@ -1,4 +1,3 @@
-using Worms.Armageddon.Files;
 using Worms.Hub.Gateway.Announcers;
 using Worms.Hub.Gateway.Announcers.Slack;
 using Worms.Hub.Gateway.API.Validators;
@@ -19,6 +18,5 @@ internal static class ServiceRegistration
             .AddQueueServices()
             .AddHttpClient()
             .AddScoped<Processor>()
-            .AddWormsArmageddonFilesServices()
             .AddScoped<IAnnouncer, Announcer>();
 }

--- a/src/Worms.Hub.Gateway/ServiceRegistration.cs
+++ b/src/Worms.Hub.Gateway/ServiceRegistration.cs
@@ -1,3 +1,4 @@
+using Worms.Armageddon.Files;
 using Worms.Hub.Gateway.Announcers;
 using Worms.Hub.Gateway.Announcers.Slack;
 using Worms.Hub.Gateway.API.Validators;
@@ -11,11 +12,12 @@ namespace Worms.Hub.Gateway;
 internal static class ServiceRegistration
 {
     public static IServiceCollection AddGatewayServices(this IServiceCollection builder) =>
-        builder.AddHttpClient().AddScoped<IAnnouncer, Announcer>().AddScoped<ReplayFileValidator>().AddScoped<CliFileValidator>().AddScoped<IFeatureFlags, GatewayFeatureFlags>();
+        builder.AddWormsArmageddonFilesServices().AddHttpClient().AddScoped<IAnnouncer, Announcer>().AddScoped<ReplayFileValidator>().AddScoped<CliFileValidator>().AddScoped<IFeatureFlags, GatewayFeatureFlags>();
 
     public static IServiceCollection AddWorkerServices(this IServiceCollection builder) =>
         builder.AddHubStorageServices()
             .AddQueueServices()
+            .AddWormsArmageddonFilesServices()
             .AddHttpClient()
             .AddScoped<Processor>()
             .AddScoped<IAnnouncer, Announcer>();

--- a/src/Worms.Hub.Web/src/App.tsx
+++ b/src/Worms.Hub.Web/src/App.tsx
@@ -5,6 +5,7 @@ import LandingPage from './pages/LandingPage'
 import CallbackPage from './pages/CallbackPage'
 import LeagueListPage from './pages/LeagueListPage'
 import LeagueDetailPage from './pages/LeagueDetailPage'
+import GameDetailPage from './pages/GameDetailPage'
 
 const router = createBrowserRouter([
     {
@@ -26,6 +27,14 @@ const router = createBrowserRouter([
                 element: (
                     <RequireAuth>
                         <LeagueDetailPage />
+                    </RequireAuth>
+                ),
+            },
+            {
+                path: 'leagues/:id/replays/:replayId',
+                element: (
+                    <RequireAuth>
+                        <GameDetailPage />
                     </RequireAuth>
                 ),
             },

--- a/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs from '@mui/material/Breadcrumbs'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
+import Divider from '@mui/material/Divider'
 import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
@@ -95,8 +96,13 @@ function TurnByTurnPanel({ turns }: TurnByTurnPanelProps) {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {turns.map((turn) => (
-                        <TableRow key={turn.turnNumber}>
+                    {turns.map((turn) => {
+                        const hasKill = turn.damage.some((d) => d.wormsKilled > 0)
+                        return (
+                        <TableRow
+                            key={turn.turnNumber}
+                            sx={{ bgcolor: hasKill ? 'rgba(211,47,47,0.08)' : 'transparent' }}
+                        >
                             <TableCell
                                 sx={{
                                     fontFamily: monoFontFamily,
@@ -140,27 +146,27 @@ function TurnByTurnPanel({ turns }: TurnByTurnPanelProps) {
                             <TableCell>
                                 {turn.damage.length === 0 ? (
                                     <Typography variant="caption" color="text.disabled">
-                                        —
+                                        — no damage —
                                     </Typography>
                                 ) : (
-                                    <Stack direction="column" spacing={0.5}>
+                                    <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }} useFlexGap>
                                         {turn.damage.map((d) => (
                                             <Box
                                                 key={d.teamName}
-                                                sx={{
-                                                    display: 'flex',
-                                                    alignItems: 'center',
-                                                    gap: 0.5,
-                                                }}
+                                                sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
                                             >
-                                                <Typography variant="body2">
-                                                    {d.teamName}: {d.healthLost}
+                                                <Typography sx={{ fontFamily: monoFontFamily, fontSize: 12, color: 'text.secondary' }}>
+                                                    {d.teamName}:
+                                                </Typography>
+                                                <Typography sx={{ fontFamily: monoFontFamily, fontSize: 12, fontWeight: 700, color: 'primary.light' }}>
+                                                    {d.healthLost}
                                                 </Typography>
                                                 {d.wormsKilled > 0 && (
                                                     <Chip
                                                         label={`+${d.wormsKilled} kill${d.wormsKilled > 1 ? 's' : ''}`}
                                                         size="small"
                                                         color="error"
+                                                        sx={{ height: 16, fontSize: 9, fontWeight: 700 }}
                                                     />
                                                 )}
                                             </Box>
@@ -169,15 +175,16 @@ function TurnByTurnPanel({ turns }: TurnByTurnPanelProps) {
                                 )}
                             </TableCell>
                         </TableRow>
-                    ))}
+                        )
+                    })}
                 </TableBody>
             </Table>
         </TableContainer>
     )
 }
 
-type WeaponStats = { name: string; usageCount: number; attributedDamage: number }
-type TeamWeaponMap = Map<string, WeaponStats[]>
+type TeamBreakdown = { teamName: string; usageCount: number; attributedDamage: number; attributedKills: number }
+type WeaponCard = { name: string; totalUses: number; totalDamage: number; totalKills: number; byTeam: TeamBreakdown[] }
 
 interface WeaponsPanelProps {
     turns: TurnDto[] | null
@@ -194,80 +201,96 @@ function WeaponsPanel({ turns }: WeaponsPanelProps) {
         )
     }
 
-    const teamWeaponMap: TeamWeaponMap = new Map()
+    const weaponMap = new Map<string, WeaponCard>()
 
     for (const turn of turns) {
-        if (!teamWeaponMap.has(turn.teamName)) {
-            teamWeaponMap.set(turn.teamName, [])
-        }
-        const stats = teamWeaponMap.get(turn.teamName)!
-
         for (const weapon of turn.weapons) {
-            let entry = stats.find((s) => s.name === weapon.name)
-            if (!entry) {
-                entry = { name: weapon.name, usageCount: 0, attributedDamage: 0 }
-                stats.push(entry)
+            if (!weaponMap.has(weapon.name)) {
+                weaponMap.set(weapon.name, { name: weapon.name, totalUses: 0, totalDamage: 0, totalKills: 0, byTeam: [] })
             }
-            entry.usageCount++
+            const card = weaponMap.get(weapon.name)!
+            card.totalUses++
+            let teamEntry = card.byTeam.find((t) => t.teamName === turn.teamName)
+            if (!teamEntry) {
+                teamEntry = { teamName: turn.teamName, usageCount: 0, attributedDamage: 0, attributedKills: 0 }
+                card.byTeam.push(teamEntry)
+            }
+            teamEntry.usageCount++
         }
 
         if (turn.weapons.length > 0) {
             const lastWeapon = turn.weapons[turn.weapons.length - 1]
-            const totalDamage = turn.damage.reduce((sum, d) => sum + d.healthLost, 0)
-            const entry = stats.find((s) => s.name === lastWeapon.name)
-            if (entry) {
-                entry.attributedDamage += totalDamage
+            const turnDamage = turn.damage.reduce((sum, d) => sum + d.healthLost, 0)
+            const turnKills = turn.damage.reduce((sum, d) => sum + d.wormsKilled, 0)
+            const card = weaponMap.get(lastWeapon.name)!
+            card.totalDamage += turnDamage
+            card.totalKills += turnKills
+            const teamEntry = card.byTeam.find((t) => t.teamName === turn.teamName)
+            if (teamEntry) {
+                teamEntry.attributedDamage += turnDamage
+                teamEntry.attributedKills += turnKills
             }
         }
     }
 
-    const sortedTeams = Array.from(teamWeaponMap.entries()).map(([teamName, weaponStats]) => ({
-        teamName,
-        weapons: weaponStats
-            .slice()
-            .sort((a, b) => b.attributedDamage - a.attributedDamage || b.usageCount - a.usageCount),
-    }))
+    const weapons = Array.from(weaponMap.values()).sort(
+        (a, b) => b.totalDamage - a.totalDamage || b.totalUses - a.totalUses,
+    )
 
     return (
-        <Stack spacing={2}>
-            {sortedTeams.map(({ teamName, weapons }) => (
-                <Box key={teamName}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
-                        {teamName}
+        <Box
+            sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(4, 1fr)',
+                gap: 2,
+            }}
+        >
+            {weapons.map((weapon) => (
+                <Paper key={weapon.name} variant="outlined" sx={{ p: 2 }}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+                        {weapon.name}
                     </Typography>
-                    <TableContainer component={Paper} variant="outlined">
-                        <Table size="small">
-                            <TableHead>
-                                <TableRow>
-                                    <TableCell sx={{ fontWeight: 700 }}>Weapon</TableCell>
-                                    <TableCell sx={{ fontWeight: 700, width: 60 }}>Uses</TableCell>
-                                    <TableCell sx={{ fontWeight: 700, width: 120 }}>
-                                        Attributed Damage
-                                    </TableCell>
-                                </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {weapons.map((w) => (
-                                    <TableRow key={w.name}>
-                                        <TableCell>{w.name}</TableCell>
-                                        <TableCell
-                                            sx={{ fontFamily: monoFontFamily, fontSize: 12 }}
-                                        >
-                                            {w.usageCount}
-                                        </TableCell>
-                                        <TableCell
-                                            sx={{ fontFamily: monoFontFamily, fontSize: 12 }}
-                                        >
-                                            {w.attributedDamage}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                </Box>
+                    <Box sx={{ display: 'flex', mb: 1.5 }}>
+                        {([
+                            ['Uses', weapon.totalUses, undefined],
+                            ['Damage', weapon.totalDamage, 'primary.main'],
+                            ['Kills', weapon.totalKills, undefined],
+                        ] as const).map(([label, value, color]) => (
+                            <Box key={label} sx={{ flex: 1 }}>
+                                <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{ display: 'block', textTransform: 'uppercase', letterSpacing: '0.1em' }}
+                                >
+                                    {label}
+                                </Typography>
+                                <Typography
+                                    sx={{ fontFamily: monoFontFamily, fontWeight: 700, fontSize: 20, color: color ?? 'text.primary' }}
+                                >
+                                    {value}
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Box>
+                    <Divider sx={{ mb: 1 }} />
+                    <Stack spacing={0.5}>
+                        {weapon.byTeam.map((team) => (
+                            <Box
+                                key={team.teamName}
+                                sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                            >
+                                <Typography variant="caption" color="text.secondary">
+                                    {team.teamName}
+                                </Typography>
+                                <Typography variant="caption" sx={{ fontFamily: monoFontFamily }}>
+                                    {team.usageCount}× · {team.attributedDamage}dmg · {team.attributedKills}k
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Stack>
+                </Paper>
             ))}
-        </Stack>
+        </Box>
     )
 }
 

--- a/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
@@ -99,82 +99,108 @@ function TurnByTurnPanel({ turns }: TurnByTurnPanelProps) {
                     {turns.map((turn) => {
                         const hasKill = turn.damage.some((d) => d.wormsKilled > 0)
                         return (
-                        <TableRow
-                            key={turn.turnNumber}
-                            sx={{ bgcolor: hasKill ? 'rgba(211,47,47,0.08)' : 'transparent' }}
-                        >
-                            <TableCell
-                                sx={{
-                                    fontFamily: monoFontFamily,
-                                    fontSize: 12,
-                                    color: 'text.secondary',
-                                }}
+                            <TableRow
+                                key={turn.turnNumber}
+                                sx={{ bgcolor: hasKill ? 'rgba(211,47,47,0.08)' : 'transparent' }}
                             >
-                                {String(turn.turnNumber).padStart(2, '0')}
-                            </TableCell>
-                            <TableCell>
-                                <Chip size="small" label={turn.teamName} />
-                            </TableCell>
-                            <TableCell>
-                                {turn.weapons.length === 0 ? (
-                                    <Typography variant="caption" color="text.disabled">
-                                        —
-                                    </Typography>
-                                ) : (
-                                    <Stack
-                                        direction="row"
-                                        spacing={0.5}
-                                        sx={{ flexWrap: 'wrap' }}
-                                        useFlexGap
-                                    >
-                                        {turn.weapons.map((w, i) => (
-                                            <Chip
-                                                key={i}
-                                                size="small"
-                                                label={w.name}
-                                                variant="outlined"
-                                                sx={
-                                                    i === turn.weapons.length - 1
-                                                        ? { fontWeight: 700 }
-                                                        : undefined
-                                                }
-                                            />
-                                        ))}
-                                    </Stack>
-                                )}
-                            </TableCell>
-                            <TableCell>
-                                {turn.damage.length === 0 ? (
-                                    <Typography variant="caption" color="text.disabled">
-                                        — no damage —
-                                    </Typography>
-                                ) : (
-                                    <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }} useFlexGap>
-                                        {turn.damage.map((d) => (
-                                            <Box
-                                                key={d.teamName}
-                                                sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
-                                            >
-                                                <Typography sx={{ fontFamily: monoFontFamily, fontSize: 12, color: 'text.secondary' }}>
-                                                    {d.teamName}:
-                                                </Typography>
-                                                <Typography sx={{ fontFamily: monoFontFamily, fontSize: 12, fontWeight: 700, color: 'primary.light' }}>
-                                                    {d.healthLost}
-                                                </Typography>
-                                                {d.wormsKilled > 0 && (
-                                                    <Chip
-                                                        label={`+${d.wormsKilled} kill${d.wormsKilled > 1 ? 's' : ''}`}
-                                                        size="small"
-                                                        color="error"
-                                                        sx={{ height: 16, fontSize: 9, fontWeight: 700 }}
-                                                    />
-                                                )}
-                                            </Box>
-                                        ))}
-                                    </Stack>
-                                )}
-                            </TableCell>
-                        </TableRow>
+                                <TableCell
+                                    sx={{
+                                        fontFamily: monoFontFamily,
+                                        fontSize: 12,
+                                        color: 'text.secondary',
+                                    }}
+                                >
+                                    {String(turn.turnNumber).padStart(2, '0')}
+                                </TableCell>
+                                <TableCell>
+                                    <Chip size="small" label={turn.teamName} />
+                                </TableCell>
+                                <TableCell>
+                                    {turn.weapons.length === 0 ? (
+                                        <Typography variant="caption" color="text.disabled">
+                                            —
+                                        </Typography>
+                                    ) : (
+                                        <Stack
+                                            direction="row"
+                                            spacing={0.5}
+                                            sx={{ flexWrap: 'wrap' }}
+                                            useFlexGap
+                                        >
+                                            {turn.weapons.map((w, i) => (
+                                                <Chip
+                                                    key={i}
+                                                    size="small"
+                                                    label={w.name}
+                                                    variant="outlined"
+                                                    sx={
+                                                        i === turn.weapons.length - 1
+                                                            ? { fontWeight: 700 }
+                                                            : undefined
+                                                    }
+                                                />
+                                            ))}
+                                        </Stack>
+                                    )}
+                                </TableCell>
+                                <TableCell>
+                                    {turn.damage.length === 0 ? (
+                                        <Typography variant="caption" color="text.disabled">
+                                            — no damage —
+                                        </Typography>
+                                    ) : (
+                                        <Stack
+                                            direction="row"
+                                            spacing={1}
+                                            sx={{ flexWrap: 'wrap' }}
+                                            useFlexGap
+                                        >
+                                            {turn.damage.map((d) => (
+                                                <Box
+                                                    key={d.teamName}
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: 0.5,
+                                                    }}
+                                                >
+                                                    <Typography
+                                                        sx={{
+                                                            fontFamily: monoFontFamily,
+                                                            fontSize: 12,
+                                                            color: 'text.secondary',
+                                                        }}
+                                                    >
+                                                        {d.teamName}:
+                                                    </Typography>
+                                                    <Typography
+                                                        sx={{
+                                                            fontFamily: monoFontFamily,
+                                                            fontSize: 12,
+                                                            fontWeight: 700,
+                                                            color: 'primary.light',
+                                                        }}
+                                                    >
+                                                        {d.healthLost}
+                                                    </Typography>
+                                                    {d.wormsKilled > 0 && (
+                                                        <Chip
+                                                            label={`+${d.wormsKilled} kill${d.wormsKilled > 1 ? 's' : ''}`}
+                                                            size="small"
+                                                            color="error"
+                                                            sx={{
+                                                                height: 16,
+                                                                fontSize: 9,
+                                                                fontWeight: 700,
+                                                            }}
+                                                        />
+                                                    )}
+                                                </Box>
+                                            ))}
+                                        </Stack>
+                                    )}
+                                </TableCell>
+                            </TableRow>
                         )
                     })}
                 </TableBody>
@@ -183,8 +209,19 @@ function TurnByTurnPanel({ turns }: TurnByTurnPanelProps) {
     )
 }
 
-type TeamBreakdown = { teamName: string; usageCount: number; attributedDamage: number; attributedKills: number }
-type WeaponCard = { name: string; totalUses: number; totalDamage: number; totalKills: number; byTeam: TeamBreakdown[] }
+type TeamBreakdown = {
+    teamName: string
+    usageCount: number
+    attributedDamage: number
+    attributedKills: number
+}
+type WeaponCard = {
+    name: string
+    totalUses: number
+    totalDamage: number
+    totalKills: number
+    byTeam: TeamBreakdown[]
+}
 
 interface WeaponsPanelProps {
     turns: TurnDto[] | null
@@ -206,13 +243,24 @@ function WeaponsPanel({ turns }: WeaponsPanelProps) {
     for (const turn of turns) {
         for (const weapon of turn.weapons) {
             if (!weaponMap.has(weapon.name)) {
-                weaponMap.set(weapon.name, { name: weapon.name, totalUses: 0, totalDamage: 0, totalKills: 0, byTeam: [] })
+                weaponMap.set(weapon.name, {
+                    name: weapon.name,
+                    totalUses: 0,
+                    totalDamage: 0,
+                    totalKills: 0,
+                    byTeam: [],
+                })
             }
             const card = weaponMap.get(weapon.name)!
             card.totalUses++
             let teamEntry = card.byTeam.find((t) => t.teamName === turn.teamName)
             if (!teamEntry) {
-                teamEntry = { teamName: turn.teamName, usageCount: 0, attributedDamage: 0, attributedKills: 0 }
+                teamEntry = {
+                    teamName: turn.teamName,
+                    usageCount: 0,
+                    attributedDamage: 0,
+                    attributedKills: 0,
+                }
                 card.byTeam.push(teamEntry)
             }
             teamEntry.usageCount++
@@ -251,21 +299,32 @@ function WeaponsPanel({ turns }: WeaponsPanelProps) {
                         {weapon.name}
                     </Typography>
                     <Box sx={{ display: 'flex', mb: 1.5 }}>
-                        {([
-                            ['Uses', weapon.totalUses, undefined],
-                            ['Damage', weapon.totalDamage, 'primary.main'],
-                            ['Kills', weapon.totalKills, undefined],
-                        ] as const).map(([label, value, color]) => (
+                        {(
+                            [
+                                ['Uses', weapon.totalUses, undefined],
+                                ['Damage', weapon.totalDamage, 'primary.main'],
+                                ['Kills', weapon.totalKills, undefined],
+                            ] as const
+                        ).map(([label, value, color]) => (
                             <Box key={label} sx={{ flex: 1 }}>
                                 <Typography
                                     variant="caption"
                                     color="text.secondary"
-                                    sx={{ display: 'block', textTransform: 'uppercase', letterSpacing: '0.1em' }}
+                                    sx={{
+                                        display: 'block',
+                                        textTransform: 'uppercase',
+                                        letterSpacing: '0.1em',
+                                    }}
                                 >
                                     {label}
                                 </Typography>
                                 <Typography
-                                    sx={{ fontFamily: monoFontFamily, fontWeight: 700, fontSize: 20, color: color ?? 'text.primary' }}
+                                    sx={{
+                                        fontFamily: monoFontFamily,
+                                        fontWeight: 700,
+                                        fontSize: 20,
+                                        color: color ?? 'text.primary',
+                                    }}
                                 >
                                     {value}
                                 </Typography>
@@ -277,13 +336,18 @@ function WeaponsPanel({ turns }: WeaponsPanelProps) {
                         {weapon.byTeam.map((team) => (
                             <Box
                                 key={team.teamName}
-                                sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                                sx={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                }}
                             >
                                 <Typography variant="caption" color="text.secondary">
                                     {team.teamName}
                                 </Typography>
                                 <Typography variant="caption" sx={{ fontFamily: monoFontFamily }}>
-                                    {team.usageCount}× · {team.attributedDamage}dmg · {team.attributedKills}k
+                                    {team.usageCount}× · {team.attributedDamage}dmg ·{' '}
+                                    {team.attributedKills}k
                                 </Typography>
                             </Box>
                         ))}

--- a/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
@@ -1,0 +1,536 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link as RouterLink } from 'react-router'
+import { useAuth } from 'react-oidc-context'
+import Box from '@mui/material/Box'
+import Breadcrumbs from '@mui/material/Breadcrumbs'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import Container from '@mui/material/Container'
+import List from '@mui/material/List'
+import ListItemButton from '@mui/material/ListItemButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import MuiLink from '@mui/material/Link'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Typography from '@mui/material/Typography'
+import TimelineIcon from '@mui/icons-material/Timeline'
+import GpsFixedIcon from '@mui/icons-material/GpsFixed'
+import { monoFontFamily } from '../theme'
+import { gatewayUrl } from '../api'
+
+interface WeaponDto {
+    name: string
+}
+
+interface DamageSummaryDto {
+    teamName: string
+    healthLost: number
+    wormsKilled: number
+}
+
+interface TurnDto {
+    turnNumber: number
+    teamName: string
+    startMs: number
+    endMs: number
+    weapons: WeaponDto[]
+    damage: DamageSummaryDto[]
+}
+
+interface ReplayDetailDto {
+    id: string
+    name: string
+    status: string
+    date: string | null
+    winner: string | null
+    teams: string[] | null
+    turns: TurnDto[] | null
+}
+
+interface LeagueDto {
+    id: string
+    name: string
+    version: string | null
+    schemeUrl: string | null
+}
+
+function formatDuration(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000)
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
+interface TurnByTurnPanelProps {
+    turns: TurnDto[] | null
+}
+
+function TurnByTurnPanel({ turns }: TurnByTurnPanelProps) {
+    if (turns === null || turns.length === 0) {
+        return (
+            <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
+                <Typography color="text.secondary">
+                    No turn-by-turn data available for this replay.
+                </Typography>
+            </Paper>
+        )
+    }
+
+    return (
+        <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+                <TableHead>
+                    <TableRow>
+                        <TableCell sx={{ fontWeight: 700, width: 48 }}>#</TableCell>
+                        <TableCell sx={{ fontWeight: 700 }}>Team</TableCell>
+                        <TableCell sx={{ fontWeight: 700 }}>Weapons used</TableCell>
+                        <TableCell sx={{ fontWeight: 700 }}>Damage dealt</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {turns.map((turn) => (
+                        <TableRow key={turn.turnNumber}>
+                            <TableCell
+                                sx={{
+                                    fontFamily: monoFontFamily,
+                                    fontSize: 12,
+                                    color: 'text.secondary',
+                                }}
+                            >
+                                {String(turn.turnNumber).padStart(2, '0')}
+                            </TableCell>
+                            <TableCell>
+                                <Chip size="small" label={turn.teamName} />
+                            </TableCell>
+                            <TableCell>
+                                {turn.weapons.length === 0 ? (
+                                    <Typography variant="caption" color="text.disabled">
+                                        —
+                                    </Typography>
+                                ) : (
+                                    <Stack
+                                        direction="row"
+                                        spacing={0.5}
+                                        sx={{ flexWrap: 'wrap' }}
+                                        useFlexGap
+                                    >
+                                        {turn.weapons.map((w, i) => (
+                                            <Chip
+                                                key={i}
+                                                size="small"
+                                                label={w.name}
+                                                variant="outlined"
+                                                sx={
+                                                    i === turn.weapons.length - 1
+                                                        ? { fontWeight: 700 }
+                                                        : undefined
+                                                }
+                                            />
+                                        ))}
+                                    </Stack>
+                                )}
+                            </TableCell>
+                            <TableCell>
+                                {turn.damage.length === 0 ? (
+                                    <Typography variant="caption" color="text.disabled">
+                                        —
+                                    </Typography>
+                                ) : (
+                                    <Stack direction="column" spacing={0.5}>
+                                        {turn.damage.map((d) => (
+                                            <Box
+                                                key={d.teamName}
+                                                sx={{
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    gap: 0.5,
+                                                }}
+                                            >
+                                                <Typography variant="body2">
+                                                    {d.teamName}: {d.healthLost}
+                                                </Typography>
+                                                {d.wormsKilled > 0 && (
+                                                    <Chip
+                                                        label={`+${d.wormsKilled} kill${d.wormsKilled > 1 ? 's' : ''}`}
+                                                        size="small"
+                                                        color="error"
+                                                    />
+                                                )}
+                                            </Box>
+                                        ))}
+                                    </Stack>
+                                )}
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    )
+}
+
+type WeaponStats = { name: string; usageCount: number; attributedDamage: number }
+type TeamWeaponMap = Map<string, WeaponStats[]>
+
+interface WeaponsPanelProps {
+    turns: TurnDto[] | null
+}
+
+function WeaponsPanel({ turns }: WeaponsPanelProps) {
+    if (turns === null || turns.length === 0) {
+        return (
+            <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
+                <Typography color="text.secondary">
+                    No weapon data available for this replay.
+                </Typography>
+            </Paper>
+        )
+    }
+
+    const teamWeaponMap: TeamWeaponMap = new Map()
+
+    for (const turn of turns) {
+        if (!teamWeaponMap.has(turn.teamName)) {
+            teamWeaponMap.set(turn.teamName, [])
+        }
+        const stats = teamWeaponMap.get(turn.teamName)!
+
+        for (const weapon of turn.weapons) {
+            let entry = stats.find((s) => s.name === weapon.name)
+            if (!entry) {
+                entry = { name: weapon.name, usageCount: 0, attributedDamage: 0 }
+                stats.push(entry)
+            }
+            entry.usageCount++
+        }
+
+        if (turn.weapons.length > 0) {
+            const lastWeapon = turn.weapons[turn.weapons.length - 1]
+            const totalDamage = turn.damage.reduce((sum, d) => sum + d.healthLost, 0)
+            const entry = stats.find((s) => s.name === lastWeapon.name)
+            if (entry) {
+                entry.attributedDamage += totalDamage
+            }
+        }
+    }
+
+    const sortedTeams = Array.from(teamWeaponMap.entries()).map(([teamName, weaponStats]) => ({
+        teamName,
+        weapons: weaponStats
+            .slice()
+            .sort((a, b) => b.attributedDamage - a.attributedDamage || b.usageCount - a.usageCount),
+    }))
+
+    return (
+        <Stack spacing={2}>
+            {sortedTeams.map(({ teamName, weapons }) => (
+                <Box key={teamName}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+                        {teamName}
+                    </Typography>
+                    <TableContainer component={Paper} variant="outlined">
+                        <Table size="small">
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell sx={{ fontWeight: 700 }}>Weapon</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, width: 60 }}>Uses</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, width: 120 }}>
+                                        Attributed Damage
+                                    </TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {weapons.map((w) => (
+                                    <TableRow key={w.name}>
+                                        <TableCell>{w.name}</TableCell>
+                                        <TableCell
+                                            sx={{ fontFamily: monoFontFamily, fontSize: 12 }}
+                                        >
+                                            {w.usageCount}
+                                        </TableCell>
+                                        <TableCell
+                                            sx={{ fontFamily: monoFontFamily, fontSize: 12 }}
+                                        >
+                                            {w.attributedDamage}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </Box>
+            ))}
+        </Stack>
+    )
+}
+
+function GameDetailPage() {
+    const { id, replayId } = useParams<{ id: string; replayId: string }>()
+    const auth = useAuth()
+    const [replay, setReplay] = useState<ReplayDetailDto | null>(null)
+    const [league, setLeague] = useState<LeagueDto | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [notFound, setNotFound] = useState(false)
+    const [activePanel, setActivePanel] = useState(0)
+
+    useEffect(() => {
+        if (!auth.user?.access_token || !id || !replayId) return
+        const token = auth.user.access_token
+        const headers = { Authorization: `Bearer ${token}` }
+        Promise.all([
+            fetch(`${gatewayUrl}/api/v1/leagues/${id}/replays/${replayId}`, { headers }),
+            fetch(`${gatewayUrl}/api/v1/leagues/${id}`, { headers }),
+        ])
+            .then(async ([replayRes, leagueRes]) => {
+                if (replayRes.status === 404) {
+                    setNotFound(true)
+                    return
+                }
+                if (!replayRes.ok) throw new Error(`HTTP ${replayRes.status}`)
+                if (!leagueRes.ok) throw new Error(`HTTP ${leagueRes.status}`)
+                const [replayData, leagueData] = await Promise.all([
+                    replayRes.json() as Promise<ReplayDetailDto>,
+                    leagueRes.json() as Promise<LeagueDto>,
+                ])
+                setReplay(replayData)
+                setLeague(leagueData)
+            })
+            .catch((err: unknown) => setError(String(err)))
+    }, [auth.user?.access_token, id, replayId])
+
+    const panels = [
+        {
+            label: 'Turn-by-turn',
+            icon: <TimelineIcon sx={{ fontSize: 18 }} />,
+            content: <TurnByTurnPanel turns={replay?.turns ?? null} />,
+        },
+        {
+            label: 'Weapons',
+            icon: <GpsFixedIcon sx={{ fontSize: 18 }} />,
+            content: <WeaponsPanel turns={replay?.turns ?? null} />,
+        },
+    ]
+
+    const isLoading = replay === null && league === null && error === null && !notFound
+
+    const turns = replay?.turns ?? null
+    const hasTurns = turns !== null && turns.length > 0
+
+    const duration = hasTurns ? turns[turns.length - 1].endMs - turns[0].startMs : 0
+
+    const maxDamagePerTurn = hasTurns
+        ? Math.max(...turns.map((t) => t.damage.reduce((sum, d) => sum + d.healthLost, 0)))
+        : 0
+
+    const totalKills = hasTurns
+        ? turns.reduce((sum, t) => sum + t.damage.reduce((sum2, d) => sum2 + d.wormsKilled, 0), 0)
+        : 0
+
+    return (
+        <Container maxWidth="xl" sx={{ py: { xs: 2, md: 4 } }}>
+            {isLoading && <CircularProgress />}
+            {notFound && <Typography>Replay not found.</Typography>}
+            {error !== null && <Typography color="error">Error: {error}</Typography>}
+            {replay !== null && replay.status !== 'Processed' && (
+                <Typography color="text.secondary">
+                    This replay is being processed. Please check back soon.
+                </Typography>
+            )}
+            {replay !== null && replay.status === 'Processed' && league !== null && (
+                <Box>
+                    {/* Breadcrumb */}
+                    <Breadcrumbs sx={{ mb: 2 }}>
+                        <MuiLink
+                            component={RouterLink}
+                            to="/leagues"
+                            variant="body2"
+                            color="inherit"
+                            underline="hover"
+                        >
+                            Leagues
+                        </MuiLink>
+                        <MuiLink
+                            component={RouterLink}
+                            to={`/leagues/${id}`}
+                            variant="body2"
+                            color="inherit"
+                            underline="hover"
+                        >
+                            {league.name}
+                        </MuiLink>
+                        <Typography variant="body2" color="text.primary" component="span">
+                            Match #{replay.id.padStart(3, '0')}
+                        </Typography>
+                    </Breadcrumbs>
+
+                    {/* Hero card */}
+                    <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+                        {/* Title row */}
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 2,
+                                mb: 2,
+                                flexWrap: 'wrap',
+                            }}
+                        >
+                            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                                Match #{replay.id.padStart(3, '0')}
+                            </Typography>
+                            {replay.date !== null && (
+                                <Typography
+                                    sx={{
+                                        fontFamily: monoFontFamily,
+                                        fontSize: 12,
+                                        color: 'text.secondary',
+                                    }}
+                                >
+                                    {new Date(replay.date).toLocaleDateString('en-GB', {
+                                        year: 'numeric',
+                                        month: 'short',
+                                        day: 'numeric',
+                                    })}{' '}
+                                    &middot;{' '}
+                                    {new Date(replay.date).toLocaleTimeString('en-GB', {
+                                        hour: '2-digit',
+                                        minute: '2-digit',
+                                    })}
+                                </Typography>
+                            )}
+                            {replay.winner !== null && (
+                                <Chip
+                                    label={replay.winner}
+                                    color={replay.winner === 'Draw' ? 'default' : 'warning'}
+                                    size="small"
+                                    sx={{ fontWeight: 700 }}
+                                />
+                            )}
+                        </Box>
+
+                        {/* Team chips */}
+                        {replay.teams !== null && (
+                            <Stack
+                                direction="row"
+                                spacing={1}
+                                sx={{ mb: 2.5, flexWrap: 'wrap' }}
+                                useFlexGap
+                            >
+                                {replay.teams.map((team) => (
+                                    <Chip
+                                        key={team}
+                                        label={team}
+                                        size="small"
+                                        variant="outlined"
+                                        sx={{ fontFamily: monoFontFamily, fontSize: 11 }}
+                                    />
+                                ))}
+                                {league.version !== null && (
+                                    <Chip
+                                        label={`Scheme v${league.version}`}
+                                        size="small"
+                                        variant="outlined"
+                                        sx={{ fontFamily: monoFontFamily, fontSize: 11 }}
+                                    />
+                                )}
+                            </Stack>
+                        )}
+
+                        {/* Stats strip */}
+                        {hasTurns && (
+                            <Box
+                                sx={{
+                                    display: 'grid',
+                                    gridTemplateColumns: 'repeat(4, 1fr)',
+                                    gap: 1.5,
+                                }}
+                            >
+                                {[
+                                    ['Duration', formatDuration(duration)],
+                                    ['Turns', String(turns.length)],
+                                    ['Max Damage', String(maxDamagePerTurn)],
+                                    ['Kills', String(totalKills)],
+                                ].map(([label, value]) => (
+                                    <Paper key={label} variant="outlined" sx={{ p: 1.5 }}>
+                                        <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                            sx={{
+                                                display: 'block',
+                                                letterSpacing: '0.12em',
+                                                textTransform: 'uppercase',
+                                            }}
+                                        >
+                                            {label}
+                                        </Typography>
+                                        <Typography
+                                            sx={{
+                                                fontFamily: monoFontFamily,
+                                                fontWeight: 700,
+                                                fontSize: 22,
+                                                mt: 0.25,
+                                            }}
+                                        >
+                                            {value}
+                                        </Typography>
+                                    </Paper>
+                                ))}
+                            </Box>
+                        )}
+                    </Paper>
+
+                    {/* Sidebar layout */}
+                    <Box
+                        sx={{
+                            display: 'grid',
+                            gridTemplateColumns: '200px 1fr',
+                            gap: 2,
+                            alignItems: 'start',
+                        }}
+                    >
+                        {/* Left nav */}
+                        <Paper variant="outlined" sx={{ p: 0.75 }}>
+                            <List dense disablePadding>
+                                {panels.map((panel, i) => (
+                                    <ListItemButton
+                                        key={i}
+                                        selected={activePanel === i}
+                                        onClick={() => setActivePanel(i)}
+                                        sx={{ borderRadius: 1, mb: 0.25 }}
+                                    >
+                                        <ListItemIcon sx={{ minWidth: 32 }}>
+                                            {panel.icon}
+                                        </ListItemIcon>
+                                        <ListItemText
+                                            primary={panel.label}
+                                            slotProps={{
+                                                primary: {
+                                                    style: {
+                                                        fontSize: 13,
+                                                        fontWeight: activePanel === i ? 700 : 400,
+                                                    },
+                                                },
+                                            }}
+                                        />
+                                    </ListItemButton>
+                                ))}
+                            </List>
+                        </Paper>
+
+                        {/* Right content */}
+                        <Box>{panels[activePanel].content}</Box>
+                    </Box>
+                </Box>
+            )}
+        </Container>
+    )
+}
+
+export default GameDetailPage

--- a/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
@@ -167,7 +167,7 @@ function LeagueDetailPage() {
                                             Date
                                         </TableCell>
                                         <TableCell sx={{ fontWeight: 700 }}>Players</TableCell>
-                                        <TableCell sx={{ fontWeight: 700, width: 160 }}>
+                                        <TableCell sx={{ fontWeight: 700, width: 300 }}>
                                             Top weapons
                                         </TableCell>
                                         <TableCell sx={{ fontWeight: 700, width: 80 }}>
@@ -327,7 +327,9 @@ function LeagueDetailPage() {
                                                             <Typography
                                                                 sx={{
                                                                     fontFamily: monoFontFamily,
-                                                                    fontSize: 12,
+                                                                    fontSize: 16,
+                                                                    fontWeight: 700,
+                                                                    color: 'primary.main',
                                                                 }}
                                                             >
                                                                 {Math.max(

--- a/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
@@ -288,21 +288,30 @@ function LeagueDetailPage() {
                                                                 sx={{ flexWrap: 'wrap' }}
                                                                 useFlexGap
                                                             >
-                                                                {topWeaponsByDamage(replay.turns, 3).map((w) => (
+                                                                {topWeaponsByDamage(
+                                                                    replay.turns,
+                                                                    3,
+                                                                ).map((w) => (
                                                                     <Chip
                                                                         key={w}
                                                                         label={w}
                                                                         size="small"
                                                                         variant="outlined"
                                                                         sx={{
-                                                                            fontFamily: monoFontFamily,
+                                                                            fontFamily:
+                                                                                monoFontFamily,
                                                                             fontSize: 11,
                                                                         }}
                                                                     />
                                                                 ))}
                                                             </Stack>
                                                         ) : (
-                                                            <Typography variant="caption" color="text.disabled">—</Typography>
+                                                            <Typography
+                                                                variant="caption"
+                                                                color="text.disabled"
+                                                            >
+                                                                —
+                                                            </Typography>
                                                         )}
                                                     </TableCell>
                                                     <TableCell>
@@ -314,12 +323,19 @@ function LeagueDetailPage() {
                                                                 }}
                                                             >
                                                                 {formatDuration(
-                                                                    replay.turns[replay.turns.length - 1].endMs -
-                                                                    replay.turns[0].startMs,
+                                                                    replay.turns[
+                                                                        replay.turns.length - 1
+                                                                    ].endMs -
+                                                                        replay.turns[0].startMs,
                                                                 )}
                                                             </Typography>
                                                         ) : (
-                                                            <Typography variant="caption" color="text.disabled">—</Typography>
+                                                            <Typography
+                                                                variant="caption"
+                                                                color="text.disabled"
+                                                            >
+                                                                —
+                                                            </Typography>
                                                         )}
                                                     </TableCell>
                                                     <TableCell align="right">
@@ -334,12 +350,21 @@ function LeagueDetailPage() {
                                                             >
                                                                 {Math.max(
                                                                     ...replay.turns.map((t) =>
-                                                                        t.damage.reduce((sum, d) => sum + d.healthLost, 0),
+                                                                        t.damage.reduce(
+                                                                            (sum, d) =>
+                                                                                sum + d.healthLost,
+                                                                            0,
+                                                                        ),
                                                                     ),
                                                                 )}
                                                             </Typography>
                                                         ) : (
-                                                            <Typography variant="caption" color="text.disabled">—</Typography>
+                                                            <Typography
+                                                                variant="caption"
+                                                                color="text.disabled"
+                                                            >
+                                                                —
+                                                            </Typography>
                                                         )}
                                                     </TableCell>
                                                 </TableRow>

--- a/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
@@ -27,6 +27,25 @@ interface LeagueDto {
     schemeUrl: string | null
 }
 
+interface WeaponDto {
+    name: string
+}
+
+interface DamageSummaryDto {
+    teamName: string
+    healthLost: number
+    wormsKilled: number
+}
+
+interface TurnDto {
+    turnNumber: number
+    teamName: string
+    startMs: number
+    endMs: number
+    weapons: WeaponDto[]
+    damage: DamageSummaryDto[]
+}
+
 interface ReplayInLeagueDto {
     id: string
     name: string
@@ -34,6 +53,28 @@ interface ReplayInLeagueDto {
     date: string | null
     winner: string | null
     teams: string[] | null
+    turns: TurnDto[] | null
+}
+
+function formatDuration(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000)
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
+function topWeaponsByDamage(turns: TurnDto[], n: number): string[] {
+    const damage = new Map<string, number>()
+    for (const turn of turns) {
+        if (turn.weapons.length === 0) continue
+        const lastWeapon = turn.weapons[turn.weapons.length - 1]
+        const total = turn.damage.reduce((sum, d) => sum + d.healthLost, 0)
+        damage.set(lastWeapon.name, (damage.get(lastWeapon.name) ?? 0) + total)
+    }
+    return Array.from(damage.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, n)
+        .map(([name]) => name)
 }
 
 function LeagueDetailPage() {
@@ -240,28 +281,64 @@ function LeagueDetailPage() {
                                                         </Stack>
                                                     </TableCell>
                                                     <TableCell>
-                                                        <Typography
-                                                            variant="caption"
-                                                            color="text.disabled"
-                                                        >
-                                                            —
-                                                        </Typography>
+                                                        {replay.turns && replay.turns.length > 0 ? (
+                                                            <Stack
+                                                                direction="row"
+                                                                spacing={0.5}
+                                                                sx={{ flexWrap: 'wrap' }}
+                                                                useFlexGap
+                                                            >
+                                                                {topWeaponsByDamage(replay.turns, 3).map((w) => (
+                                                                    <Chip
+                                                                        key={w}
+                                                                        label={w}
+                                                                        size="small"
+                                                                        variant="outlined"
+                                                                        sx={{
+                                                                            fontFamily: monoFontFamily,
+                                                                            fontSize: 11,
+                                                                        }}
+                                                                    />
+                                                                ))}
+                                                            </Stack>
+                                                        ) : (
+                                                            <Typography variant="caption" color="text.disabled">—</Typography>
+                                                        )}
                                                     </TableCell>
                                                     <TableCell>
-                                                        <Typography
-                                                            variant="caption"
-                                                            color="text.disabled"
-                                                        >
-                                                            —
-                                                        </Typography>
+                                                        {replay.turns && replay.turns.length > 0 ? (
+                                                            <Typography
+                                                                sx={{
+                                                                    fontFamily: monoFontFamily,
+                                                                    fontSize: 12,
+                                                                }}
+                                                            >
+                                                                {formatDuration(
+                                                                    replay.turns[replay.turns.length - 1].endMs -
+                                                                    replay.turns[0].startMs,
+                                                                )}
+                                                            </Typography>
+                                                        ) : (
+                                                            <Typography variant="caption" color="text.disabled">—</Typography>
+                                                        )}
                                                     </TableCell>
                                                     <TableCell align="right">
-                                                        <Typography
-                                                            variant="caption"
-                                                            color="text.disabled"
-                                                        >
-                                                            —
-                                                        </Typography>
+                                                        {replay.turns && replay.turns.length > 0 ? (
+                                                            <Typography
+                                                                sx={{
+                                                                    fontFamily: monoFontFamily,
+                                                                    fontSize: 12,
+                                                                }}
+                                                            >
+                                                                {Math.max(
+                                                                    ...replay.turns.map((t) =>
+                                                                        t.damage.reduce((sum, d) => sum + d.healthLost, 0),
+                                                                    ),
+                                                                )}
+                                                            </Typography>
+                                                        ) : (
+                                                            <Typography variant="caption" color="text.disabled">—</Typography>
+                                                        )}
                                                     </TableCell>
                                                 </TableRow>
                                             ) : (

--- a/src/database/local-dev/R__ReplaysTestData.sql
+++ b/src/database/local-dev/R__ReplaysTestData.sql
@@ -54,3 +54,36 @@ VALUES (
     NULL,
     NULL
 );
+
+INSERT INTO public.replays (name, status, filename, league_id, date, winner, teams, fulllog)
+VALUES (
+    '2024-06-01',
+    'Processed',
+    'seed_replay_withlog.WAgame',
+    'redgate',
+    '2024-06-01 19:00:00',
+    'Team Alpha',
+    ARRAY['Team Alpha', 'Team Beta'],
+    $$Game Started at 2024-06-01 19:00:00 GMT
+Red: "player1" as "Team Alpha"
+Blue: "player2" as "Team Beta"
+[00:00:05.00] ••• Team Alpha (player1) starts turn
+[00:00:08.00] ••• Team Alpha (player1) fires Shotgun
+[00:00:25.00] ••• Damage dealt: 45 to Team Beta (player2)
+[00:00:27.00] ••• Team Alpha (player1) ends turn; time used: 22.00 sec turn, 3.00 sec retreat
+[00:00:35.00] ••• Team Beta (player2) starts turn
+[00:00:40.00] ••• Team Beta (player2) fires Grenade (3 sec, min bounce)
+[00:00:58.00] ••• Damage dealt: 30 to Team Alpha (player1)
+[00:01:00.00] ••• Team Beta (player2) ends turn; time used: 25.00 sec turn, 3.00 sec retreat
+[00:01:10.00] ••• Team Alpha (player1) starts turn
+[00:01:15.00] ••• Team Alpha (player1) fires Ninja Rope
+[00:01:20.00] ••• Team Alpha (player1) fires Banana Bomb (5 sec)
+[00:01:35.00] ••• Damage dealt: 80 (1 kill) to Team Beta (player2)
+[00:01:37.00] ••• Team Alpha (player1) ends turn; time used: 27.00 sec turn, 3.00 sec retreat
+[00:01:45.00] ••• Team Beta (player2) starts turn
+[00:01:50.00] ••• Team Beta (player2) fires Bazooka
+[00:02:05.00] ••• Damage dealt: 50 to Team Alpha (player1)
+[00:02:07.00] ••• Team Beta (player2) ends turn; time used: 22.00 sec turn, 3.00 sec retreat
+Team Alpha wins the match!
+$$
+);


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/leagues/{id}/replays/{replayId}` gateway endpoint that parses the stored WA log on demand and returns a turn-by-turn breakdown with weapon usage, damage, and timestamps
- Moves `AddWormsArmageddonFilesServices()` outside the gateway-only block so it is registered in distributed worker-only mode too (fixes a startup DI failure)
- Adds `GameDetailPage` in the SPA with a hero card (winner chip, team chips, scheme version chip), stats strip (duration, turns, max damage, kills), and a sidebar with Turn-by-turn and Weapons panels
- Adds a seeded replay with a 4-turn full log for local development

## Test plan

- [x] `dotnet build src/Worms.Hub.Gateway --warnaserror` passes
- [x] `make web.build && make web.lint` passes
- [x] `docker compose up` — navigate to Redgate league, click seeded replay row; detail page loads with populated hero card, stats strip, and both panels
- [x] Navigate to `/leagues/redgate/replays/999` — shows not-found message
- [x] Navigate to `/leagues/redgate/replays/{pending-id}` — shows "processing" message
- [x] Open page without signing in — redirected by `RequireAuth`
- [x] `GET /api/v1/leagues/redgate/replays/{id}` without `Authorization` header returns 401