### PR TITLE
feat(commands): add /retro-epic and apply web-ui epic learnings

### DIFF
--- a/.claude/commands/implement-slice.md
+++ b/.claude/commands/implement-slice.md
@@ -60,6 +60,8 @@ Keep a running mental note of anything that warrants recording. Capture a learni
 
 Do not record learnings for steps that went exactly as planned.
 
+Every file you create or modify that is not in the plan's "Files to Create / Modify" table must be recorded in the "Files Added (not in plan)" section of `learnings.md`. This includes migration files, configuration files, CI workflow changes, and infrastructure files — not only application code.
+
 ## Step 5 — Tick the slice in the epic plan
 
 After all implementation tasks are complete, mark the slice as done in the epic's top-level `plan.md` by changing its checkbox from `- [ ]` to `- [x]`.

--- a/.claude/commands/plan-spec.md
+++ b/.claude/commands/plan-spec.md
@@ -32,6 +32,8 @@ Read everything needed to produce an accurate, codebase-consistent plan:
 - Any `learnings.md` files from earlier slices in the same epic — they capture known caveats from prior implementation
 - If the epic folder contains a `design/` directory (e.g. `.claude/specs/<epic-slug>/design/`) and this slice touches anything it covers, read the relevant files — treat them as a reference for layout, structure, and ideas, not as the authoritative definition.
 
+When reading source files, record exactly what you find. Any factual claim the plan makes about existing file state — "this function is not yet registered", "the middleware block currently contains X", "this method does not exist" — must be directly verified from the file you read, not inferred or assumed from prior knowledge.
+
 ## Step 3 — Plan in plan mode
 
 Use the EnterPlanMode tool to enter plan mode. Think through the full implementation before committing to any file content:
@@ -41,6 +43,7 @@ Use the EnterPlanMode tool to enter plan mode. Think through the full implementa
 - Non-obvious decisions left open by the spec: library versions, build system wiring, CI job names, config keys, DI registration — resolve them here
 - How to verify each piece of work is correct once done
 - Any risks or caveats the plan should call out explicitly
+- If the slice adds a new endpoint that returns a richer response type for a single item while a corresponding list endpoint already exists for the same domain resource, include an explicit scope decision: does the list endpoint need updating to match? Do not leave the asymmetry implicit — decide in or out of scope and note it in the plan.
 
 Use the ExitPlanMode tool to exit plan mode before writing any files.
 

--- a/.claude/commands/retro-epic.md
+++ b/.claude/commands/retro-epic.md
@@ -1,0 +1,155 @@
+---
+description: Run a retrospective on a completed epic — extract learnings from slice files and PR review activity, then update steering and component docs to prevent the same mistakes next time
+effort: high
+---
+
+You coordinate a four-phase retrospective on a completed epic. The aim is to surface what the implementation agents got wrong (in slice review.md files, in PR comments, in follow-up commits after the agent review) and feed that back into the steering and component docs so the next epic does not repeat the same mistakes.
+
+Phases 2, 3, and 4 each spawn sub-agents with clean contexts. Your job is to coordinate them, keep the epic-level `learnings.md` consistent, and confirm choices with the user where the inputs are ambiguous.
+
+## Phase 1 — Identify the epic
+
+If the user has named a specific epic, use that.
+
+Otherwise, find the most recently completed epic:
+
+1. List the epic directories under `.claude/specs/` (each is a directory containing `spec.md` and `plan.md`).
+2. For each epic, read `plan.md` and treat it as complete if every slice line is checked (`- [x]`) and no `- [ ]` remains. Skip incomplete epics.
+3. Among complete epics, pick the most recently finished by mtime of the latest file under `slices/` (typically the last `review.md`).
+4. Present the chosen epic to the user — its slug and the number of slices — and ask them to confirm or pick a different one.
+
+Do not proceed until the user has confirmed the target epic. Record the epic's full directory path (e.g. `.claude/specs/<epic-slug>`).
+
+If `<epic-path>/learnings.md` already exists, tell the user it will be overwritten and confirm before continuing.
+
+## Phase 2 — Extract learnings from slice files
+
+Spawn one sub-agent with this prompt, substituting `<epic-path>`:
+
+> You are running Phase 2 of an epic retrospective. The epic directory is `<epic-path>`.
+>
+> Read every slice's `learnings.md` and `review.md` under `<epic-path>/slices/`. Across all of them, identify:
+>
+> - Common patterns of mistakes the implementation agent made (things flagged in review.md Blockers/Suggestions, or things the implementer had to fix mid-flight as recorded in learnings.md).
+> - Recurring scope or plan deviations that point at a missing instruction in the process.
+> - Repeated gaps in test coverage, CI wiring, or guideline adherence.
+> - Any single-occurrence issue that is severe enough or general enough to be worth preventing next time.
+>
+> Do NOT include:
+> - Issues that were one-off implementation details with no broader lesson.
+> - Praise or things that went well — this retro is about what to change.
+>
+> Write the results to `<epic-path>/learnings.md` using this structure:
+>
+> ```markdown
+> # Retrospective — <epic name>
+>
+> ## From slice files
+>
+> ### L1 — <short title>
+>
+> - **Pattern:** <one or two sentences describing what kept going wrong>
+> - **Evidence:** <slice dir>/review.md (B1, S2), <slice dir>/learnings.md
+> - **Where to fix it:** <which steering or component doc should change, and what the change should say>
+>
+> ### L2 — …
+> ```
+>
+> Number entries L1, L2, L3, … in document order. For each, the "Where to fix it" line should name the specific doc under `.claude/docs/` (steering or component) most likely to prevent recurrence, and describe in one sentence what new guidance would have prevented the mistake.
+>
+> Do not modify any other file. Do not edit code or docs. Only write `<epic-path>/learnings.md`.
+
+After the agent completes, verify `<epic-path>/learnings.md` exists and contains at least one numbered entry. If it does not, stop and report the failure to the user.
+
+## Phase 3 — Extract learnings from GitHub PR activity
+
+### 3a — Determine the candidate PR list
+
+Find the date window in which the epic was delivered:
+
+- **Start:** the earliest mtime among `<epic-path>/slices/*/spec.md`.
+- **End:** the latest mtime among `<epic-path>/slices/*/review.md`.
+
+List PRs merged into `main` during that window:
+
+```
+gh pr list --base main --state merged --limit 100 \
+  --search "merged:<start-date>..<end-date>" \
+  --json number,title,headRefName,mergedAt
+```
+
+Present the list to the user and ask them to confirm which PRs belong to this epic. Renovate, unrelated refactors, and other concurrent work will appear in the window and must be filtered out. Wait for the user's confirmed list before continuing.
+
+### 3b — Spawn one sub-agent per confirmed PR
+
+For each PR number `N` in the confirmed list, spawn a sub-agent **in parallel** with this prompt, substituting `<N>` and `<epic-path>`:
+
+> You are running Phase 3 of an epic retrospective for PR #<N>. The epic learnings file lives at `<epic-path>/learnings.md`.
+>
+> Gather PR activity:
+>
+> ```
+> gh pr view <N> --json number,title,body,mergedAt,reviews,comments,commits
+> gh api repos/{owner}/{repo}/pulls/<N>/comments  # inline review comments
+> ```
+>
+> (Use `gh repo view --json owner,name` to resolve `{owner}` and `{repo}` if needed.)
+>
+> Identify two classes of signal:
+>
+> 1. **Human review comments** that asked for changes — what the reviewer caught that the agent's own review.md missed.
+> 2. **Commits made on the PR branch AFTER the agent's review.md was written** (i.e. follow-up fixes pushed in response to human review or post-review testing). The `<epic-path>/slices/*/review.md` mtime gives a reasonable cutoff; for commits, use the timestamp on the commit itself versus the PR's review.md.
+>
+> For each genuine learning — something the implementation or agent-review process should have caught but didn't — append a new numbered entry to `<epic-path>/learnings.md` under a section header `## From PR #<N>` (create the section if it does not exist). Use the same entry format as Phase 2:
+>
+> ```markdown
+> ### P<N>.1 — <short title>
+>
+> - **Pattern:** <one or two sentences>
+> - **Evidence:** PR #<N> review comment by <reviewer>, follow-up commit <sha-short>
+> - **Where to fix it:** <which doc, what change>
+> ```
+>
+> Skip noise: typo fixes, formatting churn, comments that are just questions, and merge-conflict resolution commits do not produce learnings. Only record things that point at a process or guidance gap.
+>
+> Append to `<epic-path>/learnings.md`. Do not modify any other file. Do not edit code or docs.
+
+After all PR agents complete, read `<epic-path>/learnings.md` and skim it for duplicates across sections. If multiple entries describe the same underlying pattern, consolidate them into a single entry that cites all the evidence — keep the entry numbering stable within each section.
+
+## Phase 4 — Update steering and component docs
+
+Spawn one sub-agent with this prompt, substituting `<epic-path>`:
+
+> You are running Phase 4 of an epic retrospective. The learnings live at `<epic-path>/learnings.md`.
+>
+> For each numbered learning entry, follow its **Where to fix it** line and make the smallest edit to the named doc under `.claude/docs/` that would prevent the mistake from recurring. If the named doc is wrong or the guidance fits better elsewhere, pick the more appropriate doc — but explain why in your final report.
+>
+> Rules:
+>
+> - Edit existing docs only. Do not create new files unless an entry has no plausible home and the user is told.
+> - Steering docs (`.claude/docs/steering/*.md`) must remain high-level — no file paths, line numbers, or version numbers (see `.claude/commands/update-docs.md` for the full rules; respect them).
+> - Component docs may reference type names but not line numbers.
+> - Match the tone and structure of the existing docs. Add the new guidance where a reader would expect it, not as a tacked-on "lessons learned" section.
+> - Do not reference PR numbers, commit hashes, slice numbers, or the retrospective itself in the docs. The docs should read as durable guidance, not as a changelog.
+> - If two learnings would produce contradictory or redundant guidance, reconcile them into one coherent edit and note that in your report.
+>
+> When done, report:
+>
+> - A bullet list of doc files changed and the substantive change in each (one line per file).
+> - Any learning you deliberately did NOT act on, with a one-line reason.
+> - Any learning where the guidance belongs somewhere outside `.claude/docs/` (e.g. a command file under `.claude/commands/`, a makefile, or CI config) — flag these for the user, do not edit them yourself.
+>
+> Do not commit. The user reviews and commits.
+
+After the agent completes, surface its report to the user verbatim.
+
+## Phase 5 — Hand off
+
+Tell the user:
+
+- Where the epic `learnings.md` lives.
+- How many docs were updated and the headline of each change.
+- Any learnings the Phase 4 agent flagged as needing edits outside `.claude/docs/` — these are your follow-ups.
+- Next step: review the changes and commit when satisfied.
+
+Do not commit or push — the user triggers that.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -54,13 +54,13 @@ Record the exact output of any failing command as evidence for the finding.
 
 ### 5a — Acceptance criteria
 
-For each acceptance criterion in the slice's `spec.md`, determine whether the diff satisfies it. Cite the relevant file and line as evidence. Mark each criterion MET, PARTIAL, or NOT MET.
+For each acceptance criterion in the slice's `spec.md`, determine whether the diff satisfies it. Verify against the actual diff — read the specific file and line in the diff to confirm. Do not infer satisfaction from the plan's intended structure or from what you expect the implementation to have done. Mark each criterion MET, PARTIAL, or NOT MET with a file:line citation.
 
 ### 5b — Scope
 
-Compare the diff against the plan's "Files to Create / Modify" table.
+Start by listing every file that appears in the diff. Then compare that list against the plan's "Files to Create / Modify" table.
 
-- Flag files changed that are not in the plan.
+- Flag files in the diff that are not in the plan.
 - Flag planned files that are absent from the diff.
 - Flag changes that go beyond what the plan describes for a file.
 
@@ -69,6 +69,8 @@ Changes not in the plan are not automatically wrong — but they need a reason. 
 ### 5c — Coding guidelines
 
 Check the diff for violations of the coding guidelines and CI patterns in `.claude/docs/steering/`
+
+For any CI-related changes (new jobs, job conditions, change-detection gates, triggers), cross-reference the change against `.claude/docs/steering/ci-patterns.md` — do not evaluate correctness from spec wording alone. A criterion like "job skips on unrelated changes" may conflict with repo-wide CI conventions even if the spec asked for it.
 
 For web code, check against the ESLint config and Prettier settings in `src/Worms.Hub.Web/`.
 
@@ -141,3 +143,4 @@ Valid actions: `Accept` or `Decline`. Cover every finding.
 - Be specific. "Error handling could be improved" is not useful; "`GifCreator.cs:42` does not handle the case where `frames` is empty" is.
 - Match the bar the spec set. Do not raise production-grade concerns (HA, exhaustive logging, observability) the spec did not ask for.
 - Categorise honestly. A Blocker genuinely breaks a spec criterion or the build. A Suggestion is meaningful improvement. A Nitpick is style. Do not inflate severity.
+- Every finding must cite a line read from the actual current file. Do not raise a finding based on plan code examples, prior knowledge, or inference. A suggestion stating "X is missing" or "Y deviates from convention" must quote the actual file at the relevant location — if you have not read that file, read it before raising the finding. If the implementation already matches the desired state, do not raise the finding at all.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -98,6 +98,9 @@ Do not proceed to Step 5 until you can answer "yes" to all of the following:
 - Every error case has a specified outcome.
 - Every edge case identified in Round C either has a defined behaviour or has been explicitly deferred by the user.
 - The "Open Questions" section of the spec will either be empty or contain only items the user has deliberately chosen to leave unresolved.
+- If the slice includes any UI page or visual component: the design mockup has been reviewed and approved. If the design is still in flux, the spec must flag which visual details are pending and explicitly defer them rather than describing a placeholder that will need wholesale replacement later.
+- If the slice introduces a capability for the first time (a new test framework, a new CI job category, a new make target category): the setup of that infrastructure is explicitly included in scope and its files are listed. Do not assume it can be added invisibly.
+- If the slice adds or extends an endpoint that returns a richer response type for a single item while a corresponding list endpoint exists: a scope decision has been made and recorded — either the list endpoint is updated in this slice or the asymmetry is explicitly deferred.
 
 ## Step 5 — Create the spec file
 

--- a/.claude/docs/components/hub-gateway.md
+++ b/.claude/docs/components/hub-gateway.md
@@ -64,6 +64,31 @@ End-to-end flow for a replay upload:
 - `AddGatewayServices()` — registers `IAnnouncer`, validators, HTTP client
 - `AddWorkerServices()` — registers its `Processor`, plus pulls in Storage, Queue, Files, and Announcer services
 
+Services used by both the gateway and the worker (e.g. `AddWormsArmageddonFilesServices()`, which registers `IReplayTextReader`) must be called inside **each** component's own `Add*Services()` method, not placed unconditionally in `Program.cs`. Because `AddGatewayServices()` and `AddWorkerServices()` are both called in monolith mode, any method registered from multiple components must use `TryAddScoped` / `TryAddSingleton` / `TryAddEnumerable` throughout so repeated calls in monolith mode are safe (no double-registered parsers or handlers).
+
+## Feature flags
+
+Controllers must depend on `IFeatureFlags`, not on `DatabaseSchemaVersion` or any other concrete source directly. `GatewayFeatureFlags` aggregates all feature-gate sources (schema version, environment variables, etc.) and is the single place where feature decisions are made. Any new schema-version or feature-gate check must be added to `GatewayFeatureFlags` rather than injected into a controller.
+
+## Middleware ordering
+
+Inside the `if (runGateway)` block in `Program.cs`, `UseRequestLogging()` must be the **first** middleware call, before `UseStaticFiles()`, `MapControllers()`, and `MapFallbackToFile()`. Middleware placed after endpoint dispatch misses requests short-circuited by static-file serving and fallback routing.
+
+## Deployment safety
+
+Any new endpoint backed by a DB migration must address independent gateway/DB rollout risk. If the gateway can be deployed before the migration runs, it will crash rather than degrade gracefully. Mitigate with one of:
+
+- **Schema-version gate:** check `DatabaseSchemaVersion` (via `IFeatureFlags`) before querying the new table and return a suitable fallback or 503.
+- **Feature flag:** hide the endpoint until the migration has been confirmed applied.
+
+This decision must be made during spec — not discovered after deployment.
+
+## DTOs
+
+When adding an endpoint that returns a domain type already served by an existing endpoint, reuse and extend the existing DTO rather than creating a parallel type. Derived `bool` fields (e.g. `Processed`) must not be introduced when the domain model already carries an equivalent discriminant as a string (e.g. `Status`) — the TypeScript interface on the frontend must match the actual serialised JSON shape.
+
+When a new non-nullable-in-practice column is added to an existing table, search for all controller actions and worker methods that call `repository.Create()` or `repository.Update()` for the affected type and confirm each one sets the new field. Do not rely on the repository implementation alone to surface missing write-path callers.
+
 ## Configuration
 
 All config is read via `IConfiguration`. Connection strings use the `ConnectionStrings:*` section (e.g. `ConnectionStrings:Storage`, `ConnectionStrings:Database`). Storage folder paths use `Storage:*` (e.g. `Storage:TempReplayFolder`, `Storage:CliFolder`, `Storage:SchemesFolder`, `Storage:GameFolder`).

--- a/.claude/docs/components/hub-storage.md
+++ b/.claude/docs/components/hub-storage.md
@@ -48,6 +48,15 @@ File abstractions in `Files/` wrap filesystem operations and derive their paths 
 ## Adding a new domain object
 
 1. Add a `record` in `Domain/`.
-2. Create a `XxxRepository : IRepository<Xxx>` in `Database/`, including an internal `XxxDb` record for Dapper mapping.
+2. Create a `XxxRepository : IRepository<Xxx>` in `Database/`. Include a `[PublicAPI] record XxxDb(...)` for Dapper column mapping — the type **must** be named `XxxDb` (matching `GamesDb`, `ReplayDb`). The `[PublicAPI]` annotation marks it as resolved reflectively by Dapper/DI and suppresses false-positive unused-code warnings. Use `internal sealed` for both the repository and the DB record unless the repository will be injected by concrete type from another assembly (e.g. the Gateway), in which case the repository class must be `public sealed`.
 3. Register in `ServiceRegistration.AddHubStorageServices()`.
 4. Add a migration in `src/database/migrations/` (Flyway versioned migration, e.g. `V0.3__AddXxx.sql`).
+
+## Schema compatibility
+
+When a slice adds columns to an **existing** table and the gateway reads those columns, the plan must include an explicit compatibility decision before implementation:
+
+- **Require DB upgrade first:** the gateway may crash if deployed against the old schema. Only acceptable if gateway and DB are always upgraded together.
+- **Degrade gracefully:** gate the new endpoint or query behind a `DatabaseSchemaVersion` check. The DI-factory pattern selects between a base repository implementation and a versioned subtype at startup based on the detected schema version, so controllers never reference `DatabaseSchemaVersion` directly.
+
+Any plan that extends a repository to read new columns must document which approach is chosen and enumerate all write paths (controllers, workers, tests) that construct or persist the affected record type, confirming each sets the new field correctly.

--- a/.claude/docs/components/web.md
+++ b/.claude/docs/components/web.md
@@ -51,15 +51,18 @@ Do not rely on transitive dependencies for packages that are imported directly i
 | Target | What it does |
 |---|---|
 | `make web.build` | `npm ci` then `vite build` — produces bundle at `.artifacts/web/` |
-| `make web.lint` | ESLint (`eslint src`), TypeScript type-check (`tsc --noEmit`), Prettier format check (`prettier --check src`) |
+| `make web.lint` | ESLint (`eslint src`), TypeScript type-check (`tsc -b`), Prettier format check (`prettier --check src`) |
+| `make web.test` | Vitest unit tests (Vitest + React Testing Library) |
 
 ## Linting and formatting
 
 Three tools run under `make web.lint`:
 
 - **ESLint** — configured in `eslint.config.js` with `js.configs.recommended`, `tseslint.configs.recommended`, and React-specific rules
-- **TypeScript** — `tsc --noEmit` against `tsconfig.app.json` (strict mode)
+- **TypeScript** — `tsc -b` (not `tsc --noEmit`). The root `tsconfig.json` has `files: []` combined with `references`, so `tsc --noEmit` against it type-checks nothing and exits zero. Always use `tsc -b`.
 - **Prettier** — `prettier --check src`; format source with `npx prettier --write src`
+
+`make web.lint` must pass before committing any SPA changes, including follow-up commits made in response to review feedback. Prettier formatting drift is a CI failure; catch it locally before pushing.
 
 `web.lint` is a standalone target for local use and Code Scanning. It is **not** wired into `make test` and is **not** a step in the build CI workflow. See [ci-patterns.md](../steering/ci-patterns.md).
 
@@ -68,3 +71,34 @@ Three tools run under `make web.lint`:
 The web build job (`zz-build-web.yml`) always runs — it is not gated on change detection. Change detection (`web-build` output from `zz-detect-changes.yml`) is reserved for a future release/deploy job.
 
 In the build workflow, `make web.build` must run before `make web.lint` because `npm ci` (inside `web.build`) installs the local packages that linting tools depend on. See [ci-patterns.md](../steering/ci-patterns.md).
+
+## Dependencies
+
+When adding or updating npm packages, resolve the current latest version at implementation time (e.g. `npm show <pkg> version`) rather than using versions drawn from training data. Versions in `package.json` should reflect the latest available at the time of writing.
+
+## Docker
+
+All base images in `build/web/Dockerfile` must be pinned with `@sha256:` digests, consistent with the convention in the other Dockerfiles in the repo (e.g. gateway and wa-runner). Floating tags are not acceptable.
+
+`build/web/Dockerfile.dockerignore` uses a `**` deny-all pattern and re-allows only the SPA source directory. Any file in `build/web/` that a `COPY` instruction needs (e.g. `nginx.conf`) must be explicitly whitelisted by adding `!/build/web/<filename>` to that file, or the Docker build will fail silently with a "not found" error.
+
+## Testing
+
+Web unit tests use **Vitest** and **React Testing Library**. Run them with `make web.test`.
+
+Any component that is the single enforcement point for a security or routing invariant (e.g. an auth guard) must have automated tests covering all branches as part of its slice spec. Security-critical components are not candidates for deferred testing.
+
+When a slice introduces web test infrastructure for the first time (Vitest, a new CI job, a new make target), the spec must explicitly include that infrastructure in scope.
+
+## Layout
+
+Page components rendered inside `Layout` must size themselves with `flex: 1` on their outermost element to consume remaining viewport space. Do not use `minHeight: calc(100vh - Npx)` — this hardcodes an assumed pixel height for sibling components and breaks when those components change size or the footer needs to remain visible.
+
+## MUI v9 API notes
+
+- Scalar style shorthands (`fontWeight`, `display`, `color`, etc.) are not accepted as direct JSX props on MUI components. Place them in the `sx` prop: `<Typography sx={{ fontWeight: 700 }}>`.
+- `primaryTypographyProps` and `secondaryTypographyProps` on `<ListItemText>` are removed in MUI v9. Use `slotProps={{ primary: { ... }, secondary: { ... } }}` instead.
+
+## React purity
+
+Values that depend on impure functions (e.g. `Math.random()`, `Date.now()`) and should be computed once on mount must be placed in a lazy `useState` initialiser (`useState(() => ...)`) rather than `useMemo(() => ..., [])`. The `react-compiler/react-compiler` ESLint rule rejects impure function calls anywhere in the render path, including inside `useMemo`.

--- a/.claude/docs/steering/ci-patterns.md
+++ b/.claude/docs/steering/ci-patterns.md
@@ -35,6 +35,14 @@ Correct order in a web CI job:
 3. `make web.build` (runs `npm ci` + Vite build)
 4. `make web.lint` (runs ESLint, tsc, Prettier — all require node_modules)
 
+## Code-scanning jobs: `npm ci` only, not `make web.build`
+
+Jobs in `code-scanning.yml` that run ESLint or Prettier need `node_modules` to be present, but they do not need a compiled bundle. These jobs must call `npm ci` directly rather than `make web.build` (which also runs a full Vite compilation that is immediately discarded).
+
+- ESLint SARIF and Prettier jobs: inline `npm ci`, then the tool invocation
+- CodeQL with `build-mode: none`: needs neither Node setup nor `npm ci`
+- Only the dedicated `zz-build-web.yml` job (which uploads the bundle artefact) needs `make web.build`
+
 ## `fetch-depth: 0` only when git history is needed
 
 The default `actions/checkout` does a shallow clone, which is sufficient for build and lint jobs. Only add `fetch-depth: 0` to a job that actually inspects git history — change detection (`zz-detect-changes.yml`), version tagging, or changelog generation. Build and test jobs do not need the full history.

--- a/.claude/docs/steering/coding-guidelines.md
+++ b/.claude/docs/steering/coding-guidelines.md
@@ -45,3 +45,4 @@ Enforced by `.editorconfig`:
 - 120-character line length
 - `using` directives sorted, `System.*` first, no blank line between groups
 - Allman braces (new line before `{`, `catch`, `else`, `finally`)
+- Always use braces on `if`, `else`, `for`, `foreach`, and `while` blocks, even for single-statement bodies. InspectCode enforces this rule and `dotnet build --warnaserror` will surface violations before pushing.

--- a/.claude/docs/steering/testing-strategy.md
+++ b/.claude/docs/steering/testing-strategy.md
@@ -13,8 +13,9 @@ Fast, in-process tests with no external dependencies. The test projects that exi
 - File-format parsing and serialisation in the Armageddon Files library
 - Game-discovery and runner logic in the Armageddon Game library (with `NSubstitute` for OS-specific seams like the registry)
 - The Armageddon Gifs assembly logic, exercised against fixtures
+- React components in the Web UI (Vitest + React Testing Library; run via `make web.test`)
 
-Unit tests use **NUnit** with **Shouldly** for assertions. They are the default `dotnet test` run and gate every PR via `make cli.test.unit` / equivalent.
+Unit tests for .NET use **NUnit** with **Shouldly** for assertions. They are the default `dotnet test` run and gate every PR via `make cli.test.unit` / equivalent. Web unit tests run independently via `make web.test`.
 
 The CLI, hub gateway, queues, and storage projects do not currently have dedicated unit-test projects — behaviour at those layers is exercised indirectly via the integration tier and the libraries above. When adding meaningful logic at those layers, prefer adding a new `<Project>.Tests` rather than retrofitting the integration test.
 

--- a/.claude/specs/web-ui/learnings.md
+++ b/.claude/specs/web-ui/learnings.md
@@ -1,0 +1,232 @@
+# Retrospective — Worms Hub Web UI
+
+## From slice files
+
+### L1 — CI build jobs conditionally gated on change detection
+
+- **Pattern:** The implementation agent wired `build-web` with an `if: ${{ needs.changes.outputs.web-build == 'true' }}` condition, causing the build to be skipped entirely when non-web files changed. The correct pattern in this repo is that build jobs always run; change detection gates only release/deploy jobs.
+- **Evidence:** `.claude/specs/web-ui/slices/01-spa-scaffolding/learnings.md`, `01-spa-scaffolding/review.md` (B1)
+- **Where to fix it:** `.claude/docs/steering/ci-patterns.md` already documents this correctly; it should also be reinforced in `.claude/docs/components/web.md` with an explicit note that the `web-build` change-detection output is reserved for a future deploy job and must not be placed on the `build-web` job itself.
+
+### L2 — Lint step ordered before `npm ci` in CI, causing failure on fresh runner
+
+- **Pattern:** The CI workflow placed the `make web.lint` step before `make web.build` in `zz-build-web.yml`. Because `make web.build` runs `npm ci` (installing `node_modules`), the linting tools — ESLint, `tsc`, Prettier — do not exist on a fresh GitHub Actions runner until after the build step. The lint step fails immediately on a clean runner.
+- **Evidence:** `.claude/specs/web-ui/slices/01-spa-scaffolding/review.md` (B1)
+- **Where to fix it:** `.claude/docs/steering/ci-patterns.md` already documents the required ordering; `.claude/docs/components/web.md` should also explicitly list the mandatory step order for any CI job touching web linting (checkout → setup Node → web.build → web.lint).
+
+### L3 — Repository visibility set to `internal sealed` when cross-assembly injection requires `public`
+
+- **Pattern:** Plans instructed making new `XxxRepository` classes `internal sealed` by analogy with `GamesRepository` and `ReplaysRepository`. Those existing repos are consumed via the `public IRepository<T>` interface, so the concrete type can be `internal`. New repositories (`LeaguesRepository` in slice 10, `ReplaysRepository` made public in slice 11) are injected directly by their concrete type from the Gateway assembly, which requires `public` visibility. This was caught mid-implementation in both slices.
+- **Evidence:** `.claude/specs/web-ui/slices/10-league-list/learnings.md`, `.claude/specs/web-ui/slices/11-per-league-page/learnings.md`
+- **Where to fix it:** `.claude/docs/components/hub-storage.md` — the "Adding a new domain object" guidance should note that if a repository will be injected directly by concrete type from another assembly (e.g., the Gateway), it must be declared `public sealed` rather than `internal sealed`; use `internal sealed` only when the repository is consumed exclusively via `IRepository<T>`.
+
+### L4 — DB record type named against convention (`LeagueRecord` instead of `LeagueDb`)
+
+- **Pattern:** The implementation named the Dapper mapping type `LeagueRecord` instead of `LeagueDb`, deviating from the `XxxDb` naming convention used by `GamesDb` and `ReplayDb` in the same file and documented in the hub-storage component doc. The plan failed to call out the specific convention name, leading to the deviation being caught only in review.
+- **Evidence:** `.claude/specs/web-ui/slices/10-league-list/review.md` (S2)
+- **Where to fix it:** `.claude/docs/components/hub-storage.md` — the "Adding a new domain object" step 2 should state the Dapper mapping type must be named `XxxDb` (matching the pattern `GamesDb`, `ReplayDb`) and provide an explicit example to prevent a plausible but wrong name like `XxxRecord`.
+
+### L5 — `AddWormsArmageddonFilesServices()` placed only in the gateway branch, breaking distributed worker-only mode
+
+- **Pattern:** The plan described moving `AddWormsArmageddonFilesServices()` to be unconditional in `Program.cs` (outside both `if (runGateway)` and `if (runWorker)` blocks) because `Processor` in the worker depends on `IReplayTextReader`. The implementation placed the call only inside `if (runGateway)`, which means a distributed worker-only deployment (`HUB_DISTRIBUTED=true`, `HUB_GATEWAY=false`, `HUB_WORKER=true`) cannot start — DI resolution of `Processor` fails at runtime.
+- **Evidence:** `.claude/specs/web-ui/slices/12-game-detail-page/review.md` (B1), `12-game-detail-page/learnings.md`
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — the "Service registration" section should document that services shared by both the gateway and the worker (such as `IReplayTextReader` / `AddWormsArmageddonFilesServices`) must be registered unconditionally in `Program.cs`, outside any `if (runGateway)` / `if (runWorker)` block, and should name the shared services explicitly.
+
+### L6 — MUI v9 API differences not reflected in plans (direct prop vs `sx`, `primaryTypographyProps` removed)
+
+- **Pattern:** Plan code examples passed shorthand style props (`fontWeight`, `display`) as direct JSX props on `<Typography>`, and used `primaryTypographyProps` on `<ListItemText>`. Both were valid in earlier MUI versions but are not accepted by MUI v9's TypeScript types. The implementer had to convert these to `sx={{ ... }}` and `slotProps` respectively mid-flight. The plan was authored against MUI v9 but the examples were drawn from older patterns.
+- **Evidence:** `.claude/specs/web-ui/slices/12-game-detail-page/learnings.md`; also noted as a pre-existing doc staleness in `.claude/specs/web-ui/slices/06-dark-mode/review.md` (N1)
+- **Where to fix it:** `.claude/docs/components/web.md` — add a "MUI v9 API notes" section that documents: (1) scalar style shorthands (`fontWeight`, `display`, etc.) must go in the `sx` prop, not as direct component props; (2) `primaryTypographyProps` / `secondaryTypographyProps` on `<ListItemText>` are removed — use `slotProps={{ primary: { ... } }}` instead.
+
+### L7 — `make web.build` called in CI jobs that only need `npm ci`
+
+- **Pattern:** Plans initially specified running `make web.build` (which runs `npm ci` then the full Vite bundle compilation) in every lint/scan job, including CodeQL and the ESLint SARIF job, even though those jobs do not need a built bundle. This was corrected mid-flight in slice 02: CodeQL needs neither Node nor `node_modules`; ESLint and Prettier need `npm ci` but not Vite build. Calling `make web.build` in a scan job wastes CI time by compiling a bundle that is discarded immediately.
+- **Evidence:** `.claude/specs/web-ui/slices/02-web-linting-in-ci/learnings.md`
+- **Where to fix it:** `.claude/docs/steering/ci-patterns.md` — add guidance that code-scanning jobs must call only `npm ci` (inline) rather than `make web.build` (which also compiles the bundle), except for jobs that actually require the built artefact; note that CodeQL with `build-mode: none` needs neither step.
+
+### L8 — Dockerfile base images added with floating tags; repo convention requires digest-pinned images
+
+- **Pattern:** The Dockerfile created in slice 03 used floating tags (`node:22-alpine`, `nginx:alpine`) while every existing Dockerfile in the repo pins base images with `@sha256:` digests. The deviation was caught only in review and flagged as a suggestion rather than a blocker, but it is a recurring implicit convention that the implementation agent missed.
+- **Evidence:** `.claude/specs/web-ui/slices/03-local-dev-integration/review.md` (S1)
+- **Where to fix it:** `.claude/docs/components/web.md` — add a note under a "Docker" section stating that all base images in `build/web/Dockerfile` must be pinned with `@sha256:` digests, consistent with the convention in `build/docker/gateway/Dockerfile` and `build/docker/wa-runner/Dockerfile`.
+
+### L9 — `[PublicAPI]` annotation omitted from new repository classes
+
+- **Pattern:** `GamesRepository` and `ReplaysRepository` carry `[PublicAPI]` on their DB record types to document that Dapper and DI resolve them reflectively. When a new repository (`LeaguesRepository`) was added, the `[PublicAPI]` annotation was omitted and had to be added after review feedback.
+- **Evidence:** `.claude/specs/web-ui/slices/10-league-list/review.md` (S1)
+- **Where to fix it:** `.claude/docs/components/hub-storage.md` — the "Adding a new domain object" step 2 should include `[PublicAPI]` in the checklist for the `XxxDb` record type, noting that it marks the type as resolved by Dapper/DI and suppresses false-positive unused-code warnings.
+
+### L10 — Unplanned prerequisite migration (`V0.3.1`) added without a learnings entry
+
+- **Pattern:** Slice 11 required a new versioned migration (`V0.3.1__SeedRedgateLeague.sql`) as a logical prerequisite for the FK backfill in `V0.4.1`. The migration was added correctly but was not listed in the plan and not mentioned in `learnings.md`, leaving a gap in the audit trail that was flagged in review.
+- **Evidence:** `.claude/specs/web-ui/slices/11-per-league-page/review.md` (S1), `11-per-league-page/learnings.md`
+- **Where to fix it:** The `implement-slice` skill's process guidance (or `.claude/docs/steering/` if a general implementation-process doc exists) should require that any file added outside the plan is recorded in `learnings.md` — the existing guidance covers this for new files but the agent overlooked it here specifically for migration files.
+
+### L11 — `UseRequestLogging()` placed after endpoint mapping, silently missing static-file and fallback requests
+
+- **Pattern:** In slice 13, `UseRequestLogging()` was added after the `Map*` endpoint registration calls in `Program.cs`. ASP.NET Core middleware placed after endpoint registrations runs after endpoint dispatch, so requests short-circuited by `UseStaticFiles()` or `MapFallbackToFile()` are never seen by the logging middleware.
+- **Evidence:** `.claude/specs/web-ui/slices/13-production-deployment/review.md` (S1)
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — add a note to the "Service registration" or "Configuration" section documenting the required middleware ordering: `UseRequestLogging()` (and any other cross-cutting middleware) must be registered before `UseStaticFiles()`, `MapControllers()`, and `MapFallbackToFile()` to ensure all request paths are covered.
+
+## From PR #1307
+
+### P1307.1 — Agent's recommended fix for shared-service DI placement contradicted the repo's self-contained-registration pattern
+
+- **Pattern:** The review.md for slice 12 identified the correct blocker (B1: `AddWormsArmageddonFilesServices()` placed inside the gateway-only block) and recommended moving it "outside the `if (runGateway)` block" — i.e., unconditionally in `Program.cs`. The human reviewer rejected that approach: the correct fix is to call it inside both `AddGatewayServices()` and `AddWorkerServices()`, keeping each mode's registration self-contained. However, that approach required a prerequisite the agent's review did not identify: `AddWormsArmageddonFilesServices()` used `AddScoped`/`Add` for its registrations, making repeated calls in monolith mode unsafe (double-registered `IReplayLineParser` parsers, every parser running twice per line). A separate refactor commit was needed first to switch to `TryAddScoped`/`TryAddEnumerable` so the method became idempotent. The agent's fix recommendation was technically coherent but missed both the repo's preferred pattern and the prerequisite idempotency work.
+- **Evidence:** PR #1307 inline review comment by TheEadie on `Program.cs:55`; follow-up commits `ef8f2345` (make `AddWormsArmageddonFilesServices` idempotent) and `444e6f52` (move call into component methods)
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — the "Service registration" guidance introduced for L5 should be updated: replace the instruction to call shared services unconditionally in `Program.cs` with the correct pattern: (1) call the shared service registration method inside each component's `Add*Services()` method; (2) any such method that will be called from multiple component methods must use `TryAddScoped`/`TryAddSingleton`/`TryAddEnumerable` throughout so repeated calls in monolith mode are safe.
+
+### P1307.2 — Plan did not flag that a richer DTO on the single-item endpoint makes the list endpoint inconsistent
+
+- **Pattern:** Slice 12 introduced `ReplayDetailDto` (with parsed turns data) for `GET /leagues/{id}/replays/{replayId}` while leaving `GET /leagues/{id}/replays` returning the lighter `ReplayDto`. The spec and plan did not note this asymmetry as a scope decision, so the review.md passed the PR without flagging it. The reviewer caught it post-review: the league replay list should use the same richer shape, filling the previously-empty Top Weapons, Length, and Most Damage columns. This triggered four substantial unplanned commits that touched both the gateway controller and the SPA.
+- **Evidence:** PR #1307 issue comment by TheEadie ("The league replay list should be updated with the details we now have available following this change"); follow-up commits `a242dc94`, `02486247`, `2d3e39b3`, `48e42cf8`
+- **Where to fix it:** The `spec` and `plan-spec` skill guidance should add a prompt: when a new endpoint introduces a richer DTO for a single-item response, explicitly decide whether the corresponding list endpoint should return the same shape — and record that decision (in scope or out of scope) in the spec. Leaving the decision implicit causes the asymmetry to be caught only in human review and treated as unscoped follow-up work.
+
+### P1307.3 — Prettier not run after post-review SPA changes, requiring a separate clean-up commit
+
+- **Pattern:** After four post-review SPA feature commits, a standalone `chore(web): fix Prettier formatting` commit was needed before the PR could merge. The agent's review-response workflow for SPA changes did not include running `make web.lint` as a final step before committing follow-up work.
+- **Evidence:** PR #1307 commit `4082182b` "chore(web): fix Prettier formatting", pushed after the four post-review feature commits
+- **Where to fix it:** `.claude/docs/components/web.md` — reinforce in the web development workflow section (alongside the existing Prettier guidance) that `make web.lint` must be run and pass before committing any SPA changes, including follow-up commits made in response to review feedback. Prettier diffs are a CI failure and must be caught locally before push.
+
+## From PR #1305
+
+### P1305.1 — Independent gateway/DB deployment risk not assessed during slice spec
+
+- **Pattern:** Slices 10 and 11 added new endpoints backed by a DB schema migration (V0.3), but neither the spec nor the plan considered what would happen if the gateway was deployed before the migration ran. In this deployment model the gateway and the database are updated independently, so deploying the new code against the old schema crashed the gateway rather than degrading gracefully. The gap was only discovered when the feature hit production, requiring a separate unplanned PR to add schema-version gating.
+- **Evidence:** PR #1305 existence — "feat: degrade gracefully when DB schema is behind gateway version", merged 2026-05-13, with no corresponding slice in the web-ui epic plan
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — add a "Deployment safety" section stating that any new endpoint backed by a DB migration must either (a) gate on schema version before querying the new table, or (b) be hidden behind a feature flag until the migration has been confirmed applied; the spec template (or `.claude/docs/steering/`) should include a "deployment risk" checklist item asking whether independent gateway/DB rollout can cause a crash.
+
+### P1305.2 — Missing braces on `if` statements generated by implementation agent, caught by InspectCode in CI
+
+- **Pattern:** The initial implementation commits omitted braces on single-statement `if` blocks across `LeaguesController.cs` and `DatabaseSchemaVersion.cs`. Three InspectCode violations were flagged by the GitHub Advanced Security bot in review, requiring a follow-up style-fix commit (`7b97822`). The project enforces "always use braces" via InspectCode, and the rule fires as a build warning catchable by `dotnet build --warnaserror` before pushing.
+- **Evidence:** PR #1305 review comments by `github-advanced-security[bot]` (comment IDs 3232646781, 3232646807, 3232646815); follow-up commit `7b97822`
+- **Where to fix it:** `.claude/docs/steering/coding-guidelines.md` — add an explicit rule that `if`, `else`, `for`, `foreach`, and `while` blocks must always use braces, even for single-statement bodies, and note that `dotnet build --warnaserror` will surface InspectCode violations before pushing.
+
+### P1305.3 — Feature-flag abstraction omitted in initial implementation, requiring immediate refactor
+
+- **Pattern:** The first version of `LeaguesController` injected `DatabaseSchemaVersion` directly as a constructor parameter. A follow-up commit (`00612c90`) on the same PR immediately extracted `IFeatureFlags` / `GatewayFeatureFlags` to centralise feature decisions and allow multiple sources (env-var overrides, schema version, external services) to be aggregated without touching controllers. The plan produced working code but missed the abstraction layer, making the refactor a necessary second commit rather than being correct first time.
+- **Evidence:** PR #1305 commit `00612c90` — "refactor: extract IFeatureFlags so feature gating can aggregate multiple sources"
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — document the `IFeatureFlags` / `GatewayFeatureFlags` pattern: controllers must depend on `IFeatureFlags`, not on `DatabaseSchemaVersion` or any other concrete source directly; any new schema-version or feature gate check must be added to `GatewayFeatureFlags` rather than inlined into a controller.
+
+## From PR #1289
+
+### P1289.1 — Plan asserted existing code state without verifying it
+
+- **Pattern:** The plan for slice 04 stated "The current code in `Program.cs` does not call `UseRouting()` explicitly" and included an instruction to add an explicit `UseRouting()` call. In fact `UseRouting()` was already present. The plan-writing agent read `Program.cs` as required by the `plan-spec` process but still produced a false description of what it contained. The implementer had to silently skip the planned step. In a less forgiving context — for example, if a duplicate middleware registration caused a runtime error — this could have introduced a regression.
+- **Evidence:** PR #1289 `learnings.md` ("UseRouting() was already present in Program.cs") and `plan.md` section 5 ("The current code in `Program.cs` does not call `UseRouting()` explicitly")
+- **Where to fix it:** `.claude/commands/plan-spec.md` Step 2 — add a reminder that when the plan makes a factual claim about the current state of a file (e.g. "X is not present", "the file currently has only Y sections"), that claim must be verified by reading the actual file content, not asserted from assumption or general knowledge. Plans that mis-describe absent things as present (or vice versa) force silent deviations during implementation and can mask real bugs.
+
+## From PR #1281
+
+### P1281.1 — Review agent read plan text rather than actual diff, producing false findings
+
+- **Pattern:** Across multiple slices, the review agent checked what the plan said should be done rather than reading the actual files on disk. This manifested in four distinct failure modes: (1) verifying acceptance criteria as MET based on plan wording when the implementation had deliberately deviated (PR #1281 — `make web.build` vs inline `npm ci`); (2) declaring "no unexplained deviations" while missing files present in the diff but absent from the plan (PR #1298 — `api.ts`, `.env`); (3) raising suggestions flagging things as missing or wrong that were already correct in the committed code (PR #1301 — `[PublicAPI]` and `XxxDb` naming already present; PR #1291 — `width: '100%'` already present, `gap: 3` never added); (4) reporting a bug the implementation had already self-corrected, citing a line number from the plan's code example rather than the actual file (PR #1309 — `UseRequestLogging()` placement already fixed to line 63 before review was written). In all cases the review agent was referencing its mental model or the plan's text rather than the committed files.
+- **Evidence:** PR #1281 review.md (AC row 6 false pass vs actual diff in `code-scanning.yml`); PR #1298 review.md ("No unexplained deviations" and S2 for work already done in `api.ts`); PR #1301 review.md (S1 and S2 false alarms vs `git show d81aa07d`); PR #1291 commit `e6ec08b9` vs review.md S1 and N1; PR #1309 review.md S1 citing `Program.cs:81` vs implementation commit `d37fa00f` which had moved `UseRequestLogging()` to line 63
+- **Where to fix it:** The `review` skill's process guidance — every claim about what was or was not implemented must be verified by reading the current file at the specific line before raising it. Acceptance criteria must be verified against the diff, not plan wording. The scope check must enumerate files actually in the diff and compare against the plan's table. Suggestions stating "X is missing" must quote the actual line from the file. If the implementation diverges from the plan beneficially, the review must record the divergence — not report the correct implementation as a bug.
+
+## From PR #1300
+
+### P1300.1 — Security-critical UI components planned and implemented without automated tests
+
+- **Pattern:** The spec and plan for `RequireAuth` — described in the spec itself as "the single place where this redirect logic lives" for all protected routes — listed only `make web.build` and `make web.lint` in its acceptance criteria. No test requirement was stated. The plan explicitly declared "No new dependencies are needed." The review's S1 caught the gap and triggered three unplanned commits: installing Vitest + React Testing Library (package.json, vite.config.ts, tsconfig.app.json, test-setup.ts), writing three branch-coverage tests, and adding a `make web.test` target plus a parallel CI test job. A component that is the sole auth enforcement point across the entire SPA warrants automated test coverage as a first-class requirement, not an optional post-review addition.
+- **Evidence:** PR #1300 review.md S1 decision ("Accept — Vitest + React Testing Library installed; three tests covering loading/unauthenticated/authenticated branches written"); follow-up commits `3e576c7` (install Vitest/RTL), `9ab3cd0` (tests), `769795e` (make target + CI jobs)
+- **Where to fix it:** `.claude/docs/components/web.md` — add a "Testing" section documenting: (1) Vitest + React Testing Library is the web test framework; (2) any component that is the single enforcement point for a security or routing invariant (e.g. an auth guard) must have automated tests covering all branches as part of its slice spec, not deferred; (3) the `make web.test` target and CI job structure (explicit `npm ci` then `make web.test`, separate from the package job that runs `make web.build`). Also update `.claude/docs/steering/testing-strategy.md` to include the web tier alongside the .NET tiers.
+
+### P1300.2 — Spec acceptance criteria did not include `make web.test`; test infrastructure absent from plan scope
+
+- **Pattern:** When a slice introduces test infrastructure for the first time (Vitest, a new CI job, a new make target), the spec's acceptance criteria and the plan's scope must explicitly cover that infrastructure — otherwise the plan's "files to create/modify" table, verification steps, and dependency list are all incomplete. The plan stated the only changes were `RequireAuth.tsx` and `App.tsx`; the actual PR added six additional files and a new CI job. The mismatch meant the review had to expand scope rather than confirm it.
+- **Evidence:** PR #1300 plan.md ("Files to Create / Modify" lists only two files; "No new dependencies are needed"); follow-up commits `3e576c7`, `769795e` adding five files and CI workflow changes that were never in the plan
+- **Where to fix it:** The `spec` and `plan-spec` skills' process guidance should note that if a slice is the first to exercise a capability (test framework, CI job type, make target category), the spec must include setup of that capability in scope and the plan must list every file that will be created or modified, including configuration files (`vite.config.ts`, `tsconfig.app.json`, CI workflow files) and lock files.
+
+## From PR #1309
+
+### P1309.2 — Plan-spec agent copied the existing wrong middleware order into the plan's code example
+
+- **Pattern:** The plan for slice 13 included a complete `Program.cs` code block with `UseRequestLogging()` placed last, after `MapFallbackToFile()` — reproducing the already-wrong ordering that existed in the pre-existing file. The plan-spec agent read `Program.cs` (as required) but transcribed the existing wrong order into the plan example rather than applying the correct ASP.NET Core pattern (logging middleware must precede endpoint dispatch). The implementer caught the issue independently and corrected it during the same commit, so no bug shipped — but a plan that prescribes a known-wrong pattern increases the risk that a future implementer follows it verbatim.
+- **Evidence:** PR #1309 `plan.md` section 3 Program.cs code block (last two lines: `_ = app.MapFallbackToFile("index.html"); _ = app.UseRequestLogging();`); implementation commit `d37fa00f` which moves `UseRequestLogging()` to line 63, the first statement inside `if (runGateway)`.
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — apply the fix already flagged by L11: add an explicit note that `UseRequestLogging()` must be the first middleware call inside `if (runGateway)`, before `UseStaticFiles()`, `MapControllers()`, and `MapFallbackToFile()`. Once that guidance is in place, the `plan-spec` skill should read `hub-gateway.md` before writing any `Program.cs` code examples so the plan's code reflects the documented convention rather than whatever the current file happens to contain.
+
+## From PR #1285
+
+### P1285.1 — Implementation agents pinned outdated npm dependency versions
+
+- **Pattern:** The implementation agents that built the web UI scaffolding and subsequent slices selected npm package versions from their training data rather than resolving the current latest at implementation time. This caused a full catch-up PR at the end of the epic bumping every major dependency (React 18→19, MUI 6→9, Vite 5→8, TypeScript 5→6, ESLint 9→10). The problem compounds because later slices (e.g. L6's MUI v9 API notes) had to work around API differences between the version used in plan examples and the actually-installed version.
+- **Evidence:** PR #1285 — existence of the PR itself; the commit message explicitly lists five major-version upgrades that had accumulated across the epic implementation. No human reviewer flagged this during any slice review, confirming it was silent drift rather than a conscious pinning decision.
+- **Where to fix it:** `.claude/docs/components/web.md` — add a note in a dependency management section stating that when adding or updating npm packages, agents must resolve the current latest version at implementation time (e.g. via `npm show <pkg> version`) rather than using versions from training data; versions in `package.json` should always reflect the latest available at the time of writing, not stale values from model knowledge.
+
+## From PR #1296
+
+### P1296.1 — `tsc --noEmit` against the root tsconfig is a silent no-op; `tsc -b` is required
+
+- **Pattern:** `make web.lint` invoked `tsc --noEmit` against the root `tsconfig.json`, which has `files: []` combined with `references`. This configuration makes `tsc --noEmit` check nothing — it exits zero while type-checking zero files. A bad deep-path import in `ColourSchemePicker.tsx` (`@mui/system/cssVars/useCurrentColorScheme`, absent from @mui/system's exports map) went undetected by local linting and only surfaced when Docker ran `tsc -b` inside the container. The fix — changing `make web.lint` to call `tsc -b` — was bundled into PR #1296 rather than caught before implementation began. The review.md wrote that `make web.lint` "passes cleanly" without noting that the typecheck had been inoperative before the fix landed in this same PR.
+- **Evidence:** PR #1296, follow-up commit d8956dc3 ("fix: unbreak docker web build and make lint actually typecheck")
+- **Where to fix it:** `.claude/docs/components/web.md` — document that `make web.lint` uses `tsc -b` (not `tsc --noEmit`) and explain why: the root `tsconfig.json` has `files: []` + `references`, so `tsc --noEmit` against it is always a no-op. Any plan step or CI guidance that writes `tsc --noEmit` for the web project is incorrect; the correct invocation is `tsc -b`.
+
+### P1296.2 — Hardcoded `calc(100vh - Npx)` height for page content breaks footer visibility
+
+- **Pattern:** The plan specified `minHeight: { md: 'calc(100vh - 52px)' }` on the `LandingPage` grid, intending to fill the viewport below the sticky header. The `Layout` component already establishes a `display: flex; flexDirection: column; height: 100vh` shell, so the correct way for a page's content area to consume the remaining space is `flex: 1` on its outermost element — not viewport arithmetic. Using `minHeight: calc(100vh - 52px)` made the page body fill the full remaining viewport on its own, pushing the footer below the fold. Two follow-up commits were required to converge on the correct fix (`flex: 1` inside a flex-column `main`).
+- **Evidence:** PR #1296, follow-up commits 9bde4f86 ("fix: let footer fit on initial viewport on the landing page") and 1a25c06d ("fix: vertically center landing-page content in available space")
+- **Where to fix it:** `.claude/docs/components/web.md` — add a layout note stating that page components rendered inside `Layout` must size themselves with `flex: 1` on their outermost element; explicitly prohibit `minHeight: calc(100vh - Npx)` patterns that hardcode component pixel heights, and provide the correct pattern as a short example.
+
+## From PR #1299
+
+### P1299.1 — `Math.random()` inside `useMemo` violates React purity rules and triggers ESLint error
+
+- **Pattern:** The implementation used `Math.random()` inside `useMemo(() => ..., [])` to pick a random weapon name once on mount. The repo's ESLint config includes the `react-compiler/react-compiler` rule, which treats `Math.random()` as an impure function and rejects any call to it during render — including inside `useMemo`. The correct pattern for one-time random initialisation is a lazy `useState` initialiser (`useState(() => pick())`), which runs outside the render path. The agent was unaware of this constraint; the error was caught only by the automated code-scanning bot, not during implementation.
+- **Evidence:** PR #1299 code-scanning comments by github-advanced-security[bot] on commit 569875b (code-scanning alerts #368 and #369); issue resolved in follow-up commit 92c89f6
+- **Where to fix it:** `.claude/docs/components/web.md` — add a "React purity" note: values that depend on impure functions (e.g. `Math.random()`, `Date.now()`) and should be computed once on mount must be placed in a lazy `useState` initialiser (`useState(() => ...)`) rather than `useMemo(() => ..., [])`, because the `react-compiler/react-compiler` ESLint rule rejects impure calls anywhere in the render path including inside `useMemo`.
+
+### P1299.2 — Landing page spec finalised before the design mockup was approved, requiring a wholesale follow-up PR
+
+- **Pattern:** PR #1299 was a follow-up that applied the agreed final design to the landing page after the mockup was approved — adding typewriter animation, new hero copy, a subtitle, footer removal, and a layout change. None of these were in the original landing-page slice. The original spec was written and implemented before the design was stable, so when the mockup was finalised the entire page had to be redone in a separate PR. The process did not guard against speccing UI work ahead of a settled design.
+- **Evidence:** PR #1299 existence and description ("Landing page improvements" applying design changes post-mockup finalisation); the PR body describes structural and copy changes not present in the original implementation
+- **Where to fix it:** The `spec` skill guidance should note that UI slice specs must not be finalised until the visual design mockup has been approved; if the mockup is still in flux at spec time, the spec should flag which visual details are pending and explicitly defer those details to a follow-up slice rather than spec'ing a placeholder that will need wholesale replacement.
+
+
+## From PR #1276
+
+### P1276.1 — Review agent confirmed a convention-violating CI conditional as correct
+
+- **Pattern:** The review.md for slice 01 marked "Branch not touching web paths skips CI web job — MET", treating the conditional `if: ${{ needs.changes.outputs.web-build == 'true' }}` on `build-web` as correct because it matched the spec's acceptance criterion wording. It is actually the wrong pattern: in this repo, build jobs always run and change detection gates only release/deploy steps. The review passed the check based on literal criterion wording without cross-referencing repo conventions, producing a false-positive that required a follow-up fix commit after the review was written.
+- **Evidence:** PR #1276, `.claude/specs/web-ui/slices/01-spa-scaffolding/review.md` (acceptance criteria row "Branch not touching web paths skips CI web job — MET"); follow-up commit `b074b216` ("Fix build-web change detection: always build, gate only release")
+- **Where to fix it:** The `review` skill's process guidance should require that CI-related acceptance criteria are validated against the repo's CI conventions (documented in `.claude/docs/steering/ci-patterns.md`) and not only against the spec wording. A criterion like "job skips on unrelated changes" must be flagged if it conflicts with the always-build pattern.
+
+### P1276.2 — Prettier configured but not wired into enforcement; review didn't catch the gap
+
+- **Pattern:** `.prettierrc` was committed and `prettier` was listed in `devDependencies`, but `web.lint` did not invoke `prettier --check`. Prettier was installed but silent — formatting drift would go undetected in CI. The review confirmed all acceptance criteria as met and made no mention of this gap, leaving the fix to a separate post-review commit. A tool being present in the project without a corresponding enforcement invocation is a latent process failure.
+- **Evidence:** PR #1276 initial commits (`b4a4b8e8`, `dc74b455`); follow-up commit `96fc5a08` ("Add Prettier enforcement to web.lint and format source files")
+- **Where to fix it:** `.claude/docs/components/web.md` — the `web.lint` description should explicitly list every tool that must be invoked (`eslint`, `tsc --noEmit`, `prettier --check`) so both the implementation and review agents have a concrete checklist. The `review` skill's guidance should include a check that every configured formatting/linting tool has a corresponding CI invocation.
+
+### P1276.3 — Review confirmed `make test` wired to linting, which violates repo convention
+
+- **Pattern:** The initial implementation added `test:: web.test` to `build/web/makefile`, making `make test` run ESLint and `tsc --noEmit`. This matched the spec's acceptance criterion wording exactly, so the review marked it MET. However, the repo's actual convention is that `make test` runs tests only; linting belongs in `code-scanning.yml` as SARIF uploads, not in the build/test pipeline. The review confirmed a criterion without checking whether the criterion itself was sound, requiring a follow-up fix to remove the `test::` hook and the Lint step from `zz-build-web.yml`.
+- **Evidence:** PR #1276, `.claude/specs/web-ui/slices/01-spa-scaffolding/review.md` (acceptance criteria row "`make test` runs ESLint and tsc --noEmit — MET"); follow-up commit `9e2f7836` ("Move web linting out of make test; linting belongs in Code Scanning")
+- **Where to fix it:** `.claude/docs/steering/testing-strategy.md` already has guidance on this separation; `.claude/docs/components/web.md` should explicitly state that `web.lint` is a standalone target for local use and code-scanning integration only — it must not be wired to `test::`. The `review` skill should cross-check `make test` additions against the testing-strategy doc rather than trusting spec wording alone.
+
+## From PR #1304
+
+### P1304.1 — Parallel DTO created instead of extending existing type; computed `bool` field diverged from domain model
+
+- **Pattern:** The spec defined `processed: bool` as a computed field in the API response, and the plan followed by creating a dedicated `ReplayInLeagueDto` type. The existing `ReplayDto` already mapped the same domain record and already carried `Status: string`. The new type was a parallel duplicate that the plan should have collapsed into the existing DTO. The `bool Processed` field also diverged from the domain model's `string Status` — the TypeScript interface on the frontend reflected this divergence, causing a runtime mismatch (`replay.processed` did not exist on the actual JSON response) that required a separate fix commit. When an existing DTO covers the same domain object, the plan must extend it rather than create a parallel type, and derived boolean fields must not be introduced when the underlying discriminant is already present in the domain model as a string.
+- **Evidence:** PR #1304 follow-up commits `2e3e09b` (refactor: consolidate ReplayInLeagueDto into ReplayDto) and `9eaf6cf` (fix: check status string instead of missing processed boolean in LeagueDetailPage)
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — add guidance that when adding a new endpoint returning the same domain type as an existing endpoint, the plan must reuse and extend the existing DTO rather than creating a parallel type; also note that derived bool fields (e.g. `Processed`) must not be introduced when the domain model already carries an equivalent discriminant (e.g. `Status`), because the frontend TypeScript interface must match the actual serialised shape.
+
+### P1304.2 — No schema-compatibility consideration in plan when adding DB columns the gateway reads
+
+- **Pattern:** The plan added V0.4 columns (`league_id`, `date`, `winner`, `teams`) and updated the repository and endpoint without any consideration of what happens when the gateway runs against a database that has not yet been migrated to schema 0.4 (e.g. during a rolling deployment or when pointing at a shared staging DB). The omission required significant post-review rework: adding a `DatabaseSchemaVersion` service, gating the new endpoint and repository queries behind a version check, splitting `ReplaysRepository` into a base class and a V04 subclass, then further refactoring to remove the inheritance in favour of two independent sealed classes resolved by a DI factory. Any plan that adds columns to an existing table and extends the repository to read those columns must include a compatibility section specifying whether the gateway degrades gracefully on an older schema and, if so, how (feature-flag via schema version, split repository, null-returning fallback, etc.).
+- **Evidence:** PR #1304 follow-up commits `a697630` (feat: guard replay league fields behind schema version check), `4aa5329` (refactor: split ReplaysRepository into base and V04 subclass), `60aeafc` (refactor: remove inheritance between replay repositories), `4f9571e` (refactor: make replay repository implementations internal; expose via interfaces), `1931449` (refactor: replace split interfaces with single IReplaysRepository)
+- **Where to fix it:** `.claude/docs/components/hub-storage.md` — add a "Schema compatibility" note to the "Adding a new domain object" or migration guidance: when a slice adds columns to an existing table and the gateway reads those columns, the plan must include an explicit compatibility decision (degrade gracefully vs. require DB upgrade before gateway deploy) and, if degrading gracefully, describe the `DatabaseSchemaVersion` DI-factory pattern that selects between a base repository and a versioned subtype.
+
+### P1304.3 — Write endpoints not audited when a new column with a default is added to an existing table
+
+- **Pattern:** When `league_id` was added to the `replays` table and all existing rows were backfilled to `'redgate'`, the plan updated `ReplaysRepository.Create()` and `ReplaysRepository.Update()` to write the new column but did not audit every write path in the Gateway. `ReplaysController.Post` (the replay upload endpoint) also constructs a `new Replay(...)` and calls `repository.Create()` — it was left with `league_id = null`, meaning newly uploaded replays silently had no league association and would not appear on any league page. Whenever a new non-nullable-in-practice column is added to an existing table with a backfill migration, the plan must enumerate all write paths (controllers, workers, tests) that construct or persist the affected record and verify each one sets the new field.
+- **Evidence:** PR #1304 follow-up commit `1cd09c5` (fix: default new replay uploads to redgate league)
+- **Where to fix it:** `.claude/docs/components/hub-gateway.md` — add a checklist item to guidance on extending an existing domain record: when a new column is added to an existing table, search for all controller actions and worker methods that call `repository.Create()` or `repository.Update()` for that type and confirm each one sets the new field; do not rely on the repository implementation alone to surface missing write-path callers.
+
+## From PR #1291
+
+### P1291.2 — `Dockerfile.dockerignore` `**` catch-all silently excludes new `build/web/` files
+
+- **Pattern:** `build/web/Dockerfile.dockerignore` opens with `**` (exclude everything) and re-allows only `!/src/Worms.Hub.Web`. Any file added to `build/web/` that a Dockerfile `COPY` instruction needs (e.g. `nginx.conf`) is silently excluded from the Docker build context, causing the build to fail with a "not found" error. The workaround — adding `!/build/web/<filename>` — was discovered during implementation and captured in the slice learnings, but the component doc was never updated, so future implementers will hit the same wall.
+- **Evidence:** PR #1291, commit dce153fe ("feat: add nginx config for SPA routing and wire into Docker image"), `.claude/specs/web-ui/slices/05-public-landing-page/learnings.md` entry "build/web/Dockerfile.dockerignore uses a `**` catch-all".
+- **Where to fix it:** `.claude/docs/components/web.md` — under the "Docker" section (or a new one if it does not exist), add a note that `build/web/Dockerfile.dockerignore` uses a `**` deny-all pattern; any file in `build/web/` that a `COPY` instruction needs must be explicitly whitelisted with `!/build/web/<filename>` in that file.


### PR DESCRIPTION
## Summary

- Adds a new `/retro-epic` slash command that runs a four-phase retrospective on a completed epic: extracting learnings from slice files, gathering signals from merged PRs, updating steering/component docs, and updating command files
- Applies the findings from running the retro on the web-ui epic — 6 steering/component docs and 4 command files updated with concrete guidance to prevent recurring mistakes

## What changed

### New command
`/retro-epic` orchestrates:
1. Slice-file analysis (patterns of mistakes across all `review.md` and `learnings.md`)
2. Parallel per-PR analysis via GitHub (human review comments + post-review commits)
3. Steering/component doc updates
4. Command file updates

### Steering and component docs updated
- **`ci-patterns.md`** — code-scanning jobs need only `npm ci`, not `make web.build`; CodeQL with `build-mode: none` needs neither
- **`coding-guidelines.md`** — always-use-braces rule with `--warnaserror` note
- **`testing-strategy.md`** — web unit test tier (Vitest + RTL) added alongside .NET tiers
- **`hub-storage.md`** — `[PublicAPI]` + `XxxDb` naming in the add-domain-object checklist; `public` vs `internal` visibility rule; new "Schema compatibility" section
- **`hub-gateway.md`** — shared service registration via `TryAdd*` inside component methods; `IFeatureFlags`/`GatewayFeatureFlags` pattern; middleware ordering; deployment safety; DTO reuse rules
- **`web.md`** — `tsc -b` (not `--noEmit`); `make web.test`; Prettier-before-commit; `npm show` for dependency versions; Docker digest-pinning + dockerignore caveat; testing, layout, MUI v9, and React purity sections

### Command files updated
- **`review.md`** — verify all findings against actual diff/files; enumerate files in diff before comparing to plan; cross-check CI changes against `ci-patterns.md`; require file citations before raising any suggestion
- **`plan-spec.md`** — verify existing file state claims from source; flag single-item/list DTO asymmetry as explicit scope decision
- **`spec.md`** — three new pre-Step-5 gates: approved design for UI slices, first-time infra explicitly in scope, list/single-item DTO asymmetry decided
- **`implement-slice.md`** — out-of-plan files (migrations, config, CI) must be recorded in learnings.md

## Test plan

- [x] `/retro-epic` command file is readable and the phase descriptions are self-consistent
- [x] Steering docs remain high-level (no file paths, line numbers, or version numbers)
- [x] Component docs match the tone and structure of existing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)