### PR TITLE
fix: run placements backfill in batch job mode

### DIFF
--- a/src/Worms.Hub.Gateway/Program.cs
+++ b/src/Worms.Hub.Gateway/Program.cs
@@ -86,6 +86,8 @@ if (runAsBatchJob)
 {
     var processor = app.Services.GetService<Processor>();
     await processor!.UpdateReplay();
+    var backfiller = app.Services.GetRequiredService<PlacementsBackfiller>();
+    await backfiller.RunAsync(CancellationToken.None);
     return;
 }
 

--- a/src/Worms.Hub.Gateway/ServiceRegistration.cs
+++ b/src/Worms.Hub.Gateway/ServiceRegistration.cs
@@ -22,7 +22,8 @@ internal static class ServiceRegistration
             .AddWormsArmageddonFilesServices()
             .AddHttpClient()
             .AddScoped<Processor>()
-            .AddScoped<IAnnouncer, Announcer>();
+            .AddScoped<IAnnouncer, Announcer>()
+            .AddSingleton<PlacementsBackfiller>();
         builder.TryAddScoped<IFeatureFlags, GatewayFeatureFlags>();
         return builder;
     }

--- a/src/Worms.Hub.Gateway/Worker/PlacementsBackfillService.cs
+++ b/src/Worms.Hub.Gateway/Worker/PlacementsBackfillService.cs
@@ -1,68 +1,7 @@
-using System.Diagnostics.CodeAnalysis;
-using Dapper;
-using Npgsql;
-using Worms.Armageddon.Files.Replays.Text;
-using Worms.Hub.Gateway.FeatureFlags;
-using Worms.Hub.Storage.Database;
-using Worms.Hub.Storage.Domain;
-
 namespace Worms.Hub.Gateway.Worker;
 
-internal sealed class PlacementsBackfillService(
-    IServiceProvider serviceProvider,
-    ILogger<PlacementsBackfillService> logger) : BackgroundService
+internal sealed class PlacementsBackfillService(PlacementsBackfiller backfiller) : BackgroundService
 {
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
-        Justification = "Backfill continues with remaining replays even if one fails")]
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        using var activity = Telemetry.Source.StartActivity("Placement Backfill");
-
-        using var scope = serviceProvider.CreateScope();
-        var featureFlags = scope.ServiceProvider.GetRequiredService<IFeatureFlags>();
-        var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
-        var replayRepository = scope.ServiceProvider.GetRequiredService<IReplaysRepository>();
-        var replayTextReader = scope.ServiceProvider.GetRequiredService<IReplayTextReader>();
-
-        if (!await featureFlags.IsPlacementsEnabledAsync())
-        {
-            logger.LogInformation("Placements feature not enabled — skipping backfill.");
-            return;
-        }
-
-        var connectionString = configuration.GetConnectionString("Database");
-        await using var connection = new NpgsqlConnection(connectionString);
-
-        if (await connection.QuerySingleAsync<long>("SELECT COUNT(*) FROM replay_placements") > 0)
-        {
-            logger.LogInformation("Placement backfill already complete — skipping.");
-            return;
-        }
-
-        logger.LogInformation("Starting placement backfill...");
-
-        foreach (var replay in replayRepository.GetAll().Where(r => r.Status == "Processed"))
-        {
-            if (string.IsNullOrEmpty(replay.FullLog))
-            {
-                logger.LogDebug("Skipping replay {ReplayId} — no full log available.", replay.Id);
-                continue;
-            }
-
-            try
-            {
-                var replayModel = replayTextReader.GetModel(replay.FullLog);
-                var placements = replayModel.Placements
-                    .Select(p => new ReplayPlacement(p.Team.Machine, p.Team.Name, p.Position))
-                    .ToList();
-                replayRepository.Update(replay with { Placements = placements });
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to backfill placements for replay {ReplayId}.", replay.Id);
-            }
-        }
-
-        logger.LogInformation("Placement backfill complete.");
-    }
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) =>
+        backfiller.RunAsync(stoppingToken);
 }

--- a/src/Worms.Hub.Gateway/Worker/PlacementsBackfiller.cs
+++ b/src/Worms.Hub.Gateway/Worker/PlacementsBackfiller.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.CodeAnalysis;
+using Dapper;
+using Npgsql;
+using Worms.Armageddon.Files.Replays.Text;
+using Worms.Hub.Gateway.FeatureFlags;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Gateway.Worker;
+
+internal sealed class PlacementsBackfiller(
+    IServiceProvider serviceProvider,
+    ILogger<PlacementsBackfiller> logger)
+{
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Backfill continues with remaining replays even if one fails")]
+    public async Task RunAsync(CancellationToken _)
+    {
+        using var activity = Telemetry.Source.StartActivity("Placement Backfill");
+
+        using var scope = serviceProvider.CreateScope();
+        var featureFlags = scope.ServiceProvider.GetRequiredService<IFeatureFlags>();
+        var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        var replayRepository = scope.ServiceProvider.GetRequiredService<IReplaysRepository>();
+        var replayTextReader = scope.ServiceProvider.GetRequiredService<IReplayTextReader>();
+
+        if (!await featureFlags.IsPlacementsEnabledAsync())
+        {
+            logger.LogInformation("Placements feature not enabled — skipping backfill.");
+            return;
+        }
+
+        var connectionString = configuration.GetConnectionString("Database");
+        await using var connection = new NpgsqlConnection(connectionString);
+
+        if (await connection.QuerySingleAsync<long>("SELECT COUNT(*) FROM replay_placements") > 0)
+        {
+            logger.LogInformation("Placement backfill already complete — skipping.");
+            return;
+        }
+
+        logger.LogInformation("Starting placement backfill...");
+
+        foreach (var replay in replayRepository.GetAll().Where(r => r.Status == "Processed"))
+        {
+            if (string.IsNullOrEmpty(replay.FullLog))
+            {
+                logger.LogDebug("Skipping replay {ReplayId} — no full log available.", replay.Id);
+                continue;
+            }
+
+            try
+            {
+                var replayModel = replayTextReader.GetModel(replay.FullLog);
+                var placements = replayModel.Placements
+                    .Select(p => new ReplayPlacement(p.Team.Machine, p.Team.Name, p.Position))
+                    .ToList();
+                replayRepository.Update(replay with { Placements = placements });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to backfill placements for replay {ReplayId}.", replay.Id);
+            }
+        }
+
+        logger.LogInformation("Placement backfill complete.");
+    }
+}


### PR DESCRIPTION
## Summary

- `PlacementsBackfillService` was registered as a `BackgroundService` (hosted service), but the batch job mode path in `Program.cs` calls `processor.UpdateReplay()` and returns **before** `app.RunAsync()` is ever called — so the backfill hosted service never started.
- Extract the backfill logic from `PlacementsBackfillService` into a new `PlacementsBackfiller` class that can be called directly.
- Wire `PlacementsBackfiller` into the batch job path in `Program.cs` so it runs alongside the existing replay processor.

## Test plan

- [ ] Deploy to production with `BATCH=true` and verify logs show "Starting placement backfill..." and "Placement backfill complete."
- [ ] Verify `replay_placements` table is populated after the run
- [ ] Re-run and verify "Placement backfill already complete — skipping." is logged (idempotency check)
- [ ] Normal (non-batch) worker mode still starts `PlacementsBackfillService` as a hosted service

🤖 Generated with [Claude Code](https://claude.com/claude-code)