### PR TITLE
chore: bump hub gateway/worker image to 0.9.11

### DIFF
--- a/deployment/Worms.Hub.Infrastructure/Pulumi.yaml
+++ b/deployment/Worms.Hub.Infrastructure/Pulumi.yaml
@@ -4,6 +4,6 @@ description: The Worms Hub Server
 config:
     azure-native:location: northeurope
     worms-hub:domain: davideadie.dev
-    worms-hub:gateway-image: theeadie/worms-hub-gateway:0.9.10
+    worms-hub:gateway-image: theeadie/worms-hub-gateway:0.9.11
     worms-hub:wa-runner-image: theeadie/worms-hub-wa-runner:0.5.38
     worms-hub:database-version: "0.6"


### PR DESCRIPTION
## Summary

- Bumps `gateway-image` in `Pulumi.yaml` from `0.9.10` → `0.9.11`
- Both the gateway and worker container apps use this image (Worker.cs reads the same `gateway-image` config key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)