### PR TITLE
Configure Claude Code worktree support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ dotnet-tools.json
 
 # Vite local environment overrides
 src/Worms.Hub.Web/.env.local
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,7 @@
+# Files to copy into new Claude Code worktrees (must also be gitignored to take effect)
+
+# Avoid reinstalling npm packages in every worktree
+node_modules/
+
+# Copy local environment overrides
+src/Worms.Hub.Web/.env.local


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore` so the directory Claude Code uses for worktrees is not tracked
- Add `.worktreeinclude` to copy gitignored local files into new worktrees at create time — skips npm reinstall and carries over Vite env overrides

## What is `.worktreeinclude`?

Claude Code reads this file (gitignore syntax) and copies any file that is **both gitignored and matched here** into each new worktree. Currently configured to copy:
- `node_modules/` — avoids a full `npm install` in every worktree
- `src/Worms.Hub.Web/.env.local` — carries over local Vite environment overrides