### PR TITLE
feat(web): show top-3 ELO leaderboard on league list cards

### DIFF
--- a/.claude/specs/elo-rankings/plan.md
+++ b/.claude/specs/elo-rankings/plan.md
@@ -12,4 +12,4 @@ Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a sing
 - [x] **ELO rankings** — PlayerRank library integrated, DB migration for per-league ELO ratings, ratings computed from all placement data in a league and wired into the replay processing pipeline so standings update when a new replay is processed, league detail page extended with a standings table showing each player's name, current ELO, and games played
 - [x] **ELO on alias changes** — ELO recalculation triggered when a player claims or unclaims an alias, so historical replays are accounted for when a player registers or removes an alias
 - [ ] **ELO delta on game detail** — Per-game ELO delta shown on each placement pill on the game/replay detail page (e.g. "+12 ELO"), deferred from the ELO rankings slice
-- [ ] **ELO leaderboard on league cards** — Top-3 ELO leaderboard preview shown on each league card on the leagues list page, deferred from the ELO rankings slice
+- [x] **ELO leaderboard on league cards** — Top-3 ELO leaderboard preview shown on each league card on the leagues list page, deferred from the ELO rankings slice

--- a/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/learnings.md
+++ b/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/learnings.md
@@ -1,0 +1,9 @@
+# Learnings: ELO Leaderboard on League Cards
+
+## Implementation Notes
+
+Nothing surprising. The plan was followed exactly: types extended, imports added, leaderboard JSX inserted below the scheme chip, then `npx prettier --write`, `make web.lint`, and `make web.build` all passed. Prettier did make one minor cosmetic reflow inside the `medal` const declaration (line break placement around the `as const` cast) but no manual intervention was needed beyond running prettier once as the plan already instructed.
+
+## Files Added (not in plan)
+
+None — only `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx` was modified, which the plan listed as the sole changed file.

--- a/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/plan.md
+++ b/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/plan.md
@@ -1,0 +1,177 @@
+# Plan: ELO Leaderboard on League Cards
+
+## Context
+
+This slice is the final piece of the ELO Rankings epic. Slice 06 (ELO Rankings) introduced the `standings: StandingDto[] | null` field on `GET /api/v1/leagues` and `GET /api/v1/leagues/{id}` and rendered a standings table on the league detail page. This slice surfaces a top-3 leaderboard preview on each league card on the `/leagues` list page, consuming the existing `standings` field with no backend changes. Verified from `src/Worms.Hub.Gateway/API/Controllers/LeaguesController.cs` (`GetAll`): when the ELO ratings feature flag is enabled the controller already populates `standings` for every league in the list response, so the Web UI only needs to read and render it.
+
+## Files to Create / Modify
+
+### New files
+
+None.
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx` | Add `StandingDto` interface; extend `LeagueDto` with `standings: StandingDto[] | null`; render a leaderboard section inside `LeagueCard` showing the top 3 standings entries below the existing scheme chip, separated by a divider, with caption `LEADERBOARD` and `top N of M` footer. |
+
+---
+
+## Implementation Details
+
+### 1. Type additions in `LeagueListPage.tsx`
+
+Add a `StandingDto` interface above the existing `LeagueDto` interface that exactly matches the shape used on `LeagueDetailPage.tsx` (verified at lines 23–27 of that file):
+
+```ts
+interface StandingDto {
+    playerName: string
+    elo: number
+    gamesPlayed: number
+}
+```
+
+Extend `LeagueDto` (currently at lines 15–20) by adding `standings: StandingDto[] | null` as the final property. Do not change the other existing fields.
+
+The `fetch(...)` call at line 89 already casts the response to `LeagueDto[]`; no change is needed there — the field will be picked up automatically once the interface is widened.
+
+### 2. New leaderboard section inside `LeagueCard`
+
+Render the leaderboard inside the existing `<CardContent>` block, after the existing `Chip` for `Scheme v…` (currently the last child, at lines 68–75). Wrap the leaderboard in a guard so it is omitted entirely when `standings` is `null` or an empty array:
+
+```tsx
+{league.standings !== null && league.standings.length > 0 && (
+    <>
+        <Divider sx={{ mt: 2, mb: 1.5 }} />
+        <Box>
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'baseline',
+                    justifyContent: 'space-between',
+                    mb: 1,
+                }}
+            >
+                <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ textTransform: 'uppercase', letterSpacing: '0.1em' }}
+                >
+                    Leaderboard
+                </Typography>
+                <Typography
+                    sx={{
+                        fontFamily: monoFontFamily,
+                        fontSize: 10,
+                        color: 'text.disabled',
+                    }}
+                >
+                    top {Math.min(3, league.standings.length)} of {league.standings.length}
+                </Typography>
+            </Box>
+            <Stack spacing={0.5}>
+                {league.standings.slice(0, 3).map((s, index) => {
+                    const place = index + 1
+                    const medal = (['#ffca28', '#bdbdbd', '#cd7f32'] as const)[index]
+                    return (
+                        <Box
+                            key={index}
+                            sx={{
+                                display: 'grid',
+                                gridTemplateColumns: '22px 1fr auto',
+                                gap: 1,
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Typography
+                                sx={{
+                                    fontFamily: monoFontFamily,
+                                    fontSize: 12,
+                                    fontWeight: 700,
+                                    color: medal,
+                                    textAlign: 'center',
+                                }}
+                            >
+                                {place}
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    fontWeight: place === 1 ? 700 : 500,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {s.playerName}
+                            </Typography>
+                            <Typography
+                                sx={{
+                                    fontFamily: monoFontFamily,
+                                    fontSize: 13,
+                                    fontWeight: 700,
+                                    color: 'primary.main',
+                                    textAlign: 'right',
+                                }}
+                            >
+                                {s.elo}
+                            </Typography>
+                        </Box>
+                    )
+                })}
+            </Stack>
+        </Box>
+    </>
+)}
+```
+
+Notes:
+
+- The caption text uses `Leaderboard` with `textTransform: 'uppercase'` applied via `sx` (consistent with the design reference). The spec requires the rendered text to read "LEADERBOARD"; using `textTransform: 'uppercase'` satisfies this and matches the pattern used on the design mock.
+- The footer string is computed as `top ${Math.min(3, M)} of ${M}`, so for `M=1` it renders `top 1 of 1`, for `M=2` it renders `top 2 of 2`, etc.
+- Rows iterate `standings.slice(0, 3)` so when fewer than 3 entries exist only the present rows render.
+- The whole card remains a single `<Link to={...}>` (lines 24–27); no per-row `onClick` or per-row `<Link>` is added, satisfying the "leaderboard rows are not individually interactive" requirement.
+- Player-name truncation uses inline `overflow: hidden` + `textOverflow: ellipsis` + `whiteSpace: nowrap` on the `Typography`'s `sx`. Do not use `noWrap` as a prop because the grid column `1fr` already provides the width constraint; the explicit `sx` form keeps the rule local and avoids interaction issues seen with MUI v9 prop shorthands (see `.claude/docs/components/web.md`).
+
+### 3. Required new imports
+
+Add the following imports to `LeagueListPage.tsx` (the file currently imports `Box`, `Breadcrumbs`, `Card`, `CardContent`, `Chip`, `CircularProgress`, `Container`, `Typography`):
+
+```ts
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
+```
+
+`monoFontFamily` is already imported (line 12); no change.
+
+### 4. Formatting and linting
+
+After the edit:
+
+1. Run `npm ci` once inside `src/Worms.Hub.Web/` if `node_modules/` is not already present (see slice 05 learnings — `make web.lint` fails with `ERR_MODULE_NOT_FOUND` otherwise).
+2. Run `npx prettier --write src/pages/LeagueListPage.tsx` from `src/Worms.Hub.Web/` to align indentation, trailing commas, and quote style with the rest of the file. Slice 03 learnings explicitly call this out as a recurring issue.
+3. Run `make web.lint` from the repo root and ensure ESLint, `tsc -b`, and Prettier all pass. Pay particular attention to the React Compiler ESLint rule (`react-compiler/react-compiler`) — the leaderboard JSX is pure rendering with no impure calls (no `Math.random`, no `Date.now`), so no `useState` initialiser tricks are needed.
+4. Run `make web.build` from the repo root and ensure the bundle builds cleanly.
+
+### 5. Scope decision — list vs detail symmetry
+
+The list endpoint (`GET /api/v1/leagues`) and the single-item endpoint (`GET /api/v1/leagues/{id}`) already return identical `standings` shapes, populated by the same `RatingsRepository.GetByLeagueId(...)` call (verified in `LeaguesController.cs`). No API-side symmetry work is required. The Web UI detail page (`LeagueDetailPage.tsx`) already renders the full standings table from this data and is **explicitly out of scope** for this slice — it must not be modified.
+
+### 6. Out-of-scope guard rails
+
+- No changes to `LeagueDetailPage.tsx`, the Gateway, the storage layer, the database, or any tests.
+- No new test infrastructure (the web component currently has no Vitest tests for these pages; this slice does not introduce them — consistent with the existing pattern for purely visual list/card components).
+- No empty-state placeholder when `standings` is `null` or empty — the entire leaderboard subtree must be omitted (the guard above ensures this).
+
+---
+
+## Verification
+
+1. `make web.lint` passes (ESLint, `tsc -b`, Prettier).
+2. `make web.build` passes (Vite production build).
+3. Manually load `/leagues` with the local dev stack against a database where at least one league has 3+ ELO-rated players: the card renders a `LEADERBOARD` section with 3 rows ranked gold/silver/bronze and a footer `top 3 of M`.
+4. For a league with `standings.length === 2`, the same card renders exactly 2 rows and footer reads `top 2 of 2`. For `standings.length === 1`, 1 row and `top 1 of 1`. For an empty array or `null`, no leaderboard section, divider, caption, or footer is rendered on that card.
+5. Clicking anywhere on the card (including over the leaderboard area) navigates to `/leagues/{id}` — confirmed because the entire `Card` is still wrapped in the existing `<Link to={…}>` at the top of `LeagueCard`.
+6. Resizing the window or rendering a deliberately long player name confirms the name truncates with an ellipsis on a single line; ELO values remain right-aligned and unmoved.
+7. The standings table on `/leagues/{id}` is unchanged (visual comparison before/after).

--- a/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/review.md
+++ b/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/review.md
@@ -1,0 +1,74 @@
+# Review — ELO Leaderboard on League Cards
+
+## Verdict
+
+The implementation satisfies every acceptance criterion in the spec. The diff is limited to `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx` (plus an unrelated tick in the epic plan), `make web.lint` and `make web.build` both pass cleanly, and the `LeagueDetailPage.tsx` standings table is untouched. No blockers. A few small suggestions and nitpicks around React keys, the duplicated `StandingDto` interface, and a minor visual concern are listed below for triage.
+
+## Acceptance Criteria
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Card with 3+ rated players renders 3 rows + `top 3 of M` | MET | `LeagueListPage.tsx:115-117` (`top {Math.min(3, …)} of {length}`), `:120` (`.slice(0, 3)`) |
+| Card with 2 rated players: 2 rows + `top 2 of 2` | MET | Same computation at `:115-117`; `.slice(0, 3)` returns 2 |
+| Card with 1 rated player: 1 row + `top 1 of 1` | MET | Same computation; `.slice(0, 3)` returns 1 |
+| Card with empty standings: section omitted entirely | MET | Guard at `LeagueListPage.tsx:86` (`length > 0`) |
+| Card with null standings: section omitted entirely | MET | Guard at `LeagueListPage.tsx:86` (`!== null`) |
+| Rank medal colours gold/silver/bronze | MET | `LeagueListPage.tsx:122` (`['#ffca28', '#bdbdbd', '#cd7f32']`) applied via `color: medal` at `:140` |
+| ELO uses `monoFontFamily`, right-aligned | MET | `LeagueListPage.tsx:159` (`fontFamily: monoFontFamily`) and `:163` (`textAlign: 'right'`) |
+| Long player names truncate with ellipsis | MET | `LeagueListPage.tsx:150-152` (`overflow: hidden`, `textOverflow: ellipsis`, `whiteSpace: nowrap`) |
+| Card click target covers leaderboard area | MET | Entire card still wrapped in `<Link>` at `:33`; no per-row handlers added |
+| Existing card content unchanged | MET | id badge (`:49-71`), name (`:73-75`), scheme chip (`:77-84`) untouched in diff |
+| Detail page unchanged | MET | `LeagueDetailPage.tsx` not in diff |
+| No API changes | MET | No backend files in diff |
+| `make web.lint` and `make web.build` pass | MET | Verified locally: lint completes with "All matched files use Prettier code style!" and ESLint/tsc clean; `vite build` produces `.artifacts/web/` bundle |
+
+## Scope
+
+Plan listed exactly one file to modify: `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx`. The diff modifies that one file plus `.claude/specs/elo-rankings/plan.md` (a workflow artefact — an epic-level status tick) and adds the slice's spec/plan/learnings directory (workflow artefacts, excluded by the review rules). No source files outside the plan were touched. Imports added (`Divider`, `Stack`) match the plan; `monoFontFamily` was already imported. The leaderboard JSX block matches the plan's design 1:1 including the `as const` cast for medal colours.
+
+## Blockers
+
+None.
+
+## Suggestions
+
+### S1 — Duplicate `StandingDto` interface
+
+- **File:** `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx:17-21`
+- **Issue:** `StandingDto` is now declared identically in both `LeagueListPage.tsx` (`:17-21`) and `LeagueDetailPage.tsx` (`:23-27`). The two pages now drift independently if the API shape changes, and the spec itself notes the new declaration must match the existing one.
+- **Fix:** Extract `StandingDto` (and arguably `LeagueDto`) into a shared module, e.g. `src/Worms.Hub.Web/src/api/types.ts`, and import from both pages. Out of scope for the slice's stated scope (UI-only on the list page) but worth doing as a tiny follow-up.
+- **Decision:** Accept
+
+## Nitpicks
+
+### N1 — `index` used as React key for rendered rows
+
+- **File:** `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx:127`
+- **Issue:** `<Box key={index} …>` keys rows by array position. The rows are always rendered in API order and the list is at most 3 entries, so this is harmless in practice, but `playerName` would be a more stable key and matches the convention used elsewhere in the codebase for keyed lists of player rows.
+- **Fix:** `key={s.playerName}` (or `key={`${s.playerName}-${index}`}` if a duplicate-name guard is wanted).
+- **Decision:** Accept
+
+### N2 — `medal` is `undefined` for any 4th+ row (defence-in-depth only)
+
+- **File:** `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx:122-124`
+- **Issue:** `(['#ffca28', '#bdbdbd', '#cd7f32'] as const)[index]` returns `undefined` for `index >= 3`. The `.slice(0, 3)` at `:120` guarantees we never reach that branch, so this is purely theoretical, but the TypeScript type of `medal` is `'#ffca28' | '#bdbdbd' | '#cd7f32' | undefined` and downstream the `color` sx accepts `undefined`. A future change to the slice or row count could silently degrade.
+- **Fix:** Either tighten by indexing `place - 1` with a non-null assertion explicitly tied to the `slice(0, 3)` bound, or pull the array out as `const MEDAL_COLOURS: readonly [string, string, string] = …` and read with a bounded helper. Not worth doing on its own.
+- **Decision:** Decline
+
+### N3 — Caption text rendered as `Leaderboard` and uppercased via CSS
+
+- **File:** `src/Worms.Hub.Web/src/pages/LeagueListPage.tsx:101-106`
+- **Issue:** The spec says the caption reads `LEADERBOARD`. The DOM text node is `Leaderboard` and `textTransform: 'uppercase'` does the case change at render time. This is functionally identical visually and was explicitly called out in the plan, but means copy/paste of the rendered text and accessibility tools will see the title case form rather than uppercase. Consistent with the rest of the codebase's caption pattern, so likely acceptable.
+- **Fix:** None needed unless the team prefers literal uppercase strings for accessibility/copy parity.
+- **Decision:** Accept
+
+## Tests
+
+No tests were added or modified, consistent with the slice scope and `learnings.md`. The web component layer for these list/card pages currently has no Vitest coverage (confirmed by repo grep — no `LeagueListPage.test.tsx`), and the slice did not commit to introducing test infrastructure. Per `.claude/docs/components/web.md`, this is acceptable because the leaderboard is a purely visual list-card concern, not a security/routing invariant. No coverage gaps to flag; no padding or fragile tests were introduced.
+
+## Recommended Actions
+
+- **S1** — Decline — explicitly out of scope; the existing duplication is small (one interface, three fields), and consolidating is better tracked as a follow-up rather than expanding this slice.
+- **N1** — Accept — trivial change to a more stable key, and `playerName` is unique-by-construction in a single-league standings array.
+- **N2** — Decline — defended by `.slice(0, 3)` immediately above; refactoring for a hypothetical regression isn't worth the noise.
+- **N3** — Decline — pattern is consistent with the rest of the design and was deliberate in the plan.

--- a/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/spec.md
+++ b/.claude/specs/elo-rankings/slices/08-elo-leaderboard-on-league-cards/spec.md
@@ -1,0 +1,54 @@
+# ELO Leaderboard on League Cards
+
+## Overview
+
+Extend each league card on the `/leagues` page to show a top-3 ELO leaderboard preview, sourced from the `standings` field already returned by `GET /api/v1/leagues`. No backend changes are required — this is a Web UI–only slice that surfaces existing data.
+
+## Requirements
+
+- The `LeagueDto` interface in `LeagueListPage.tsx` is extended to include `standings: StandingDto[] | null`, with `StandingDto` shaped as `{ playerName: string; elo: number; gamesPlayed: number }`, matching the Gateway response and the existing definition on `LeagueDetailPage.tsx`.
+- Each league card on the `/leagues` page renders a leaderboard section showing the top 3 entries from `standings`.
+- The leaderboard section appears inside the existing card, below the existing scheme chip, and is separated from it by a horizontal divider.
+- Above the rows, an uppercase caption reads `LEADERBOARD`. To the right of (or below) the caption, a small mono-style label reads `top N of M`, where:
+  - `M` is the total number of entries in `standings`.
+  - `N` is `min(3, M)`, i.e. it always reflects the actual number of rows rendered.
+- Each leaderboard row shows three pieces of data, in this order:
+  - Rank (`1`, `2`, `3`), with the rank number styled in the medal colours used on the league detail page (`#ffca28` gold, `#bdbdbd` silver, `#cd7f32` bronze).
+  - Player name.
+  - ELO rating, in the mono font, right-aligned.
+- If a league has fewer than 3 rated players, only the rows that exist are rendered (no placeholder rows).
+- The leaderboard section is omitted entirely when `standings` is `null` or an empty array — no caption, footer, divider, or placeholder is rendered in that case.
+- Player names that are too long to fit on one line are truncated with an ellipsis (single-line, no wrap).
+- Leaderboard rows preserve the order returned by the API (already ELO-descending); no client-side resorting or tiebreaker logic is added.
+- The entire card remains a single link to `/leagues/{id}` — clicking anywhere on the card, including the leaderboard area, navigates to the per-league page. Leaderboard rows are not individually interactive.
+
+## Out of Scope
+
+- Any backend or API changes — `GET /api/v1/leagues` is consumed as-is.
+- Per-row data beyond rank + name + ELO (no avatars, no colour badges, no wins, no games-played on the row).
+- Per-player links from leaderboard rows (no player pages exist yet).
+- Showing the leaderboard anywhere other than the `/leagues` cards (the existing detail page standings table is untouched).
+- An empty-state message when `standings` is `null` or empty — the section is silently omitted instead.
+- Per-card loading skeletons — the existing page-level `CircularProgress` is unchanged.
+- Visual changes to the league cards outside the new leaderboard section.
+- Changes to the API response shape, ordering guarantees, or tiebreaker behaviour.
+
+## Acceptance Criteria
+
+- **Card with 3+ rated players**: when a league's `standings` array contains 3 or more entries, the card renders a leaderboard with exactly 3 rows in the order returned by the API; the caption reads `LEADERBOARD` and the footer reads `top 3 of M` where M is `standings.length`.
+- **Card with 2 rated players**: when `standings.length === 2`, the leaderboard renders 2 rows and the footer reads `top 2 of 2`.
+- **Card with 1 rated player**: when `standings.length === 1`, the leaderboard renders 1 row and the footer reads `top 1 of 1`.
+- **Card with empty standings**: when `standings` is an empty array, no leaderboard section is rendered on the card — no caption, no divider, no footer.
+- **Card with null standings**: when `standings` is `null` (e.g. before the ELO schema migration has been applied), no leaderboard section is rendered on the card.
+- **Rank medal colours**: the first row's rank number is rendered in gold (`#ffca28`), the second in silver (`#bdbdbd`), the third in bronze (`#cd7f32`).
+- **ELO typography**: ELO values use the existing `monoFontFamily` from `theme.ts` and are right-aligned within their row.
+- **Long player names**: a player name that exceeds the available width is truncated to a single line with an ellipsis.
+- **Card click target**: clicking the leaderboard area navigates to `/leagues/{id}`; no separate click handler is attached to rows.
+- **Existing card content unchanged**: the league id, name, and scheme version chip continue to render exactly as before, in the same positions.
+- **Detail page unchanged**: the standings table on `/leagues/{id}` is not modified by this slice.
+- **No API changes**: `GET /api/v1/leagues` and `GET /api/v1/leagues/{id}` return the same payloads as before this slice was implemented.
+- **Lint and build**: `make web.lint` and `make web.build` both pass with the changes in place.
+
+## Open Questions
+
+None.

--- a/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/LeagueDetailPage.tsx
@@ -19,12 +19,7 @@ import Typography from '@mui/material/Typography'
 import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium'
 import { monoFontFamily } from '../theme'
 import { gatewayUrl } from '../api'
-
-interface StandingDto {
-    playerName: string
-    elo: number
-    gamesPlayed: number
-}
+import type { StandingDto } from '../types'
 
 interface LeagueDto {
     id: string

--- a/src/Worms.Hub.Web/src/pages/LeagueListPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/LeagueListPage.tsx
@@ -8,15 +8,19 @@ import CardContent from '@mui/material/CardContent'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { monoFontFamily } from '../theme'
 import { gatewayUrl } from '../api'
+import type { StandingDto } from '../types'
 
 interface LeagueDto {
     id: string
     name: string
     version: string | null
     schemeUrl: string
+    standings: StandingDto[] | null
 }
 
 function LeagueCard({ league }: { league: LeagueDto }) {
@@ -72,6 +76,95 @@ function LeagueCard({ league }: { league: LeagueDto }) {
                             variant="outlined"
                             sx={{ mt: 1.5, fontFamily: monoFontFamily, fontSize: 11 }}
                         />
+                    )}
+
+                    {league.standings !== null && league.standings.length > 0 && (
+                        <>
+                            <Divider sx={{ mt: 2, mb: 1.5 }} />
+                            <Box>
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'baseline',
+                                        justifyContent: 'space-between',
+                                        mb: 1,
+                                    }}
+                                >
+                                    <Typography
+                                        variant="caption"
+                                        color="text.secondary"
+                                        sx={{
+                                            letterSpacing: '0.1em',
+                                        }}
+                                    >
+                                        LEADERBOARD
+                                    </Typography>
+                                    <Typography
+                                        sx={{
+                                            fontFamily: monoFontFamily,
+                                            fontSize: 10,
+                                            color: 'text.disabled',
+                                        }}
+                                    >
+                                        top {Math.min(3, league.standings.length)} of{' '}
+                                        {league.standings.length}
+                                    </Typography>
+                                </Box>
+                                <Stack spacing={0.5}>
+                                    {league.standings.slice(0, 3).map((s, index) => {
+                                        const place = index + 1
+                                        const medal = (['#ffca28', '#bdbdbd', '#cd7f32'] as const)[
+                                            index
+                                        ]
+                                        return (
+                                            <Box
+                                                key={s.playerName}
+                                                sx={{
+                                                    display: 'grid',
+                                                    gridTemplateColumns: '22px 1fr auto',
+                                                    gap: 1,
+                                                    alignItems: 'center',
+                                                }}
+                                            >
+                                                <Typography
+                                                    sx={{
+                                                        fontFamily: monoFontFamily,
+                                                        fontSize: 12,
+                                                        fontWeight: 700,
+                                                        color: medal,
+                                                        textAlign: 'center',
+                                                    }}
+                                                >
+                                                    {place}
+                                                </Typography>
+                                                <Typography
+                                                    variant="body2"
+                                                    sx={{
+                                                        fontWeight: place === 1 ? 700 : 500,
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        whiteSpace: 'nowrap',
+                                                    }}
+                                                >
+                                                    {s.playerName}
+                                                </Typography>
+                                                <Typography
+                                                    sx={{
+                                                        fontFamily: monoFontFamily,
+                                                        fontSize: 13,
+                                                        fontWeight: 700,
+                                                        color: 'primary.main',
+                                                        textAlign: 'right',
+                                                    }}
+                                                >
+                                                    {s.elo}
+                                                </Typography>
+                                            </Box>
+                                        )
+                                    })}
+                                </Stack>
+                            </Box>
+                        </>
                     )}
                 </CardContent>
             </Card>

--- a/src/Worms.Hub.Web/src/types.ts
+++ b/src/Worms.Hub.Web/src/types.ts
@@ -1,0 +1,5 @@
+export interface StandingDto {
+    playerName: string
+    elo: number
+    gamesPlayed: number
+}


### PR DESCRIPTION
## Summary
- Each league card on the list page now shows the top 3 rated players with medal colours, ELO scores, and a `top N of M` footer
- Section is omitted when standings are null or empty, leaving existing cards untouched
- Extracts the duplicated `StandingDto` interface into a shared `src/types.ts` so the list and detail pages share a single declaration

## Test plan
- [x] `make web.lint` passes
- [x] `make web.build` passes
- [ ] Visually verify card with 3+ rated players renders 3 rows and `top 3 of M`
- [x] Visually verify cards with 0/1/2 rated players render correctly (section omitted / 1 row / 2 rows)
- [ ] Visually verify long player names truncate with ellipsis
- [x] Visually verify clicking anywhere on the card still navigates to the league detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)