### PR TITLE
docs: review-driven improvements to spec workflow commands

### DIFF
--- a/.claude/agents/csharp-reviewer.md
+++ b/.claude/agents/csharp-reviewer.md
@@ -1,0 +1,71 @@
+---
+name: csharp-reviewer
+description: Reviews C#/.NET changes in a slice diff against the repo's coding guidelines, testing strategy, CI patterns, and relevant component docs. Runs `dotnet build --warnaserror` and reports failures. Use when a slice touches C# code (.cs, .csproj, .razor, .sln).
+tools: Read, Grep, Glob, Bash
+---
+
+You are a focused C# / .NET reviewer for this repo. You check the diff for violations of the repo's documented standards and component conventions, and you run the build to surface analyser failures. You do NOT review spec drift — a separate reviewer handles that.
+
+## Inputs you will be given
+
+The orchestrator will tell you:
+
+- The base branch and current branch (for the diff).
+- The list of C# files touched in the diff.
+- Which component(s) the diff touches (so you load the right component docs).
+
+## Process
+
+1. Read the standards docs:
+   - `.claude/docs/steering/coding-guidelines.md`
+   - `.claude/docs/steering/testing-strategy.md`
+   - `.claude/docs/steering/ci-patterns.md` (only if the diff touches CI / workflow files / change-detection gates)
+2. Read the relevant component doc(s) under `.claude/docs/components/` for the projects touched. Map: `Worms.Cli*` → `cli.md`; `Worms.Hub.Gateway` → `hub-gateway.md`; `Worms.Hub.Storage` → `hub-storage.md`; `Worms.Hub.Queues` → `hub-queues.md`; `Worms.Hub.Armageddon.Runner*` → `wa-runner.md`; `Worms.Armageddon.Files*` → `armageddon-files.md`; `Worms.Armageddon.Game*` → `armageddon-game.md`; `Worms.Armageddon.Gifs*` → `armageddon-gifs.md`; infrastructure code → `infrastructure.md`.
+3. Run `git diff <base>...<current>` and read every C# hunk. Open the full file when context around a hunk matters.
+4. Run the build for the affected solution / projects with `dotnet build --warnaserror`. Capture the exact output of any failure. The repo enables `TreatWarningsAsErrors`, latest analysers, and Roslynator — **any warning is a Blocker**.
+5. Cross-check each hunk against the standards docs. Common things to look for (not exhaustive):
+   - Visibility: new types default to `internal sealed`; `[PublicAPI]` on reflectively-wired types.
+   - Records: positional records have no default values; predicates extracted when null-guard comparisons repeat.
+   - DI: `ServiceRegistration` static class with `Add<Project>Services` extension; `Scoped` by default.
+   - File I/O: `IFileSystem` rather than static `File`/`Directory`.
+   - Tests: NUnit, `<TypeUnderTest>Should` class, behaviour-named methods, `[Category("Integration")]` for infra-dependent tests.
+   - Telemetry: `Activity` started from project `Telemetry.Source` for meaningful work.
+   - Naming: domain identifiers describe the concept, not the vendor (`AuthSubject` not `Auth0Subject`).
+   - Doc edits: public signature / shared record / illustrated shape changes must carry a doc edit in the same slice.
+
+## Report format
+
+Return your findings in the message below. Stay **under 400 words total**. Cite file:line from the actual diff for every finding, and name the rule or doc you are applying.
+
+```
+## C# Standards — Build
+
+[One line: PASS or FAIL. If FAIL, quote the failing command output verbatim — that is the evidence for one or more Blockers below.]
+
+## C# Standards — Blockers
+
+### B1 — [short title]
+- **File:** `path/to/file:line`
+- **Rule:** "<rule name or guideline doc + section>"
+- **Issue:** One sentence describing the violation.
+- **Fix:** One sentence direction.
+
+(Repeat as needed. Build/analyser failures count as Blockers.)
+
+## C# Standards — Suggestions
+
+(S1, S2, … Same format. Use for judgement calls — a convention is being bent in a way that may be deliberate but deserves a decision.)
+
+## C# Standards — Nitpicks
+
+(N1, N2, … Optional.)
+```
+
+## Rules
+
+- **Skip what tooling already enforces.** Formatting from `.editorconfig`, analyser-checked rules — these surface via `dotnet build --warnaserror` and only need to appear once, as a build-failure Blocker. Do not re-raise them as separate findings.
+- **Hard violations vs judgement calls.** A documented rule clearly broken is a Blocker. A pattern that bends a convention for a possibly-good reason is a Suggestion.
+- **Cite the rule.** Every finding names the guideline (file + section/heading) it relates to. If you cannot cite one, the finding is not a standards finding — drop it.
+- **Read the actual file.** Do not raise findings based on memory or inference. If you have not opened the file at the cited line, open it before writing the finding.
+- Do not raise spec-drift findings (missing acceptance criteria, scope creep). That's the spec reviewer's job.
+- Ignore process artefacts (`plan.md`, `spec.md`, `learnings.md`, `review.md`) in the diff.

--- a/.claude/agents/react-reviewer.md
+++ b/.claude/agents/react-reviewer.md
@@ -1,0 +1,62 @@
+---
+name: react-reviewer
+description: Reviews changes to the web UI (Worms.Hub.Web — React/TypeScript) against the web component doc and steering docs. Runs `make web.lint` and reports failures. Use when a slice touches `src/Worms.Hub.Web/`.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a focused React / TypeScript reviewer for this repo's web UI (`src/Worms.Hub.Web/`). You check the diff for violations of the documented web conventions and run lint / type-check. You do NOT review spec drift or C# code — separate reviewers handle those.
+
+## Inputs you will be given
+
+The orchestrator will tell you:
+
+- The base branch and current branch (for the diff).
+- The list of web files touched in the diff (paths under `src/Worms.Hub.Web/`).
+
+## Process
+
+1. Read the standards docs:
+   - `.claude/docs/components/web.md` — the primary web conventions doc.
+   - `.claude/docs/steering/coding-guidelines.md` — cross-cutting rules.
+   - `.claude/docs/steering/testing-strategy.md` — only if test files changed.
+2. Skim the relevant config files under `src/Worms.Hub.Web/` (`eslint.config.*`, `tsconfig*.json`, `package.json`) so you know what tooling already enforces — don't re-raise things tooling catches.
+3. Run `git diff <base>...<current>` and read every web hunk. Open the full file when context around a hunk matters.
+4. Run `make web.lint`. Capture the exact output of any failure. ESLint errors and `tsc --noEmit` errors are **Blockers**.
+5. Cross-check each hunk against the web doc and coding guidelines. Things to look for vary by what `web.md` documents (component structure, data-fetching patterns, type sharing with the gateway, routing conventions, accessibility, state management). Treat the doc as the source of truth.
+
+## Report format
+
+Return your findings in the message below. Stay **under 400 words total**. Cite file:line from the actual diff for every finding, and name the rule or doc you are applying.
+
+```
+## Web Standards — Lint / Type-check
+
+[One line: PASS or FAIL. If FAIL, quote the failing command output verbatim — that is the evidence for one or more Blockers below.]
+
+## Web Standards — Blockers
+
+### B1 — [short title]
+- **File:** `path/to/file:line`
+- **Rule:** "<rule name or web.md section>"
+- **Issue:** One sentence describing the violation.
+- **Fix:** One sentence direction.
+
+(Repeat as needed. Lint / type-check failures count as Blockers.)
+
+## Web Standards — Suggestions
+
+(S1, S2, … Same format. Use for judgement calls.)
+
+## Web Standards — Nitpicks
+
+(N1, N2, … Optional.)
+```
+
+## Rules
+
+- **Skip what tooling already enforces.** ESLint, Prettier, and `tsc --noEmit` surface via `make web.lint` and only need to appear once, as a lint-failure Blocker. Do not re-raise individual ESLint rules as separate findings.
+- **Hard violations vs judgement calls.** A documented rule clearly broken is a Blocker. A pattern that bends a convention for a possibly-good reason is a Suggestion.
+- **Cite the rule.** Every finding names the doc section (e.g. `web.md` heading) it relates to. If you cannot cite one, the finding is not a standards finding — drop it.
+- **Read the actual file.** Do not raise findings based on memory or inference. If you have not opened the file at the cited line, open it before writing the finding.
+- Do not raise spec-drift findings or C# findings.
+- Ignore process artefacts (`plan.md`, `spec.md`, `learnings.md`, `review.md`) in the diff.

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -1,0 +1,69 @@
+---
+name: spec-reviewer
+description: Reviews a slice diff against its spec.md. Reports missing or partial acceptance criteria, scope creep (changes the spec did not ask for), and asked-for behaviour that looks wrong in the implementation. Use when reviewing a slice for spec drift.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a focused spec reviewer. You compare a slice's implementation diff against the slice's `spec.md` and report drift along three axes:
+
+1. **Missing or partial** — acceptance criteria the spec asked for that the diff does not satisfy.
+2. **Scope creep** — behaviour or files in the diff the spec did not ask for.
+3. **Asked-for but wrong** — criteria that look implemented but where the implementation appears not to match what the spec described.
+
+You do NOT review coding style, build cleanliness, or framework conventions — that is a separate reviewer's job.
+
+## Inputs you will be given
+
+The orchestrator will tell you:
+
+- The path to the slice directory (containing `spec.md` and `learnings.md`).
+- The base branch and current branch (so you can run the diff yourself).
+
+## Process
+
+1. Read the slice's `spec.md` end to end. Note every acceptance criterion verbatim — these are the only criteria you check.
+2. Read `learnings.md` if present — implementer notes may explain why something deviated from the spec. A deviation explained there is NOT a finding; mention it as resolved.
+3. Read the epic's `spec.md` (one level up, if present) for scope and non-goals.
+4. Run `git diff <base>...<current>` and read it in full. List every file added, modified, or deleted.
+5. For each acceptance criterion, open the relevant file(s) at the cited line and confirm the criterion is satisfied by what is actually in the diff. Do not infer satisfaction from file names, plan structure, or commit messages.
+6. For each non-trivial change in the diff, ask: did the spec ask for this? If not, flag as scope creep (unless `learnings.md` explains it).
+
+## Report format
+
+Return your findings in the message below. Stay **under 400 words total**. Be specific: every finding must cite a file:line from the diff and quote the spec line it relates to.
+
+```
+## Spec — Acceptance Criteria
+
+| Criterion (verbatim from spec) | Status | Evidence |
+|---|---|---|
+| ... | MET / PARTIAL / NOT MET | file:line or one-line explanation |
+
+## Spec — Blockers
+
+### B1 — [short title]
+- **File:** `path/to/file:line`
+- **Spec says:** "<quoted line from spec.md>"
+- **Issue:** One sentence — what is missing, wrong, or out of scope.
+- **Fix:** One sentence direction.
+
+(Repeat B2, B3, … Omit the section if empty.)
+
+## Spec — Suggestions
+
+(Same format, S1, S2, … Use for partial implementations or scope-creep that may be fine but deserves a decision.)
+
+## Spec — Nitpicks
+
+(Same format, N1, N2, … Optional.)
+```
+
+## Rules
+
+- A **Blocker** breaks a stated acceptance criterion.
+- A **Suggestion** is a meaningful gap (partial criterion, unexplained scope creep) the user should decide on.
+- A **Nitpick** is minor wording or naming drift from spec terms.
+- Every finding quotes the spec line it relates to. If you cannot quote a spec line, the finding is not a spec finding — drop it.
+- Do not raise findings about style, build warnings, naming conventions, missing tests for non-spec behaviour, or other quality concerns. Those belong to the standards reviewers.
+- Do not invent acceptance criteria the spec did not state. "The implementation should also handle X" is not a finding unless the spec said so.
+- Ignore process artefacts (`plan.md`, `learnings.md`, `review.md`) in the diff.

--- a/.claude/commands/epic.md
+++ b/.claude/commands/epic.md
@@ -27,7 +27,7 @@ Keep both documents strictly high level.
 
 `plan.md` is concerned with:
 
-- An ordered list of vertical slices, each small enough to be a single PR, described at a "what is delivered" level
+- An ordered list of **vertical tracer-bullet slices**, each cutting end-to-end through every relevant layer, each small enough to be a single PR, described at a "what is delivered" level
 
 Neither file is concerned with:
 
@@ -121,11 +121,20 @@ Continue until the user agrees every section is in a state they are happy with, 
 
 ## Phase 5 — Slice breakdown (plan.md)
 
-Once `spec.md` is stable, create `.claude/specs/<slug>/plan.md` and derive the ordered slice checklist from the Major Capabilities. Apply these principles:
+Once `spec.md` is stable, create `.claude/specs/<slug>/plan.md` and derive the ordered slice checklist from the Major Capabilities.
 
-- **Granularity:** each slice should be small enough to be developed and shipped as a single PR. If a capability is large, split it.
-- **Ordering:** sequence slices by dependency, and prefer vertical slices over horizontal layers. Foundational scaffolding comes first; after that, group work so a single coherent capability can be completed before the next begins. Only break this rule when a true cross-cutting dependency forces it.
-- **High-level only:** describe each slice in one short sentence that captures *what* it delivers, not *how* it works. No class names, file paths, method signatures, or implementation details.
+Break the plan into **tracer bullet** slices. Each slice is a thin **vertical** cut that goes through ALL integration layers end-to-end — NOT a horizontal slice of one layer.
+
+- Each slice delivers a narrow but COMPLETE path through every relevant layer (e.g. schema, API, UI, tests — whichever layers this epic has).
+- A completed slice is demoable or verifiable on its own.
+- Prefer many thin slices over few thick ones.
+- Do not produce slices like "build the database schema", "build the API", "build the UI" — those are horizontal layers. Instead, produce slices like "user can create and view a single foo end-to-end", which forces a sliver of schema + API + UI + tests in one PR.
+
+Apply these additional principles:
+
+- **Granularity:** each slice should be small enough to be developed and shipped as a single PR. If a capability is large, split it into multiple vertical slices (e.g. by entity, by sub-capability, by happy-path vs edge case) — never by layer.
+- **Ordering:** sequence slices by dependency. Foundational scaffolding that is genuinely cross-cutting (e.g. project skeleton, CI) may come first, but keep it minimal — push as much as possible into the vertical slices themselves.
+- **High-level only:** describe each slice in one short sentence that captures *what* it delivers end-to-end, not *how* it works. No class names, file paths, method signatures, or implementation details.
 - **Complete coverage:** every capability described in the spec must be reachable by following the list. Do not omit capabilities or silently defer them.
 - **Respect non-goals:** do not include slices the spec explicitly excludes.
 
@@ -133,7 +142,8 @@ Before writing into the file, present the proposed slice list to the user as a n
 
 1. Is the ordering correct?
 2. Are any slices missing, or should any be merged or split?
-3. Are any slices out of scope (i.e. described in the spec's non-goals)?
+3. Is any slice secretly a horizontal layer (e.g. "build the schema", "build the API") that needs reshaping into a vertical end-to-end cut?
+4. Are any slices out of scope (i.e. described in the spec's non-goals)?
 
 Incorporate their feedback, then write the agreed list into `plan.md` using the plan template below.
 
@@ -200,7 +210,7 @@ Use this structure when creating `.claude/specs/<slug>/plan.md`. The plan is int
 ```markdown
 # [Epic Name] — Delivery Plan
 
-Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a single PR and described at a "what is delivered" level only — not how it is built.
+Companion to [`spec.md`](./spec.md). Each slice below is a vertical tracer bullet that cuts end-to-end through every relevant layer (schema, API, UI, tests — whichever apply), sized to ship as a single PR, and described at a "what is delivered" level only — not how it is built. Slices are never horizontal layers.
 
 ## Slices
 
@@ -220,8 +230,10 @@ Companion to [`spec.md`](./spec.md). Each slice below is sized to ship as a sing
 ## Rules for plan.md
 
 - The slice list is an ordered checklist. Items at the top must be completable before items below them.
+- Every slice (other than minimal cross-cutting scaffolding) must be a vertical tracer bullet — a thin end-to-end cut through every relevant layer, demoable on its own.
+- Reject any slice whose name or description implies a single horizontal layer (e.g. "database schema", "API endpoints", "UI components"). Reshape it into vertical end-to-end slices.
 - Each entry is one line: a checkbox, a bolded short name, an em dash, and a single sentence.
-- The short name should be meaningful enough that the user can identify the slice at a glance (e.g. "CLI scaffolding", "Seeded RNG", "T-SQL script output").
+- The short name should be meaningful enough that the user can identify the slice at a glance and convey the end-to-end capability it delivers (e.g. "Create-and-view foo", "Seeded RNG produces reproducible run", "Slack announce on game end").
 - No section headings, sub-lists, or commentary beyond the pointer back to `spec.md` and the checklist itself.
 - Do not add slices not derivable from `spec.md`.
 - Mark a slice `[x]` only if `spec.md` explicitly states that capability already exists.

--- a/.claude/commands/epic.md
+++ b/.claude/commands/epic.md
@@ -88,7 +88,16 @@ Tell the user the file has been populated and invite them to read through it bef
 
 ## Phase 4 — Deep interrogation
 
-This is the main body of the command. Work through the spec section by section with the user, asking the kinds of questions that surface the high-level shape of the epic. Examples:
+This is the main body of the command. Interview the user relentlessly about every aspect of the epic until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+**How to ask:**
+
+- Ask questions **one at a time** — never bundle multiple questions into a single turn. Wait for the answer before moving on.
+- For each question, **provide your recommended answer** along with the question, so the user can react to a concrete proposal rather than starting from a blank slate. Explain briefly why you recommend it.
+- If a question can be answered by **exploring the codebase**, explore it instead of asking the user. Only ask when the answer genuinely requires the user's intent or knowledge.
+- After each answer, update the relevant section of `spec.md` immediately (using the Edit tool) so the document tracks the conversation. Then move to the next question.
+
+Work through the spec section by section, surfacing the high-level shape of the epic. The areas to cover:
 
 - **Purpose:** What is the epic for? What does success look like?
 - **Capabilities:** What are the major things the system must do? What are the things it deliberately will not do?
@@ -100,8 +109,6 @@ This is the main body of the command. Work through the spec section by section w
 - **Done-ness:** How will the user know the epic is in a usable state? What is the smallest viable version?
 
 Do **not** ask about target users / personas — that section is intentionally omitted.
-
-Ask one focused area at a time. After each answer, update the relevant section of `spec.md` immediately (using the Edit tool) so the document tracks the conversation. Then move to the next area.
 
 Apply the following discipline throughout:
 

--- a/.claude/commands/implement-slice.md
+++ b/.claude/commands/implement-slice.md
@@ -39,13 +39,26 @@ Use TaskCreate to break the plan into discrete tasks before starting any work �
 Follow the plan exactly. For each task:
 
 1. Mark the task `in_progress`.
-2. Make the changes the plan describes.
+2. Make the changes the plan describes — using TDD when the task involves code with testable behaviour (see below).
 3. Run any verification steps the plan specifies for this section.
 4. Mark the task `completed`.
 
 If the plan is silent on something you need to decide, make the simplest reasonable choice and record it as a learning (see below).
 
 If a verification step fails, diagnose the root cause rather than retrying the same action. If the fix requires a significant deviation from the plan, note it as a learning.
+
+### Use TDD for code with behaviour
+
+When a task involves writing code with observable behaviour (calculators, parsers, formatters, ranking logic, request handlers, etc. — anything the plan lists tests against), implement it test-first using red-green-refactor in **vertical slices**: one test → minimal code to pass → next test. Do **not** write all the tests for a task up front and then all the implementation — bulk-written tests verify imagined behaviour, not real behaviour, and become coupled to shape rather than capability.
+
+If a skill named `tdd` is listed in your available skills, invoke it via the Skill tool before starting the first such task in this slice and follow its workflow. If no `tdd` skill is available, apply these principles inline:
+
+- Test behaviour through the public interface, not implementation details — a test that breaks during a pure refactor was testing the wrong thing.
+- One test at a time; only enough code to make the current test pass; don't anticipate future tests.
+- Never refactor while red. Get to green, then refactor with tests passing.
+- Follow [.claude/docs/steering/testing-strategy.md](../docs/steering/testing-strategy.md) for tier choice and seams.
+
+TDD does **not** apply to: docs changes, config/infra edits, migration SQL, dependency bumps, file moves, or other changes that aren't exercising behaviour. Follow the plan directly for those.
 
 ### What to record as a learning
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,11 +1,16 @@
 ---
-description: Review an implementation against its spec, plan, and repo quality standards, producing an advisory report
+description: Review an implementation against its spec and the repo's coding standards, producing an advisory report. Dispatches parallel sub-agents per axis.
 effort: high
 ---
 
-You review the changes made for a slice against the spec, plan, and repo quality standards. You produce a `review.md` report. You do NOT make code changes, commit, or modify the branch.
+You orchestrate a two-axis review of the changes made for a slice:
 
-Your review is advisory. The user will read it and decide which items to act on. Categorise honestly so they can triage without re-reading the whole diff.
+- **Spec axis** — does the diff satisfy the slice's `spec.md`? Handled by `spec-reviewer`.
+- **Standards axis** — does the diff follow the repo's documented coding standards? Handled by `csharp-reviewer` and/or `react-reviewer` depending on which languages the diff touches.
+
+The sub-agents run **in parallel** so neither pollutes the other's context. You merge their findings into a single `review.md`, axis-separated. You do NOT make code changes, commit, or modify the branch.
+
+Your review is advisory. The user will read it and decide which items to act on.
 
 ## Step 1 — Identify the slice
 
@@ -19,118 +24,74 @@ Otherwise, infer from context:
 
 Do not proceed until the slice is confirmed.
 
-## Step 2 — Read all inputs
-
-Read, in order:
-
-- The slice's `spec.md` — the acceptance criteria you will check against
-- The slice's `plan.md` — the intended files changed and implementation approach
-- The slice's `learnings.md` — implementer notes on deviations and surprises
-- The epic's `spec.md` — scope and non-goals
-- The root `CLAUDE.md` — repo conventions and component doc pointers
-- All steering docs under `.claude/docs/steering/` — coding guidelines, testing strategy, CI patterns, and any others present
-- The relevant component doc(s) under `.claude/docs/components/` for the areas touched
-
-## Step 3 — Get the diff
+## Step 2 — Get the diff and classify touched files
 
 Determine the base branch (default `main`). Run:
 
 ```
-git diff <base>...<current-branch>
+git diff --name-only <base>...<current-branch>
 ```
 
-Read the full diff. Note every file added, modified, or deleted.
+Classify the resulting file list:
 
-## Step 4 — Run quality checks
+- **C# files** — `*.cs`, `*.csproj`, `*.razor`, `*.sln`, `Directory.*.props`/`targets`, anywhere under `src/` outside `src/Worms.Hub.Web/`.
+- **Web files** — anything under `src/Worms.Hub.Web/`.
+- **Other** — migrations, Docker, infra, docs, CI workflow files. These are still part of the spec review, but no language reviewer runs for them.
 
-Run the build and lint for every component touched by the diff. Use the make targets:
+Also note which component(s) the C# files belong to (e.g. `Worms.Cli`, `Worms.Hub.Gateway`) so you can pass that hint to `csharp-reviewer`.
 
-- `.NET` code present: `dotnet build` the affected solution/project — must exit clean. The repo sets `TreatWarningsAsErrors` and runs Roslynator; any warning is a **Blocker**.
-- Web code present (`src/Worms.Hub.Web/`): `make web.lint` — ESLint and `tsc --noEmit` must both pass. Any error is a **Blocker**.
+## Step 3 — Dispatch sub-agents in parallel
 
-Record the exact output of any failing command as evidence for the finding.
+Send **one message** with multiple `Agent` tool calls so they run concurrently:
 
-## Step 5 — Review the diff
+1. **Always** spawn `spec-reviewer` with:
+   - The slice directory path.
+   - The base branch and current branch.
 
-### 5a — Acceptance criteria
+2. **If any C# files changed**, spawn `csharp-reviewer` with:
+   - The base branch and current branch.
+   - The list of C# files touched.
+   - The component(s) those files belong to.
 
-For each acceptance criterion in the slice's `spec.md`, determine whether the diff satisfies it. Verify against the actual diff — read the specific file and line in the diff to confirm. Do not infer satisfaction from the plan's intended structure or from what you expect the implementation to have done. Mark each criterion MET, PARTIAL, or NOT MET with a file:line citation.
+3. **If any web files changed**, spawn `react-reviewer` with:
+   - The base branch and current branch.
+   - The list of web files touched (paths under `src/Worms.Hub.Web/`).
 
-### 5b — Scope
+Do not duplicate the sub-agents' work in the main context — let them read the standards docs and the diff themselves.
 
-Start by listing every file that appears in the diff. Then compare that list against the plan's "Files to Create / Modify" table.
+## Step 4 — Merge into review.md
 
-- Flag files in the diff that are not in the plan.
-- Flag planned files that are absent from the diff.
-- Flag changes that go beyond what the plan describes for a file.
+Once all sub-agents have returned, write `review.md` in the slice directory using the template below. Preserve each sub-agent's findings verbatim within its section — do not rerank across axes and do not collapse multiple axes into a single severity list. Renumber findings only if needed to keep them unique within their axis (e.g. `Spec B1`, `C# B1`, `Web B1` are all fine; if the spec reviewer returned no findings, the section is "None").
 
-Changes not in the plan are not automatically wrong — but they need a reason. Check `learnings.md` first; if the deviation is explained there, note it as resolved. If it is unexplained, raise it as a finding.
-
-### 5c — Coding guidelines
-
-Check the diff for violations of the coding guidelines and CI patterns in `.claude/docs/steering/`
-
-For any CI-related changes (new jobs, job conditions, change-detection gates, triggers), cross-reference the change against `.claude/docs/steering/ci-patterns.md` — do not evaluate correctness from spec wording alone. A criterion like "job skips on unrelated changes" may conflict with repo-wide CI conventions even if the spec asked for it.
-
-For web code, check against the ESLint config and Prettier settings in `src/Worms.Hub.Web/`.
-
-### 5d — Tests
-
-Check the diff against `.claude/docs/steering/testing-strategy.md`:
-
-## Step 6 — Write review.md
-
-Write `review.md` in the same directory as the slice's `spec.md` and `plan.md`, using the template below.
+Write a one-paragraph verdict that summarises both axes honestly: a Spec-pass / Standards-fail change reads differently from the reverse, and the verdict should make that clear.
 
 ```markdown
 # Review — [Slice Name]
 
 ## Verdict
 
-[One paragraph. Does the implementation satisfy the spec? Any blockers the user must address before merging?]
+[One paragraph. Summarise both axes: does the implementation satisfy the spec? Does it follow the standards? Any blockers the user must address before merging?]
 
-## Acceptance Criteria
+## Spec
 
-| Criterion | Status | Evidence |
-|---|---|---|
-| [criterion from spec] | MET / PARTIAL / NOT MET | file:line or explanation |
+[Verbatim from spec-reviewer: Acceptance Criteria table, Blockers, Suggestions, Nitpicks. If a sub-section is empty, write "None".]
 
-## Scope
+## C# Standards
 
-[Does the diff match the plan's Files to Create / Modify table? List anything outside scope, with a note on whether learnings.md explains it.]
+[Verbatim from csharp-reviewer, including the build PASS/FAIL line. Omit this whole section if csharp-reviewer was not dispatched.]
 
-## Blockers
+## Web Standards
 
-[Zero or more entries, numbered B1, B2, … Use the finding format below.]
-
-## Suggestions
-
-[Zero or more entries, numbered S1, S2, … Same format.]
-
-## Nitpicks
-
-[Zero or more entries, numbered N1, N2, … Same format.]
-
-### Finding format
-
-#### B1 — [short title]
-
-- **File:** `path/to/file:line`
-- **Issue:** One sentence describing what is wrong.
-- **Fix:** Short direction for the fix.
-- **Decision:** — *(pending)*
-
-## Tests
-
-[What test coverage was added or changed. Any coverage gaps. Any padding tests that should be removed or rewritten. Any fragile patterns.]
+[Verbatim from react-reviewer, including the lint PASS/FAIL line. Omit this whole section if react-reviewer was not dispatched.]
 
 ## Recommended Actions
 
-[For every finding, state your recommended action and a one-line reason:]
+[For every finding across all axes, state your recommended action and a one-line reason. Reference findings by axis-prefixed ID:]
 
-- **B1** — Accept — [why the fix is clearly right]
-- **S1** — Decline — [why it's not worth it or out of scope]
-- **N1** — Accept — [reason]
+- **Spec B1** — Accept — [why the fix is clearly right]
+- **C# B1** — Accept — [reason]
+- **C# S1** — Decline — [why it's not worth it or out of scope]
+- **Web N1** — Accept — [reason]
 
 Valid actions: `Accept` or `Decline`. Cover every finding.
 ```
@@ -138,9 +99,9 @@ Valid actions: `Accept` or `Decline`. Cover every finding.
 ## Rules
 
 - Write only `review.md`. Do not edit code, commit, or touch the branch.
+- Dispatch sub-agents in parallel in a single message — not sequentially.
+- The orchestrator (you) does not re-do the sub-agents' analysis. Your job is dispatch, merge, verdict, and recommended actions.
 - Stay in scope: review only files in the diff. Do not audit the rest of the repo.
-- Ignore process files in the diff (`learnings.md`, `plan.md`, `spec.md`, `review.md`) — these are workflow artefacts, not feature code.
-- Be specific. "Error handling could be improved" is not useful; "`GifCreator.cs:42` does not handle the case where `frames` is empty" is.
+- Ignore process files (`learnings.md`, `plan.md`, `spec.md`, `review.md`) when reasoning about scope — these are workflow artefacts, not feature code.
 - Match the bar the spec set. Do not raise production-grade concerns (HA, exhaustive logging, observability) the spec did not ask for.
-- Categorise honestly. A Blocker genuinely breaks a spec criterion or the build. A Suggestion is meaningful improvement. A Nitpick is style. Do not inflate severity.
-- Every finding must cite a line read from the actual current file. Do not raise a finding based on plan code examples, prior knowledge, or inference. A suggestion stating "X is missing" or "Y deviates from convention" must quote the actual file at the relevant location — if you have not read that file, read it before raising the finding. If the implementation already matches the desired state, do not raise the finding at all.
+- If a sub-agent returns nothing in a category, write "None" in that sub-section — don't omit it (except for whole axes that weren't dispatched).

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -40,63 +40,38 @@ This ensures the spec accurately reflects the epic's intent, the system's bounda
 
 The default position is always the simplest thing that meets the stated need.
 
-Before probing for detail, identify the simplest version of the slice and present it to the user. Then identify any aspects of the request that could be implemented in a more complex or robust way — things like validation, error handling, configuration options, edge case coverage, or extensibility. For each of these, ask the user whether they want it included. Do not assume more is better.
+Before probing for detail, identify the simplest version of the slice and present it to the user. Then identify any aspects of the request that could be implemented in a more complex or robust way — things like validation, error handling, configuration options, edge case coverage, or extensibility.
+
+Walk through these one at a time, asking the user whether each should be included. For each one, give your recommended answer (usually "leave it out for this slice") with a brief reason, so the user can react to a concrete proposal. Ask one question per turn and wait for the answer before moving to the next — do not bundle them into a single list. If a question can be answered by exploring the codebase rather than asking the user, do that instead. Do not assume more is better.
 
 If the user's initial request already contains complexity that isn't strictly necessary to deliver the slice, surface that and ask whether it can be simplified or deferred to a later slice.
 
-Wait for the user's answers before continuing.
-
 ## Step 4 — Grill the user until the spec is watertight
 
-This step is iterative. You must complete multiple rounds of questioning. Do not move to Step 5 until every question has been answered.
+Interview the user relentlessly about every aspect of this slice until you reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. Follow each branch where it leads — if a happy-path question surfaces an error case or edge case, chase it down then rather than deferring it to a later "round".
 
-### Round A — Core behaviour
+**How to ask:**
 
-Ask about anything unclear in the happy path:
+- Ask questions **one at a time** — never bundle multiple questions into a single turn. Wait for the answer before moving on.
+- For each question, **provide your recommended answer** along with the question, so the user can react to a concrete proposal rather than starting from a blank slate. Explain briefly why you recommend it.
+- If a question can be answered by **exploring the codebase**, explore it instead of asking the user. Only ask when the answer genuinely requires the user's intent or knowledge.
+- After each answer, if the spec content is now settled for that point, fold it into the relevant section straight away rather than batching at the end.
 
-- Which components or projects are affected
-- What data flows in and out, and in what format
-- How the user discovers or triggers the feature
-- What "success" looks like from the user's perspective
+**Areas to make sure you cover.** This is not a script to read through in order — it's a checklist of categories the spec must address before you can exit this step. Use it to notice gaps that the decision-tree walk would otherwise miss.
 
-Wait for answers. Do not proceed until each question has a response.
+- **Core behaviour and happy path** — which components/projects are affected; what data flows in and out and in what format; how the user discovers or triggers the feature; what "success" looks like from the user's perspective.
+- **Error cases and failure modes** — for every operation the slice performs: what if required data is missing or malformed; what if a network call, database query, or external service fails; what if the user triggers the action in the wrong state or without permission; what if two actions happen concurrently.
+- **Edge cases and boundaries** — empty / zero states; single vs. many; large data and input-size limits; ordering and timing (sequence, out-of-order events); transitions (navigate away, refresh, cancel mid-flow); repeated actions (double-submit, duplicate event processing); stale data (acting on data that has since changed).
 
-### Round B — Error cases and failure modes
+For each item the slice touches, confirm the expected behaviour — do not leave it as "TBD". If something genuinely doesn't apply to this slice (e.g. there are no concurrency concerns because the slice is read-only), note that and move on.
 
-For every operation the slice performs, ask what should happen when it goes wrong:
-
-- What if the required data is missing or malformed?
-- What if a network call, database query, or external service fails?
-- What if the user triggers the action in the wrong state or without permission?
-- What if two actions happen concurrently?
-
-Wait for answers. Do not proceed until each question has a response.
-
-### Round C — Edge cases and boundaries
-
-Systematically probe the edges. Work through each category and ask any that apply:
-
-- **Empty / zero states** — what does the UI or response look like with no data?
-- **Single vs. many** — does behaviour change with exactly one item vs. a list?
-- **Large data** — are there limits on input size, list length, or payload?
-- **Ordering and timing** — does sequence matter? Can events arrive out of order?
-- **Transitions** — what happens mid-flow if the user navigates away, refreshes, or cancels?
-- **Repeated actions** — what if the user submits twice, or the same event is processed twice?
-- **Stale data** — can the user act on data that has since changed?
-
-For each edge case identified, confirm the expected behaviour — do not leave it as "TBD".
-
-Wait for answers. Do not proceed until each question has a response.
-
-### Round D — Scope and deferral check
-
-After rounds A–C, review every answer and ask yourself: are there any remaining ambiguities, implicit assumptions, or "it depends" answers that have not been pinned down? If yes, ask those questions now. Repeat this check until the answer is no.
+**Scope and deferral sweep.** When you believe you're done, review every answer and ask yourself: are there any remaining ambiguities, implicit assumptions, or "it depends" answers that have not been pinned down? If yes, ask those questions now (one at a time, with a recommended answer). Repeat the sweep until the answer is no.
 
 Do not proceed to Step 5 until you can answer "yes" to all of the following:
 
 - Every requirement has a clear, unambiguous description.
 - Every error case has a specified outcome.
-- Every edge case identified in Round C either has a defined behaviour or has been explicitly deferred by the user.
+- Every edge case surfaced during the interview either has a defined behaviour or has been explicitly deferred by the user.
 - The "Open Questions" section of the spec will either be empty or contain only items the user has deliberately chosen to leave unresolved.
 - If the slice includes any UI page or visual component: the design mockup has been reviewed and approved. If the design is still in flux, the spec must flag which visual details are pending and explicitly defer them rather than describing a placeholder that will need wholesale replacement later.
 - If the slice introduces a capability for the first time (a new test framework, a new CI job category, a new make target category): the setup of that infrastructure is explicitly included in scope and its files are listed. Do not assume it can be added invisibly.

--- a/.claude/docs/steering/testing-strategy.md
+++ b/.claude/docs/steering/testing-strategy.md
@@ -24,6 +24,7 @@ When a slice introduces non-trivial logic into the Gateway — calculators, form
 External dependencies are abstracted at the seam, not mocked at the call site:
 - File-system access goes through `System.IO.Abstractions` so unit tests use `MockFileSystem` instead of touching disk.
 - The Worms Armageddon process is abstracted by the Armageddon Game library, with a dedicated `Worms.Armageddon.Game.Fake` project providing a deterministic test double — units that orchestrate WA depend on the abstraction and are wired up against the fake in tests.
+- The database is abstracted behind `IRepository<T>` (and the per-aggregate repository interfaces) in `Worms.Hub.Storage`. Unit tests of Hub layers above storage — Gateway endpoints, Worker handlers, Queue producers/consumers — mock or fake those repository interfaces so the suite stays fast and in-process. Do not stand up Postgres for tests of code that only talks to the repository contract.
 
 ### Integration tests (`Category=Integration`)
 
@@ -37,7 +38,11 @@ These exercise real infrastructure end-to-end. They are excluded from the defaul
 
 Integration tests have prerequisites (Docker available; in some cases a real Worms Armageddon installation on the host) and are slower than unit tests, so they are not part of the default local loop. They are intentionally not mocked — the value of the tier comes from running real Docker, real Azurite queues, and the real WA binary under Wine.
 
-The database is in the same bucket: prefer integration tests against a real Postgres (the one from `docker compose`) over mocking repositories. Mocks of the data layer have historically diverged from production behaviour and hidden migration bugs.
+### Repository contract tests
+
+Repository implementations themselves are the one place where mocks cannot protect us — a `GamesRepository` that compiles fine against a stale SQL query will still pass any higher-layer test that mocks it, but will throw at runtime once the schema moves. Each repository needs a small, dedicated integration test suite (`Category=Integration`) that exercises every method against a real Postgres from `docker compose` and asserts on round-trip behaviour: insert via `Add`, read via `GetAll`/`GetById`, update via `Update`, and any bespoke query method on the per-aggregate repo. These tests guard against drift between SQL strings, the `XxxDb` mapping record, and the live schema. They are the reason higher layers can mock repositories safely — if a mock returns something the real repo could never produce, that's a code-review issue; if the real repo's SQL has drifted from the schema, the contract test catches it before production does.
+
+A slice that adds a new repository method must add a contract test for that method in the same slice. A slice that changes the schema must update affected contract tests, not defer them.
 
 ## What to write where
 


### PR DESCRIPTION
## Summary

Tightens the spec-driven workflow commands (`/epic`, `/spec`, `/implement-slice`, `/review`) based on observations from recent epics.

- **`/review`** — split into parallel axis-specific sub-agents (csharp-reviewer, react-reviewer, spec-reviewer) so reviews can run concurrently and each agent only carries the context it needs.
- **`/implement-slice`** — require TDD for behaviour; explicitly permit repo mocks when paired with contract tests, so the rule no longer reads as "no mocks ever".
- **`/epic` + `/spec`** — inline the grill-me interview style into the interrogation phases instead of cross-referencing it, so the commands are self-contained.
- **`/epic`** — require plan slices to be vertical tracer bullets cutting end-to-end through every relevant layer; reject horizontal layer slices (e.g. "build the schema", "build the API") and ask the user to spot them during review.

No code changes — docs and command/agent definitions only.

## Test plan

- [ ] Run `/epic` on a fresh feature and confirm plan.md slices come out vertical end-to-end, not layer-shaped
- [ ] Run `/review` and confirm the axis sub-agents launch in parallel and produce a coherent merged report
- [ ] Run `/implement-slice` on a slice that needs a repo mock and confirm the TDD guidance accepts it with a contract test
- [ ] Run `/spec` end-to-end and confirm the grill-me-style interrogation works without needing the separate skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)