### PR TITLE
feat: add Replay log tab to replay details page

### DIFF
--- a/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
+++ b/src/Worms.Hub.Gateway/API/DTOs/ReplayDtos.cs
@@ -42,7 +42,8 @@ internal sealed record ReplayDetailDto(
     string? Winner,
     IReadOnlyList<string>? Teams,
     IReadOnlyList<TurnDto>? Turns,
-    IReadOnlyList<PlacementDto>? Placements)
+    IReadOnlyList<PlacementDto>? Placements,
+    string? FullLog)
 {
     internal static ReplayDetailDto FromDomain(Replay replay, ReplayResource? parsed)
     {
@@ -71,7 +72,8 @@ internal sealed record ReplayDetailDto(
             replay.Winner,
             replay.Teams,
             turns,
-            placements);
+            placements,
+            replay.FullLog);
     }
 }
 

--- a/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
+++ b/src/Worms.Hub.Web/src/pages/GameDetailPage.tsx
@@ -23,9 +23,11 @@ import TableRow from '@mui/material/TableRow'
 import Typography from '@mui/material/Typography'
 import TimelineIcon from '@mui/icons-material/Timeline'
 import GpsFixedIcon from '@mui/icons-material/GpsFixed'
+import ArticleIcon from '@mui/icons-material/Article'
 import { monoFontFamily } from '../theme'
 import { gatewayUrl } from '../api'
 import { PlacementDto, PlacementPill, TeamDto } from './PlacementPill'
+import ReplayLogPanel from './ReplayLogPanel'
 
 interface WeaponDto {
     name: string
@@ -55,6 +57,7 @@ interface ReplayDetailDto {
     teams: string[] | null
     turns: TurnDto[] | null
     placements: PlacementDto[] | null
+    fullLog: string | null
 }
 
 interface LeagueDto {
@@ -458,6 +461,11 @@ function GameDetailPage() {
             label: 'Weapons',
             icon: <GpsFixedIcon sx={{ fontSize: 18 }} />,
             content: <WeaponsPanel turns={replay?.turns ?? null} />,
+        },
+        {
+            label: 'Replay log',
+            icon: <ArticleIcon sx={{ fontSize: 18 }} />,
+            content: <ReplayLogPanel log={replay?.fullLog ?? null} />,
         },
     ]
 

--- a/src/Worms.Hub.Web/src/pages/ReplayLogPanel.test.tsx
+++ b/src/Worms.Hub.Web/src/pages/ReplayLogPanel.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ReplayLogPanel from './ReplayLogPanel'
+
+describe('ReplayLogPanel', () => {
+    it('renders the supplied log text with line breaks preserved', () => {
+        const log = 'first line\nsecond line\nthird line'
+        render(<ReplayLogPanel log={log} />)
+
+        const pre = screen.getByText((_, node) => node?.tagName === 'PRE')
+        expect(pre.textContent).toBe(log)
+    })
+
+    it('shows the empty state when log is null', () => {
+        render(<ReplayLogPanel log={null} />)
+        expect(screen.getByText('No replay log available.')).toBeInTheDocument()
+    })
+
+    it('shows the empty state when log is an empty string', () => {
+        render(<ReplayLogPanel log="" />)
+        expect(screen.getByText('No replay log available.')).toBeInTheDocument()
+    })
+})

--- a/src/Worms.Hub.Web/src/pages/ReplayLogPanel.tsx
+++ b/src/Worms.Hub.Web/src/pages/ReplayLogPanel.tsx
@@ -1,0 +1,35 @@
+import Paper from '@mui/material/Paper'
+import Typography from '@mui/material/Typography'
+import { monoFontFamily } from '../theme'
+
+interface ReplayLogPanelProps {
+    log: string | null
+}
+
+function ReplayLogPanel({ log }: ReplayLogPanelProps) {
+    if (log === null || log.length === 0) {
+        return (
+            <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
+                <Typography color="text.secondary">No replay log available.</Typography>
+            </Paper>
+        )
+    }
+
+    return (
+        <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography
+                component="pre"
+                sx={{
+                    fontFamily: monoFontFamily,
+                    fontSize: 12,
+                    margin: 0,
+                    whiteSpace: 'pre',
+                }}
+            >
+                {log}
+            </Typography>
+        </Paper>
+    )
+}
+
+export default ReplayLogPanel


### PR DESCRIPTION
## Summary
- Expose `FullLog` on `ReplayDetailDto` so the API returns the raw replay log on both the list and single-replay endpoints.
- Add a `ReplayLogPanel` component that renders the log as plain monospace text with line breaks preserved, plus an empty state for missing/null logs.
- Wire the new panel into `GameDetailPage` as a third tab (`Replay log`, `ArticleIcon`) after Turn-by-turn and Weapons.

Closes #1354.

## Test plan
- [x] `dotnet build src/Worms.Hub.Gateway --warnaserror` clean
- [x] `make web.lint` clean
- [x] `make web.test` — 6 tests pass (3 new `ReplayLogPanel` cases: populated log, `null` log, empty string log)
- [x] Manual: open a processed replay in the web UI, confirm the third tab appears with `ArticleIcon`, click it, and verify the log renders in monospace with line breaks preserved
- [ ] Manual: confirm a processed replay with no stored log shows the "No replay log available." empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)