### PR TITLE
fix(gifs): sort extracted frames by filename before assembling GIF

### DIFF
--- a/.claude/docs/components/armageddon-gifs.md
+++ b/.claude/docs/components/armageddon-gifs.md
@@ -26,9 +26,10 @@ Returns the filename (not the full path) of the generated GIF.
 1. Computes `framesFolder` from `GameInfo.CaptureFolder` (where WA deposits extracted PNGs)
 2. Deletes any existing frames in that folder
 3. Calls `IWormsArmageddon.ExtractReplayFrames(...)` — this runs WA with `/getvideo` to dump PNG frames
-4. Assembles frames into a GIF using **ImageMagick** (`MagickImageCollection`)
-5. Quantises to 256 colours and optimises transparency
-6. Deletes the frame folder
+4. Lists frames via `Directory.GetFiles` and sorts ordinally by filename — `GetFiles` makes no ordering guarantee, and on Linux/ext4 (where wa-runner runs in Docker) the returned order can be arbitrary, so the sort is required to keep playback in sequence
+5. Assembles frames into a GIF using **ImageMagick** (`MagickImageCollection`)
+6. Quantises to 256 colours and optimises transparency
+7. Deletes the frame folder
 
 If WA produces no frames (no folder, or folder with zero PNGs), `GifCreator` throws `GifFrameExtractionFailedException` carrying the `ReplayPath` and `FramesFolder`. Callers (e.g. the WA Runner `Processor`) log the exception and continue — GIF generation is non-fatal to replay processing.
 

--- a/src/Worms.Armageddon.Gifs.Tests/GifCreatorShould.cs
+++ b/src/Worms.Armageddon.Gifs.Tests/GifCreatorShould.cs
@@ -1,6 +1,8 @@
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using ImageMagick;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
 using Worms.Armageddon.Game;
@@ -111,6 +113,98 @@ internal sealed class GifCreatorShould
 
         exception.ReplayPath.ShouldBe("/storage/replay.gjb");
         exception.FramesFolder.ShouldBe("/wa/User/Capture/replay.gjb");
+    }
+
+    [Test]
+    public async Task AssembleFramesInSortedOrderWhenFileSystemReturnsThemUnsorted()
+    {
+        // Directory.GetFiles makes no ordering guarantee — on Linux/ext4 it can return files
+        // in arbitrary order. This test simulates that by reversing the GetFiles result, and
+        // verifies the resulting GIF still plays frames in sorted (filename) order.
+        var gamePath = Path.Combine(_tempRoot, "wa");
+        var captureFolder = Path.Combine(gamePath, "User", "Capture", "sample");
+        _ = Directory.CreateDirectory(captureFolder);
+        var outputFolder = Path.Combine(_tempRoot, "output");
+        _ = Directory.CreateDirectory(outputFolder);
+        var replayPath = Path.Combine(_tempRoot, "sample.WAGame");
+        await File.WriteAllBytesAsync(replayPath, []);
+
+        var frameColors = new[] { MagickColors.Red, MagickColors.Lime, MagickColors.Blue };
+        var wa = Substitute.For<IWormsArmageddon>();
+        _ = wa.FindInstallation()
+            .Returns(
+                new GameInfo(
+                    true,
+                    Path.Combine(gamePath, "WA.exe"),
+                    "WA",
+                    new Version(1, 0, 0, 0),
+                    Path.Combine(gamePath, "User", "Schemes"),
+                    Path.Combine(gamePath, "User", "Games"),
+                    Path.Combine(gamePath, "User", "Capture")));
+        _ = wa.ExtractReplayFrames(
+                Arg.Any<string>(),
+                Arg.Any<uint>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<int>(),
+                Arg.Any<int>())
+            .Returns(Task.CompletedTask)
+            .AndDoes(_ => WriteColoredFrames(captureFolder, frameColors));
+
+        var fileSystem = BuildFileSystemWithReversedGetFiles();
+        var gifCreator = new GifCreator(wa, fileSystem);
+
+        var gifFileName = await gifCreator.CreateGif(
+            replayPath,
+            TimeSpan.FromSeconds(0),
+            TimeSpan.FromSeconds(1),
+            1,
+            outputFolder);
+
+        using var gif = new MagickImageCollection(Path.Combine(outputFolder, gifFileName));
+        gif.Count.ShouldBe(frameColors.Length);
+        for (var i = 0; i < frameColors.Length; i++)
+        {
+            var pixel = gif[i].GetPixels().GetPixel(0, 0).ToColor()!;
+            pixel.R.ShouldBe(frameColors[i].R);
+            pixel.G.ShouldBe(frameColors[i].G);
+            pixel.B.ShouldBe(frameColors[i].B);
+        }
+    }
+
+    private static void WriteColoredFrames(string folder, MagickColor[] colors)
+    {
+        _ = Directory.CreateDirectory(folder);
+        for (var i = 0; i < colors.Length; i++)
+        {
+            using var image = new MagickImage(colors[i], 16, 16);
+            image.Write(Path.Combine(folder, $"frame_{i:D3}.png"));
+        }
+    }
+
+    private static IFileSystem BuildFileSystemWithReversedGetFiles()
+    {
+        var real = new FileSystem();
+        var fileSystem = Substitute.For<IFileSystem>();
+        _ = fileSystem.Path.Returns(real.Path);
+        _ = fileSystem.File.Returns(real.File);
+
+        var directory = Substitute.For<IDirectory>();
+        _ = directory.Exists(Arg.Any<string>())
+            .Returns(c => real.Directory.Exists(c.ArgAt<string>(0)));
+        _ = directory.CreateDirectory(Arg.Any<string>())
+            .Returns(c => real.Directory.CreateDirectory(c.ArgAt<string>(0)));
+        directory.When(d => d.Delete(Arg.Any<string>(), Arg.Any<bool>()))
+            .Do(c => real.Directory.Delete(c.ArgAt<string>(0), c.ArgAt<bool>(1)));
+        _ = directory.GetFiles(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(
+                c => real.Directory
+                    .GetFiles(c.ArgAt<string>(0), c.ArgAt<string>(1))
+                    .OrderByDescending(f => f, StringComparer.Ordinal)
+                    .ToArray());
+        _ = fileSystem.Directory.Returns(directory);
+
+        return fileSystem;
     }
 
     private (GifCreator GifCreator, IFileSystem FileSystem, string GamePath) SetupFakeWa()

--- a/src/Worms.Armageddon.Gifs/GifCreator.cs
+++ b/src/Worms.Armageddon.Gifs/GifCreator.cs
@@ -60,7 +60,13 @@ public sealed class GifCreator(IWormsArmageddon wormsArmageddon, IFileSystem fil
             throw new GifFrameExtractionFailedException(replayPath, framesFolder);
         }
 
-        var frames = fileSystem.Directory.GetFiles(framesFolder, "*.png");
+        // Directory.GetFiles makes no ordering guarantee — on Linux/ext4 (the wa-runner
+        // container) it can return files in arbitrary order, which causes GIF frames to
+        // assemble out of sequence. WA names frames with a zero-padded counter, so an
+        // ordinal sort matches playback order.
+        var frames = fileSystem.Directory.GetFiles(framesFolder, "*.png")
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToArray();
         if (frames.Length == 0)
         {
             throw new GifFrameExtractionFailedException(replayPath, framesFolder);


### PR DESCRIPTION
## Summary
- `GifCreator` was passing frames to ImageMagick in whatever order `Directory.GetFiles` happened to return. That order is filesystem-dependent — on Linux/ext4 (which the wa-runner container runs on) it can be effectively arbitrary, causing assembled GIFs to jump between frames out of sequence.
- Sort the frame list ordinally by filename before assembly. WA names frames with a zero-padded counter (`video_NNNNNN.png`), so an ordinal sort matches playback order.
- Added a regression test that injects an `IFileSystem` whose `GetFiles` returns results in reverse order, writes three distinguishable solid-colour PNGs, and asserts the resulting GIF plays them back in sorted (filename) order.

## Test plan
- [x] `dotnet test src/Worms.Armageddon.Gifs.Tests` — 5/5 pass
- [x] New test fails without the sort and passes with it (verified by reverting the fix)
- [x] `dotnet build --warnaserror` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)