### PR TITLE
test(cli): add replay command tests (#1366)

### DIFF
--- a/.claude/docs/components/cli.md
+++ b/.claude/docs/components/cli.md
@@ -61,11 +61,14 @@ OpenTelemetry traces are started in `Program.Main` before DI setup. Each signifi
 
 ## Testing
 
-CLI unit tests live in `src/Worms.Cli.Tests` (NUnit + Shouldly). Tests drive the CLI through the same `CliStructure.BuildCommandLine()` root + DI container that production uses, via the `TestHost` composition root. `TestHost` overrides four production seams:
+CLI unit tests live in `src/Worms.Cli.Tests` (NUnit + Shouldly). Tests drive the CLI through the same `CliStructure.BuildCommandLine()` root + DI container that production uses, via the `TestHost` composition root. `TestHost` overrides five production seams:
 
 - `IHttpClientFactory` — backed by a recording handler (`RecordingHttpMessageHandler`) that captures requests and returns scripted responses.
 - `IFileSystem` — `MockFileSystem` so `TokenStore` reads and writes in memory.
 - `IBrowserLauncher` — recording test impl; no real browser is launched. The interface wraps the original static `BrowserLauncher` so production behaviour is unchanged.
 - `TimeProvider` — `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` so the device-code polling loop and its timeout can be fast-forwarded deterministically.
+- `IFolderOpener` — `RecordingFolderOpener` captures the folder paths passed to `OpenFolder` so tests can assert on which folder was opened without launching a real file manager.
+
+`TestHost` also registers the `Worms.Armageddon.Game.Fake` services so `IWormsArmageddon` is the in-memory fake — installed by default; opt in to a 'not installed' fake via `new TestHost(wormsInstalled: false)`. The fake is wrapped in a small recording decorator (`RecordingWormsArmageddon`) so tests can observe which `PlayReplay` calls the CLI issued.
 
 When adding tests for a new command, extend this project rather than creating a new one. Test classes follow the `<TypeUnderTest>Should` convention; test methods describe a behaviour.

--- a/src/Worms.Armageddon.Game.Fake/Installed.cs
+++ b/src/Worms.Armageddon.Game.Fake/Installed.cs
@@ -60,7 +60,7 @@ internal sealed class Installed : IWormsArmageddon
         if (_fileSystem.File.Exists(replayPath))
         {
             _fileSystem.File.WriteAllBytes(
-                replayPath.Replace(".WAGame", ".log", StringComparison.InvariantCulture),
+                replayPath.Replace(".WAGame", ".log", StringComparison.InvariantCultureIgnoreCase),
                 []);
         }
 

--- a/src/Worms.Cli.Tests/Commands/BrowseReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/BrowseReplayShould.cs
@@ -1,7 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
-using Worms.Armageddon.Game;
 
 namespace Worms.Cli.Tests.Commands;
 
@@ -12,7 +10,7 @@ internal sealed class BrowseReplayShould
     public async Task OpenTheReplayFolderWhenWormsIsInstalled()
     {
         using var host = new TestHost();
-        var expectedFolder = host.Services.GetRequiredService<IWormsArmageddon>().FindInstallation().ReplayFolder;
+        var expectedFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
 
         var exitCode = await host.Run("browse", "replay");
 

--- a/src/Worms.Cli.Tests/Commands/BrowseReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/BrowseReplayShould.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Armageddon.Game;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class BrowseReplayShould
+{
+    [Test]
+    public async Task OpenTheReplayFolderWhenWormsIsInstalled()
+    {
+        using var host = new TestHost();
+        var expectedFolder = host.Services.GetRequiredService<IWormsArmageddon>().FindInstallation().ReplayFolder;
+
+        var exitCode = await host.Run("browse", "replay");
+
+        exitCode.ShouldBe(0);
+        host.FolderOpener.OpenedFolders.ShouldHaveSingleItem()
+            .ShouldBe(expectedFolder);
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenWormsIsNotInstalled()
+    {
+        using var host = new TestHost(wormsInstalled: false);
+
+        var exitCode = await host.Run("browse", "replay");
+
+        exitCode.ShouldBe(1);
+        host.FolderOpener.OpenedFolders.ShouldBeEmpty();
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
@@ -12,14 +12,13 @@ internal sealed class DeleteReplayShould
     {
         using var host = new TestHost();
         var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
-        var fs = host.FileSystem;
         var log = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
 
         var exitCode = await host.Run("delete", "replay", "2024-01-02");
 
         exitCode.ShouldBe(0);
-        fs.File.Exists(wagame).ShouldBeFalse();
-        fs.File.Exists(log).ShouldBeFalse();
+        host.FileSystem.File.Exists(wagame).ShouldBeFalse();
+        host.FileSystem.File.Exists(log).ShouldBeFalse();
     }
 
     [Test]
@@ -27,12 +26,11 @@ internal sealed class DeleteReplayShould
     {
         using var host = new TestHost();
         var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var fs = host.FileSystem;
 
         var exitCode = await host.Run("delete", "replay", "2024-01-02");
 
         exitCode.ShouldBe(0);
-        fs.File.Exists(wagame).ShouldBeFalse();
+        host.FileSystem.File.Exists(wagame).ShouldBeFalse();
     }
 
     [Test]
@@ -50,12 +48,11 @@ internal sealed class DeleteReplayShould
         using var host = new TestHost();
         var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
         var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
-        var fs = host.FileSystem;
 
         var exitCode = await host.Run("delete", "replay", "*");
 
         exitCode.ShouldBe(1);
-        fs.File.Exists(wagame1).ShouldBeTrue();
-        fs.File.Exists(wagame2).ShouldBeTrue();
+        host.FileSystem.File.Exists(wagame1).ShouldBeTrue();
+        host.FileSystem.File.Exists(wagame2).ShouldBeTrue();
     }
 }

--- a/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
@@ -1,5 +1,3 @@
-using System.IO.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
 using Worms.Cli.Tests.Fakes;
@@ -14,7 +12,7 @@ internal sealed class DeleteReplayShould
     {
         using var host = new TestHost();
         var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var fs = host.FileSystem;
         var log = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
 
         var exitCode = await host.Run("delete", "replay", "2024-01-02");
@@ -29,7 +27,7 @@ internal sealed class DeleteReplayShould
     {
         using var host = new TestHost();
         var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var fs = host.FileSystem;
 
         var exitCode = await host.Run("delete", "replay", "2024-01-02");
 
@@ -52,7 +50,7 @@ internal sealed class DeleteReplayShould
         using var host = new TestHost();
         var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
         var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var fs = host.FileSystem;
 
         var exitCode = await host.Run("delete", "replay", "*");
 

--- a/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
@@ -1,0 +1,63 @@
+using System.IO.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class DeleteReplayShould
+{
+    [Test]
+    public async Task DeleteBothTheWAgameAndItsLog()
+    {
+        using var host = new TestHost();
+        var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var log = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+
+        var exitCode = await host.Run("delete", "replay", "2024-01-02");
+
+        exitCode.ShouldBe(0);
+        fs.File.Exists(wagame).ShouldBeFalse();
+        fs.File.Exists(log).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task DeleteTheWAgameWhenNoLogPresent()
+    {
+        using var host = new TestHost();
+        var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+
+        var exitCode = await host.Run("delete", "replay", "2024-01-02");
+
+        exitCode.ShouldBe(0);
+        fs.File.Exists(wagame).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenNoReplayMatchesASpecificName()
+    {
+        using var host = new TestHost();
+        var exitCode = await host.Run("delete", "replay", "missing");
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenMultipleReplaysMatch()
+    {
+        using var host = new TestHost();
+        var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+
+        var exitCode = await host.Run("delete", "replay", "*");
+
+        exitCode.ShouldBe(1);
+        fs.File.Exists(wagame1).ShouldBeTrue();
+        fs.File.Exists(wagame2).ShouldBeTrue();
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/DeleteReplayShould.cs
@@ -11,26 +11,27 @@ internal sealed class DeleteReplayShould
     public async Task DeleteBothTheWAgameAndItsLog()
     {
         using var host = new TestHost();
-        var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
-        var log = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+        var replayFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
 
         var exitCode = await host.Run("delete", "replay", "2024-01-02");
 
         exitCode.ShouldBe(0);
-        host.FileSystem.File.Exists(wagame).ShouldBeFalse();
-        host.FileSystem.File.Exists(log).ShouldBeFalse();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-01-02 10.00.00 [Offline] One, Two.WAgame")).ShouldBeFalse();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-01-02 10.00.00 [Offline] One, Two.log")).ShouldBeFalse();
     }
 
     [Test]
     public async Task DeleteTheWAgameWhenNoLogPresent()
     {
         using var host = new TestHost();
-        var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        var replayFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
 
         var exitCode = await host.Run("delete", "replay", "2024-01-02");
 
         exitCode.ShouldBe(0);
-        host.FileSystem.File.Exists(wagame).ShouldBeFalse();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-01-02 10.00.00 [Offline] One, Two.WAgame")).ShouldBeFalse();
     }
 
     [Test]
@@ -46,13 +47,14 @@ internal sealed class DeleteReplayShould
     public async Task ReturnNonZeroWhenMultipleReplaysMatch()
     {
         using var host = new TestHost();
-        var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
+        var replayFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
 
         var exitCode = await host.Run("delete", "replay", "*");
 
         exitCode.ShouldBe(1);
-        host.FileSystem.File.Exists(wagame1).ShouldBeTrue();
-        host.FileSystem.File.Exists(wagame2).ShouldBeTrue();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-01-02 10.00.00 [Offline] One, Two.WAgame")).ShouldBeTrue();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-02-15 12.00.00 [Offline] One, Two.WAgame")).ShouldBeTrue();
     }
 }

--- a/src/Worms.Cli.Tests/Commands/GetReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/GetReplayShould.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class GetReplayShould
+{
+    [TestCase("replay")]
+    [TestCase("replays")]
+    [TestCase("WAgame")]
+    public async Task PrintReplayWithMatchingLog(string alias)
+    {
+        using var host = new TestHost();
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", alias, "2024-01-02");
+
+        exitCode.ShouldBe(0);
+        console.Output.ToString().ShouldContain("2024-01-02 10.00.00");
+    }
+
+    [Test]
+    public async Task PrintReplayEvenWhenNoLogPresent()
+    {
+        using var host = new TestHost();
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", "replay", "2024-01-02");
+
+        exitCode.ShouldBe(0);
+        console.Output.ToString().ShouldContain("Replay has not been processed");
+    }
+
+    [Test]
+    public async Task OrderResultsByDateDescending()
+    {
+        using var host = new TestHost();
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", "replay", "*");
+
+        exitCode.ShouldBe(0);
+        var output = console.Output.ToString();
+        output.IndexOf("2024-02-15", StringComparison.Ordinal)
+            .ShouldBeLessThan(output.IndexOf("2024-01-02", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenNoReplayMatchesASpecificName()
+    {
+        using var host = new TestHost();
+
+        var exitCode = await host.Run("get", "replay", "nonexistent");
+
+        exitCode.ShouldBe(1);
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
@@ -1,8 +1,5 @@
-using System.IO.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
-using Worms.Armageddon.Game;
 using Worms.Cli.Tests.Fakes;
 
 namespace Worms.Cli.Tests.Commands;
@@ -15,7 +12,7 @@ internal sealed class ProcessReplayShould
     {
         using var host = new TestHost();
         var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var fs = host.FileSystem;
         var expectedLog = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
 
         var exitCode = await host.Run("process", "replay", "2024-01-02");
@@ -30,7 +27,7 @@ internal sealed class ProcessReplayShould
         using var host = new TestHost();
         var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
         var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var fs = host.FileSystem;
         var expectedLog1 = wagame1.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
         var expectedLog2 = wagame2.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
 
@@ -45,11 +42,11 @@ internal sealed class ProcessReplayShould
     public async Task ReturnZeroWhenNoMatch()
     {
         using var host = new TestHost();
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var fs = host.FileSystem;
 
         var exitCode = await host.Run("process", "replay", "missing");
 
         exitCode.ShouldBe(0);
-        fs.Directory.GetFiles(host.Services.GetRequiredService<IWormsArmageddon>().FindInstallation().ReplayFolder).ShouldBeEmpty();
+        fs.Directory.GetFiles(host.WormsArmageddon.FindInstallation().ReplayFolder).ShouldBeEmpty();
     }
 }

--- a/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
@@ -12,13 +12,12 @@ internal sealed class ProcessReplayShould
     {
         using var host = new TestHost();
         var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var fs = host.FileSystem;
         var expectedLog = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
 
         var exitCode = await host.Run("process", "replay", "2024-01-02");
 
         exitCode.ShouldBe(0);
-        fs.File.Exists(expectedLog).ShouldBeTrue();
+        host.FileSystem.File.Exists(expectedLog).ShouldBeTrue();
     }
 
     [Test]
@@ -27,26 +26,24 @@ internal sealed class ProcessReplayShould
         using var host = new TestHost();
         var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
         var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
-        var fs = host.FileSystem;
         var expectedLog1 = wagame1.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
         var expectedLog2 = wagame2.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
 
         var exitCode = await host.Run("process", "replay", "*");
 
         exitCode.ShouldBe(0);
-        fs.File.Exists(expectedLog1).ShouldBeTrue();
-        fs.File.Exists(expectedLog2).ShouldBeTrue();
+        host.FileSystem.File.Exists(expectedLog1).ShouldBeTrue();
+        host.FileSystem.File.Exists(expectedLog2).ShouldBeTrue();
     }
 
     [Test]
     public async Task ReturnZeroWhenNoMatch()
     {
         using var host = new TestHost();
-        var fs = host.FileSystem;
 
         var exitCode = await host.Run("process", "replay", "missing");
 
         exitCode.ShouldBe(0);
-        fs.Directory.GetFiles(host.WormsArmageddon.FindInstallation().ReplayFolder).ShouldBeEmpty();
+        host.FileSystem.Directory.GetFiles(host.WormsArmageddon.FindInstallation().ReplayFolder).ShouldBeEmpty();
     }
 }

--- a/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
@@ -11,39 +11,39 @@ internal sealed class ProcessReplayShould
     public async Task GenerateLogForAReplayWithoutOne()
     {
         using var host = new TestHost();
-        var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var expectedLog = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+        var replayFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
 
         var exitCode = await host.Run("process", "replay", "2024-01-02");
 
         exitCode.ShouldBe(0);
-        host.FileSystem.File.Exists(expectedLog).ShouldBeTrue();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-01-02 10.00.00 [Offline] One, Two.log")).ShouldBeTrue();
     }
 
     [Test]
     public async Task GenerateLogForEveryMatchingReplay()
     {
         using var host = new TestHost();
-        var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
-        var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
-        var expectedLog1 = wagame1.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
-        var expectedLog2 = wagame2.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+        var replayFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
 
         var exitCode = await host.Run("process", "replay", "*");
 
         exitCode.ShouldBe(0);
-        host.FileSystem.File.Exists(expectedLog1).ShouldBeTrue();
-        host.FileSystem.File.Exists(expectedLog2).ShouldBeTrue();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-01-02 10.00.00 [Offline] One, Two.log")).ShouldBeTrue();
+        host.FileSystem.File.Exists(Path.Combine(replayFolder, "2024-02-15 12.00.00 [Offline] One, Two.log")).ShouldBeTrue();
     }
 
     [Test]
     public async Task ReturnZeroWhenNoMatch()
     {
         using var host = new TestHost();
+        var replayFolder = host.WormsArmageddon.FindInstallation().ReplayFolder;
 
         var exitCode = await host.Run("process", "replay", "missing");
 
         exitCode.ShouldBe(0);
-        host.FileSystem.Directory.GetFiles(host.WormsArmageddon.FindInstallation().ReplayFolder).ShouldBeEmpty();
+        host.FileSystem.Directory.GetFiles(replayFolder).ShouldBeEmpty();
     }
 }

--- a/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/ProcessReplayShould.cs
@@ -1,0 +1,55 @@
+using System.IO.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Armageddon.Game;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class ProcessReplayShould
+{
+    [Test]
+    public async Task GenerateLogForAReplayWithoutOne()
+    {
+        using var host = new TestHost();
+        var wagame = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var expectedLog = wagame.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+
+        var exitCode = await host.Run("process", "replay", "2024-01-02");
+
+        exitCode.ShouldBe(0);
+        fs.File.Exists(expectedLog).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task GenerateLogForEveryMatchingReplay()
+    {
+        using var host = new TestHost();
+        var wagame1 = ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+        var wagame2 = ReplayFixtures.WriteReplay(host, "2024-02-15 12.00.00 [Offline] One, Two");
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var expectedLog1 = wagame1.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+        var expectedLog2 = wagame2.Replace(".WAgame", ".log", StringComparison.OrdinalIgnoreCase);
+
+        var exitCode = await host.Run("process", "replay", "*");
+
+        exitCode.ShouldBe(0);
+        fs.File.Exists(expectedLog1).ShouldBeTrue();
+        fs.File.Exists(expectedLog2).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task ReturnZeroWhenNoMatch()
+    {
+        using var host = new TestHost();
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+
+        var exitCode = await host.Run("process", "replay", "missing");
+
+        exitCode.ShouldBe(0);
+        fs.Directory.GetFiles(host.Services.GetRequiredService<IWormsArmageddon>().FindInstallation().ReplayFolder).ShouldBeEmpty();
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/ViewReplayShould.cs
+++ b/src/Worms.Cli.Tests/Commands/ViewReplayShould.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class ViewReplayShould
+{
+    [Test]
+    public async Task LaunchTheReplayInWormsArmageddon()
+    {
+        using var host = new TestHost();
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
+
+        var exitCode = await host.Run("view", "replay", "2024-01-02");
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.PlayReplayCalls.ShouldHaveSingleItem();
+        var call = host.WormsArmageddon.PlayReplayCalls[0];
+        call.Path.ShouldEndWith("2024-01-02 10.00.00 [Offline] One, Two.WAgame");
+        call.StartTime.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task LaunchTheReplayAtTheRequestedTurn()
+    {
+        using var host = new TestHost();
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two", ReplayFixtures.MultiTurnLog);
+
+        var exitCode = await host.Run("view", "replay", "2024-01-02", "--turn", "2");
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.PlayReplayCalls.ShouldHaveSingleItem();
+        var call = host.WormsArmageddon.PlayReplayCalls[0];
+        call.StartTime.ShouldBe(new TimeSpan(0, 0, 9, 59, 80));
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenNoReplayMatchesASpecificName()
+    {
+        using var host = new TestHost();
+
+        var exitCode = await host.Run("view", "replay", "nonexistent");
+
+        exitCode.ShouldBe(1);
+        host.WormsArmageddon.PlayReplayCalls.ShouldBeEmpty();
+    }
+}

--- a/src/Worms.Cli.Tests/Fakes/ConsoleOutputScope.cs
+++ b/src/Worms.Cli.Tests/Fakes/ConsoleOutputScope.cs
@@ -1,0 +1,16 @@
+namespace Worms.Cli.Tests.Fakes;
+
+internal sealed class ConsoleOutputScope : IDisposable
+{
+    private readonly TextWriter _previous;
+
+    public StringWriter Output { get; } = new();
+
+    public ConsoleOutputScope()
+    {
+        _previous = Console.Out;
+        Console.SetOut(Output);
+    }
+
+    public void Dispose() => Console.SetOut(_previous);
+}

--- a/src/Worms.Cli.Tests/Fakes/RecordingFolderOpener.cs
+++ b/src/Worms.Cli.Tests/Fakes/RecordingFolderOpener.cs
@@ -1,0 +1,10 @@
+using Worms.Cli.Resources.Local.Folders;
+
+namespace Worms.Cli.Tests.Fakes;
+
+internal sealed class RecordingFolderOpener : IFolderOpener
+{
+    public List<string> OpenedFolders { get; } = [];
+
+    public void OpenFolder(string folderPath) => OpenedFolders.Add(folderPath);
+}

--- a/src/Worms.Cli.Tests/Fakes/RecordingWormsArmageddon.cs
+++ b/src/Worms.Cli.Tests/Fakes/RecordingWormsArmageddon.cs
@@ -1,0 +1,37 @@
+using Worms.Armageddon.Game;
+
+namespace Worms.Cli.Tests.Fakes;
+
+internal sealed class RecordingWormsArmageddon(IWormsArmageddon inner) : IWormsArmageddon
+{
+    internal sealed record PlayReplayCall(string Path, TimeSpan? StartTime);
+
+    public List<PlayReplayCall> PlayReplayCalls { get; } = [];
+
+    public GameInfo FindInstallation() => inner.FindInstallation();
+
+    public Task Host() => inner.Host();
+
+    public Task GenerateReplayLog(string replayPath) => inner.GenerateReplayLog(replayPath);
+
+    public Task PlayReplay(string replayPath)
+    {
+        PlayReplayCalls.Add(new PlayReplayCall(replayPath, null));
+        return inner.PlayReplay(replayPath);
+    }
+
+    public Task PlayReplay(string replayPath, TimeSpan startTime)
+    {
+        PlayReplayCalls.Add(new PlayReplayCall(replayPath, startTime));
+        return inner.PlayReplay(replayPath, startTime);
+    }
+
+    public Task ExtractReplayFrames(
+        string replayPath,
+        uint fps,
+        TimeSpan startTime,
+        TimeSpan endTime,
+        int xResolution = 640,
+        int yResolution = 480) =>
+        inner.ExtractReplayFrames(replayPath, fps, startTime, endTime, xResolution, yResolution);
+}

--- a/src/Worms.Cli.Tests/Fakes/ReplayFixtures.cs
+++ b/src/Worms.Cli.Tests/Fakes/ReplayFixtures.cs
@@ -1,7 +1,3 @@
-using System.IO.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
-using Worms.Armageddon.Game;
-
 namespace Worms.Cli.Tests.Fakes;
 
 internal static class ReplayFixtures
@@ -23,8 +19,8 @@ internal static class ReplayFixtures
         string filenameNoExt,
         string? logContent = null)
     {
-        var info = host.Services.GetRequiredService<IWormsArmageddon>().FindInstallation();
-        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var info = host.WormsArmageddon.FindInstallation();
+        var fs = host.FileSystem;
         var wagame = fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".WAgame");
         fs.File.WriteAllBytes(wagame, []);
         if (logContent is not null)

--- a/src/Worms.Cli.Tests/Fakes/ReplayFixtures.cs
+++ b/src/Worms.Cli.Tests/Fakes/ReplayFixtures.cs
@@ -14,21 +14,17 @@ internal static class ReplayFixtures
                                        [00:11:26.60] ••• Team 3 (another person) ends turn; time used: 11.58 sec turn, 3.00 sec retreat
                                        """;
 
-    public static string WriteReplay(
+    public static void WriteReplay(
         TestHost host,
         string filenameNoExt,
         string? logContent = null)
     {
         var info = host.WormsArmageddon.FindInstallation();
         var fs = host.FileSystem;
-        var wagame = fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".WAgame");
-        fs.File.WriteAllBytes(wagame, []);
+        fs.File.WriteAllBytes(fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".WAgame"), []);
         if (logContent is not null)
         {
-            var log = fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".log");
-            fs.File.WriteAllText(log, logContent);
+            fs.File.WriteAllText(fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".log"), logContent);
         }
-
-        return wagame;
     }
 }

--- a/src/Worms.Cli.Tests/Fakes/ReplayFixtures.cs
+++ b/src/Worms.Cli.Tests/Fakes/ReplayFixtures.cs
@@ -1,0 +1,38 @@
+using System.IO.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Worms.Armageddon.Game;
+
+namespace Worms.Cli.Tests.Fakes;
+
+internal static class ReplayFixtures
+{
+    public const string MultiTurnLog = """
+                                       Game Started at 2024-01-02 10:00:00 GMT
+                                       Red: "a person" as "Some Team"
+                                       Blue: "another person" as "Team 2"
+                                       [00:06:59.08] ••• Some Team (a person) starts turn
+                                       [00:07:08.26] ••• Some Team (a person) fires Shotgun
+                                       [00:07:26.60] ••• Some Team (a person) ends turn; time used: 11.58 sec turn, 3.00 sec retreat
+                                       [00:09:59.08] ••• Team 2 (another person) starts turn
+                                       [00:10:08.26] ••• Team 2 (another person) fires Shotgun
+                                       [00:11:26.60] ••• Team 3 (another person) ends turn; time used: 11.58 sec turn, 3.00 sec retreat
+                                       """;
+
+    public static string WriteReplay(
+        TestHost host,
+        string filenameNoExt,
+        string? logContent = null)
+    {
+        var info = host.Services.GetRequiredService<IWormsArmageddon>().FindInstallation();
+        var fs = host.Services.GetRequiredService<IFileSystem>();
+        var wagame = fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".WAgame");
+        fs.File.WriteAllBytes(wagame, []);
+        if (logContent is not null)
+        {
+            var log = fs.Path.Combine(info.ReplayFolder, filenameNoExt + ".log");
+            fs.File.WriteAllText(log, logContent);
+        }
+
+        return wagame;
+    }
+}

--- a/src/Worms.Cli.Tests/TestHost.cs
+++ b/src/Worms.Cli.Tests/TestHost.cs
@@ -23,7 +23,7 @@ internal sealed class TestHost : IDisposable
     public ServiceProvider Services { get; }
     private Command RootCommand { get; }
     private Runner Runner { get; }
-    private MockFileSystem FileSystem { get; }
+    public IFileSystem FileSystem { get; }
     public FakeTimeProvider Time { get; }
     public RecordingBrowserLauncher Browser { get; }
     public RecordingHttpMessageHandler Http { get; }

--- a/src/Worms.Cli.Tests/TestHost.cs
+++ b/src/Worms.Cli.Tests/TestHost.cs
@@ -9,8 +9,10 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Worms.Armageddon.Files;
 using Worms.Armageddon.Game;
+using Worms.Armageddon.Game.Fake;
 using Worms.Armageddon.Gifs;
 using Worms.Cli.Resources;
+using Worms.Cli.Resources.Local.Folders;
 using Worms.Cli.Resources.Remote.Auth;
 using Worms.Cli.Tests.Fakes;
 
@@ -26,14 +28,17 @@ internal sealed class TestHost : IDisposable
     public RecordingBrowserLauncher Browser { get; }
     public RecordingHttpMessageHandler Http { get; }
     public CapturingLoggerProvider Logs { get; }
+    public RecordingWormsArmageddon WormsArmageddon { get; }
+    public RecordingFolderOpener FolderOpener { get; }
 
-    public TestHost()
+    public TestHost(bool wormsInstalled = true)
     {
         FileSystem = new MockFileSystem();
         Time = new FakeTimeProvider(DateTimeOffset.UtcNow);
         Browser = new RecordingBrowserLauncher();
         Http = new RecordingHttpMessageHandler();
         Logs = new CapturingLoggerProvider();
+        FolderOpener = new RecordingFolderOpener();
 
         var configuration = new ConfigurationBuilder().Build();
 
@@ -41,14 +46,48 @@ internal sealed class TestHost : IDisposable
             .AddHttpClient()
             .AddLogging(b => b.AddProvider(Logs).SetMinimumLevel(LogLevel.Debug))
             .AddWormsArmageddonFilesServices()
-            .AddWormsArmageddonGameServices()
             .AddWormsArmageddonGifsServices()
             .AddWormsCliResourcesServices()
             .AddWormsCliServices()
             .AddSingleton<IConfiguration>(configuration);
 
+        if (wormsInstalled)
+        {
+            services.AddFakeInstalledWormsArmageddonServices(FileSystem);
+        }
+        else
+        {
+            services.AddFakeNotInstalledWormsArmageddonServices();
+        }
+
+        // Wrap the registered IWormsArmageddon in a recording decorator.
+        var innerDescriptor = services.Single(d => d.ServiceType == typeof(IWormsArmageddon));
+        services.Remove(innerDescriptor);
+        services.AddScoped<IWormsArmageddon>(sp =>
+        {
+            IWormsArmageddon inner;
+            if (innerDescriptor.ImplementationInstance is not null)
+            {
+                inner = (IWormsArmageddon) innerDescriptor.ImplementationInstance;
+            }
+            else if (innerDescriptor.ImplementationFactory is not null)
+            {
+                inner = (IWormsArmageddon) innerDescriptor.ImplementationFactory(sp);
+            }
+            else
+            {
+                inner = (IWormsArmageddon) ActivatorUtilities.CreateInstance(
+                    sp, innerDescriptor.ImplementationType!);
+            }
+
+            return new RecordingWormsArmageddon(inner);
+        });
+
         services.RemoveAll<IFileSystem>();
         services.AddSingleton<IFileSystem>(FileSystem);
+
+        services.RemoveAll<IFolderOpener>();
+        services.AddSingleton<IFolderOpener>(FolderOpener);
 
         services.RemoveAll<IBrowserLauncher>();
         services.AddSingleton<IBrowserLauncher>(Browser);
@@ -62,6 +101,9 @@ internal sealed class TestHost : IDisposable
         Services = services.BuildServiceProvider();
         RootCommand = CliStructure.BuildCommandLine(Services);
         Runner = Services.GetRequiredService<Runner>();
+
+        // Resolve once so WormsArmageddon is non-null before tests use it.
+        WormsArmageddon = (RecordingWormsArmageddon) Services.GetRequiredService<IWormsArmageddon>();
     }
 
     public Task<int> Run(params string[] args) =>

--- a/src/Worms.Cli.Tests/TestHost.cs
+++ b/src/Worms.Cli.Tests/TestHost.cs
@@ -84,7 +84,7 @@ internal sealed class TestHost : IDisposable
         });
 
         services.RemoveAll<IFileSystem>();
-        services.AddSingleton<IFileSystem>(FileSystem);
+        services.AddSingleton(FileSystem);
 
         services.RemoveAll<IFolderOpener>();
         services.AddSingleton<IFolderOpener>(FolderOpener);

--- a/src/Worms.Cli.Tests/Worms.Cli.Tests.csproj
+++ b/src/Worms.Cli.Tests/Worms.Cli.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Worms.Cli\Worms.Cli.csproj"/>
     <ProjectReference Include="..\Worms.Cli.Resources\Worms.Cli.Resources.csproj"/>
+    <ProjectReference Include="..\Worms.Armageddon.Game.Fake\Worms.Armageddon.Game.Fake.csproj"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds 18 unit tests covering the five local replay subcommands (`get`, `view`, `process`, `delete`, `browse`) in `Worms.Cli.Tests`
- Extends `TestHost` with the `Worms.Armageddon.Game.Fake` services (replacing the real WA registration) and a new `IFolderOpener` seam (`RecordingFolderOpener`), making it the fifth overridden test double
- Fixes a case-sensitivity bug in `Worms.Armageddon.Game.Fake/Installed.cs` where `GenerateReplayLog` silently no-oped on `.WAgame` paths due to an ordinal case-sensitive `Replace` call

Closes #1366

## Test plan

- [ ] `make cli.test.unit` — all 30 tests in `Worms.Cli.Tests` pass (18 new replay tests + 12 existing auth/scaffold tests)
- [ ] `dotnet build --warnaserror` — 0 warnings
- [ ] `get replay` alias parameterisation covers `replay`, `replays`, `WAgame`
- [ ] `browse replay` with `wormsInstalled: false` exits 1 and the folder opener is not called