### PR TITLE
test(cli): cover all four scheme commands with unit tests

### DIFF
--- a/src/Worms.Armageddon.Files.Tests/Schemes/WscRoundTripShould.cs
+++ b/src/Worms.Armageddon.Files.Tests/Schemes/WscRoundTripShould.cs
@@ -19,7 +19,6 @@ internal sealed class WscRoundTripShould : IDisposable
     public WscRoundTripShould()
     {
         var services = new ServiceCollection();
-        _ = services.AddSingleton<IFileSystem>(new FileSystem());
         _ = services.AddWormsArmageddonFilesServices();
         var serviceProvider = services.BuildServiceProvider();
         _writer = serviceProvider.GetRequiredService<IWscWriter>();

--- a/src/Worms.Armageddon.Files.Tests/Schemes/WscRoundTripShould.cs
+++ b/src/Worms.Armageddon.Files.Tests/Schemes/WscRoundTripShould.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
@@ -11,21 +12,24 @@ internal sealed class WscRoundTripShould : IDisposable
 {
     private readonly IWscWriter _writer;
     private readonly IWscReader _reader;
+    private readonly IFileSystem _fileSystem;
     private readonly string _tempDirectory;
     private readonly string _file;
 
     public WscRoundTripShould()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IFileSystem>(new FileSystem());
         _ = services.AddWormsArmageddonFilesServices();
         var serviceProvider = services.BuildServiceProvider();
         _writer = serviceProvider.GetRequiredService<IWscWriter>();
         _reader = serviceProvider.GetRequiredService<IWscReader>();
+        _fileSystem = serviceProvider.GetRequiredService<IFileSystem>();
 
         _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         _file = Path.Combine(_tempDirectory, Path.GetRandomFileName() + ".wsc");
 
-        _ = Directory.CreateDirectory(_tempDirectory);
+        _ = _fileSystem.Directory.CreateDirectory(_tempDirectory);
     }
 
     [Test]
@@ -56,7 +60,7 @@ internal sealed class WscRoundTripShould : IDisposable
 
     public void Dispose()
     {
-        File.Delete(_file);
-        Directory.Delete(_tempDirectory);
+        _fileSystem.File.Delete(_file);
+        _fileSystem.Directory.Delete(_tempDirectory);
     }
 }

--- a/src/Worms.Armageddon.Files.Tests/Worms.Armageddon.Files.Tests.csproj
+++ b/src/Worms.Armageddon.Files.Tests/Worms.Armageddon.Files.Tests.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
     <PackageReference Include="Shouldly" Version="4.3.0"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worms.Armageddon.Files/Schemes/Binary/WscReader.cs
+++ b/src/Worms.Armageddon.Files/Schemes/Binary/WscReader.cs
@@ -1,12 +1,15 @@
+using System.IO.Abstractions;
 using Syroot.Worms.Armageddon;
 
 namespace Worms.Armageddon.Files.Schemes.Binary;
 
-internal sealed class WscReader : IWscReader
+internal sealed class WscReader(IFileSystem fileSystem) : IWscReader
 {
     public Scheme Read(string path)
     {
-        var scheme = new Scheme(path);
+        var bytes = fileSystem.File.ReadAllBytes(path);
+        using var stream = new MemoryStream(bytes);
+        var scheme = new Scheme(stream);
 
         // This value incorrectly defaults to false in the 3rd party library
         // when the scheme is Version 1

--- a/src/Worms.Armageddon.Files/Schemes/Binary/WscWriter.cs
+++ b/src/Worms.Armageddon.Files/Schemes/Binary/WscWriter.cs
@@ -1,8 +1,14 @@
+using System.IO.Abstractions;
 using Syroot.Worms.Armageddon;
 
 namespace Worms.Armageddon.Files.Schemes.Binary;
 
-internal sealed class WscWriter : IWscWriter
+internal sealed class WscWriter(IFileSystem fileSystem) : IWscWriter
 {
-    public void Write(Scheme definition, string path) => definition.Save(path);
+    public void Write(Scheme definition, string path)
+    {
+        using var stream = new MemoryStream();
+        definition.Save(stream);
+        fileSystem.File.WriteAllBytes(path, stream.ToArray());
+    }
 }

--- a/src/Worms.Armageddon.Files/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Files/ServiceRegistration.cs
@@ -16,7 +16,7 @@ public static class ServiceRegistration
 {
     public static IServiceCollection AddWormsArmageddonFilesServices(this IServiceCollection services)
     {
-        services.TryAddSingleton<IFileSystem>(new FileSystem());
+        services.TryAddSingleton<IFileSystem, FileSystem>();
         services.TryAddScoped<IWscReader, WscReader>();
         services.TryAddScoped<IWscWriter, WscWriter>();
         services.TryAddScoped<ISchemeTextReader, SchemeTextReader>();

--- a/src/Worms.Armageddon.Files/ServiceRegistration.cs
+++ b/src/Worms.Armageddon.Files/ServiceRegistration.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Worms.Armageddon.Files.Replays.Filename;
@@ -15,6 +16,7 @@ public static class ServiceRegistration
 {
     public static IServiceCollection AddWormsArmageddonFilesServices(this IServiceCollection services)
     {
+        services.TryAddSingleton<IFileSystem>(new FileSystem());
         services.TryAddScoped<IWscReader, WscReader>();
         services.TryAddScoped<IWscWriter, WscWriter>();
         services.TryAddScoped<ISchemeTextReader, SchemeTextReader>();

--- a/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
+++ b/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Syroot.Worms.Armageddon" Version="4.0.3"/>
     <PackageReference Include="System.Drawing.Common" Version="10.0.8"/>
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1"/>
   </ItemGroup>
 
 </Project>

--- a/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
+++ b/src/Worms.Armageddon.Files/Worms.Armageddon.Files.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8"/>
     <PackageReference Include="Syroot.Worms.Armageddon" Version="4.0.3"/>
     <PackageReference Include="System.Drawing.Common" Version="10.0.8"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1"/>
   </ItemGroup>
 
 </Project>

--- a/src/Worms.Cli.Tests/Commands/BrowseSchemeShould.cs
+++ b/src/Worms.Cli.Tests/Commands/BrowseSchemeShould.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using Shouldly;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class BrowseSchemeShould
+{
+    [Test]
+    public async Task OpenTheSchemesFolderWhenWormsIsInstalled()
+    {
+        using var host = new TestHost();
+        var expectedFolder = host.WormsArmageddon.FindInstallation().SchemesFolder;
+
+        var exitCode = await host.Run("browse", "scheme");
+
+        exitCode.ShouldBe(0);
+        host.FolderOpener.OpenedFolders.ShouldHaveSingleItem().ShouldBe(expectedFolder);
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenWormsIsNotInstalled()
+    {
+        using var host = new TestHost(wormsInstalled: false);
+
+        var exitCode = await host.Run("browse", "scheme");
+
+        exitCode.ShouldBe(1);
+        host.FolderOpener.OpenedFolders.ShouldBeEmpty();
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/CreateSchemeShould.cs
+++ b/src/Worms.Cli.Tests/Commands/CreateSchemeShould.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Armageddon.Files.Schemes.Text;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class CreateSchemeShould
+{
+    private static readonly Lazy<string> ValidSchemeText = new(() =>
+    {
+        using var host = new TestHost();
+        var writer = host.Services.GetRequiredService<ISchemeTextWriter>();
+        using var output = new StringWriter();
+        writer.Write(new Syroot.Worms.Armageddon.Scheme(), output);
+        return output.ToString();
+    });
+
+    [Test]
+    public async Task CreateSchemeFromRandomWhenWormsIsInstalled()
+    {
+        using var host = new TestHost();
+        var folder = host.WormsArmageddon.FindInstallation().SchemesFolder;
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("create", "scheme", "myscheme", "--random");
+
+        exitCode.ShouldBe(0);
+        var expectedPath = Path.Combine(folder, "myscheme.wsc");
+        console.Output.ToString().ShouldContain(expectedPath);
+        host.FileSystem.File.Exists(expectedPath).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task CreateSchemeFromFile()
+    {
+        using var host = new TestHost();
+        var folder = host.WormsArmageddon.FindInstallation().SchemesFolder;
+        const string definitionPath = "/tmp/scheme.txt";
+        host.FileSystem.Directory.CreateDirectory("/tmp");
+        await host.FileSystem.File.WriteAllTextAsync(definitionPath, ValidSchemeText.Value);
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("create", "scheme", "myscheme", "--file", definitionPath);
+
+        exitCode.ShouldBe(0);
+        var expectedPath = Path.Combine(folder, "myscheme.wsc");
+        console.Output.ToString().ShouldContain(expectedPath);
+        host.FileSystem.File.Exists(expectedPath).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenWormsNotInstalledAndNoResourceFolder()
+    {
+        using var host = new TestHost(wormsInstalled: false);
+
+        var exitCode = await host.Run("create", "scheme", "myscheme", "--random");
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task CreateSchemeInResourceFolderWhenWormsNotInstalled()
+    {
+        using var host = new TestHost(wormsInstalled: false);
+        const string customFolder = "/tmp/custom-schemes";
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("create", "scheme", "myscheme", "--random", "--resource-folder", customFolder);
+
+        exitCode.ShouldBe(0);
+        var expectedPath = Path.Combine(customFolder, "myscheme.wsc");
+        console.Output.ToString().ShouldContain(expectedPath);
+        host.FileSystem.File.Exists(expectedPath).ShouldBeTrue();
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/DeleteSchemeShould.cs
+++ b/src/Worms.Cli.Tests/Commands/DeleteSchemeShould.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class DeleteSchemeShould
+{
+    [Test]
+    public async Task RemoveTheSchemeFile()
+    {
+        using var host = new TestHost();
+        var folder = host.WormsArmageddon.FindInstallation().SchemesFolder;
+        SchemeFixtures.WriteScheme(host, "redgate");
+
+        var exitCode = await host.Run("delete", "scheme", "redgate");
+
+        exitCode.ShouldBe(0);
+        host.FileSystem.File.Exists(Path.Combine(folder, "redgate.wsc")).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenNoSchemeMatches()
+    {
+        using var host = new TestHost();
+
+        var exitCode = await host.Run("delete", "scheme", "missing");
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task ReturnNonZeroAndDeleteNothingWhenMultipleSchemesMatch()
+    {
+        using var host = new TestHost();
+        var folder = host.WormsArmageddon.FindInstallation().SchemesFolder;
+        SchemeFixtures.WriteScheme(host, "redgate");
+        SchemeFixtures.WriteScheme(host, "redgate2");
+
+        var exitCode = await host.Run("delete", "scheme", "*");
+
+        exitCode.ShouldBe(1);
+        host.FileSystem.File.Exists(Path.Combine(folder, "redgate.wsc")).ShouldBeTrue();
+        host.FileSystem.File.Exists(Path.Combine(folder, "redgate2.wsc")).ShouldBeTrue();
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/GetSchemeShould.cs
+++ b/src/Worms.Cli.Tests/Commands/GetSchemeShould.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class GetSchemeShould
+{
+    [TestCase("scheme")]
+    [TestCase("schemes")]
+    [TestCase("wsc")]
+    public async Task PrintSchemeDetailsForMatchingName(string alias)
+    {
+        using var host = new TestHost();
+        SchemeFixtures.WriteScheme(host, "redgate");
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", alias, "redgate");
+
+        exitCode.ShouldBe(0);
+        console.Output.ToString().ShouldContain("GENERAL");
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenNoSchemeMatchesASpecificName()
+    {
+        using var host = new TestHost();
+
+        var exitCode = await host.Run("get", "scheme", "nonexistent");
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task PrintAllMatchingSchemesForWildcardPattern()
+    {
+        using var host = new TestHost();
+        SchemeFixtures.WriteScheme(host, "redgate");
+        SchemeFixtures.WriteScheme(host, "redgate2");
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", "scheme", "*");
+
+        exitCode.ShouldBe(0);
+        var output = console.Output.ToString();
+        output.ShouldContain("redgate");
+        output.ShouldContain("redgate2");
+    }
+
+    [Test]
+    public async Task ReturnZeroWhenNoSchemesMatchWildcardPattern()
+    {
+        using var host = new TestHost();
+
+        var exitCode = await host.Run("get", "scheme", "*");
+
+        exitCode.ShouldBe(0);
+    }
+}

--- a/src/Worms.Cli.Tests/Fakes/SchemeFixtures.cs
+++ b/src/Worms.Cli.Tests/Fakes/SchemeFixtures.cs
@@ -1,0 +1,35 @@
+namespace Worms.Cli.Tests.Fakes;
+
+internal static class SchemeFixtures
+{
+    private static readonly Lazy<byte[]> RedgateBytes = new(() =>
+    {
+        var repoRoot = FindRepoRoot();
+        var path = Path.Combine(repoRoot, "sample-data", "schemes", "redgate.wsc");
+        return File.ReadAllBytes(path);
+    });
+
+    /// <summary>
+    /// Writes the bytes of sample-data/schemes/redgate.wsc into MockFileSystem at
+    /// &lt;SchemesFolder&gt;/&lt;schemeName&gt;.wsc so LocalSchemesRetriever can discover it.
+    /// </summary>
+    public static void WriteScheme(TestHost host, string schemeName)
+    {
+        var info = host.WormsArmageddon.FindInstallation();
+        var fs = host.FileSystem;
+        var path = fs.Path.Combine(info.SchemesFolder, schemeName + ".wsc");
+        fs.File.WriteAllBytes(path, RedgateBytes.Value);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "docker-compose.yaml")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not find repo root (docker-compose.yaml not found)");
+    }
+}


### PR DESCRIPTION
Closes #1367

## Summary

- `WscReader` and `WscWriter` now route file I/O through `IFileSystem` using Syroot's stream-based API, so `MockFileSystem` works end-to-end in unit tests without touching the real filesystem.
- `WscRoundTripShould` registers `new FileSystem()` in its service collection and uses it for temp-directory setup and teardown, keeping usage consistent through the same abstraction.
- `SchemeFixtures` seeds `MockFileSystem` with real `redgate.wsc` bytes (read once from `sample-data/schemes/`) so `LocalSchemesRetriever` can discover and parse schemes without OS filesystem access.
- 15 new unit tests covering `get scheme` (aliases, exact match, wildcard, missing), `delete scheme` (hit, miss, multi-match), `create scheme` (random, file, no-worms, resource-folder), and `browse scheme` (installed, not installed).

## Test plan

- [x] `dotnet test src/Worms.Armageddon.Files.Tests` — existing round-trip tests still pass
- [x] `dotnet test src/Worms.Cli.Tests` — all 15 new scheme tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)