### PR TITLE
test(cli): cover host and get-game commands with unit tests

### DIFF
--- a/.claude/docs/components/cli.md
+++ b/.claude/docs/components/cli.md
@@ -61,14 +61,15 @@ OpenTelemetry traces are started in `Program.Main` before DI setup. Each signifi
 
 ## Testing
 
-CLI unit tests live in `src/Worms.Cli.Tests` (NUnit + Shouldly). Tests drive the CLI through the same `CliStructure.BuildCommandLine()` root + DI container that production uses, via the `TestHost` composition root. `TestHost` overrides five production seams:
+CLI unit tests live in `src/Worms.Cli.Tests` (NUnit + Shouldly). Tests drive the CLI through the same `CliStructure.BuildCommandLine()` root + DI container that production uses, via the `TestHost` composition root. `TestHost` overrides six production seams:
 
 - `IHttpClientFactory` — backed by a recording handler (`RecordingHttpMessageHandler`) that captures requests and returns scripted responses.
 - `IFileSystem` — `MockFileSystem` so `TokenStore` reads and writes in memory.
 - `IBrowserLauncher` — recording test impl; no real browser is launched. The interface wraps the original static `BrowserLauncher` so production behaviour is unchanged.
 - `TimeProvider` — `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` so the device-code polling loop and its timeout can be fast-forwarded deterministically.
 - `IFolderOpener` — `RecordingFolderOpener` captures the folder paths passed to `OpenFolder` so tests can assert on which folder was opened without launching a real file manager.
+- `IIpAddressLookup` — `StubIpAddressLookup` returns a configurable `IpAddressLookupResult`. Tests assert on whether `worms host` proceeds, falls back to an error, or surfaces the validation message, without touching real network interfaces.
 
-`TestHost` also registers the `Worms.Armageddon.Game.Fake` services so `IWormsArmageddon` is the in-memory fake — installed by default; opt in to a 'not installed' fake via `new TestHost(wormsInstalled: false)`. The fake is wrapped in a small recording decorator (`RecordingWormsArmageddon`) so tests can observe which `PlayReplay` calls the CLI issued.
+`TestHost` also registers the `Worms.Armageddon.Game.Fake` services so `IWormsArmageddon` is the in-memory fake — installed by default; opt in to a 'not installed' fake via `new TestHost(wormsInstalled: false)`, or suppress the fake's automatic `.WAGame` replay write via `new TestHost(hostCreatesReplay: false)` (used by the no-replay / old-replay `worms host` tests to populate the replay folder explicitly or leave it empty). The fake is wrapped in a small recording decorator (`RecordingWormsArmageddon`) so tests can observe which `PlayReplay` calls the CLI issued, and whether `Host()` was called.
 
 When adding tests for a new command, extend this project rather than creating a new one. Test classes follow the `<TypeUnderTest>Should` convention; test methods describe a behaviour.

--- a/src/Worms.Cli.Resources/Local/Network/IIpAddressLookup.cs
+++ b/src/Worms.Cli.Resources/Local/Network/IIpAddressLookup.cs
@@ -1,0 +1,12 @@
+namespace Worms.Cli.Resources.Local.Network;
+
+public interface IIpAddressLookup
+{
+    IpAddressLookupResult LookupForDomain(string domain);
+}
+
+public abstract record IpAddressLookupResult
+{
+    public sealed record Found(string Address) : IpAddressLookupResult;
+    public sealed record NotFound(string Error) : IpAddressLookupResult;
+}

--- a/src/Worms.Cli.Resources/Local/Network/IIpAddressLookup.cs
+++ b/src/Worms.Cli.Resources/Local/Network/IIpAddressLookup.cs
@@ -5,8 +5,8 @@ public interface IIpAddressLookup
     IpAddressLookupResult LookupForDomain(string domain);
 }
 
-public abstract record IpAddressLookupResult
-{
-    public sealed record Found(string Address) : IpAddressLookupResult;
-    public sealed record NotFound(string Error) : IpAddressLookupResult;
-}
+public abstract record IpAddressLookupResult;
+
+public sealed record IpAddressFound(string Address) : IpAddressLookupResult;
+
+public sealed record IpAddressNotFound(string Error) : IpAddressLookupResult;

--- a/src/Worms.Cli.Resources/Local/Network/NetworkInterfaceIpAddressLookup.cs
+++ b/src/Worms.Cli.Resources/Local/Network/NetworkInterfaceIpAddressLookup.cs
@@ -14,7 +14,7 @@ internal sealed class NetworkInterfaceIpAddressLookup : IIpAddressLookup
 
         if (adapter is null)
         {
-            return new IpAddressLookupResult.NotFound($"No network adapter found for domain: {domain}");
+            return new IpAddressNotFound($"No network adapter found for domain: {domain}");
         }
 
         var ipv4 = adapter.GetIPProperties()
@@ -22,7 +22,7 @@ internal sealed class NetworkInterfaceIpAddressLookup : IIpAddressLookup
             ?.Address.ToString();
 
         return ipv4 is null
-            ? new IpAddressLookupResult.NotFound($"No IPv4 address found for domain: {domain}")
-            : new IpAddressLookupResult.Found(ipv4);
+            ? new IpAddressNotFound($"No IPv4 address found for domain: {domain}")
+            : new IpAddressFound(ipv4);
     }
 }

--- a/src/Worms.Cli.Resources/Local/Network/NetworkInterfaceIpAddressLookup.cs
+++ b/src/Worms.Cli.Resources/Local/Network/NetworkInterfaceIpAddressLookup.cs
@@ -1,0 +1,28 @@
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace Worms.Cli.Resources.Local.Network;
+
+internal sealed class NetworkInterfaceIpAddressLookup : IIpAddressLookup
+{
+    public IpAddressLookupResult LookupForDomain(string domain)
+    {
+        var adapter = Array.Find(
+            NetworkInterface.GetAllNetworkInterfaces(),
+            a => a.GetIPProperties().DnsSuffix == domain
+                 && a.OperationalStatus == OperationalStatus.Up);
+
+        if (adapter is null)
+        {
+            return new IpAddressLookupResult.NotFound($"No network adapter found for domain: {domain}");
+        }
+
+        var ipv4 = adapter.GetIPProperties()
+            .UnicastAddresses.FirstOrDefault(u => u.Address.AddressFamily == AddressFamily.InterNetwork)
+            ?.Address.ToString();
+
+        return ipv4 is null
+            ? new IpAddressLookupResult.NotFound($"No IPv4 address found for domain: {domain}")
+            : new IpAddressLookupResult.Found(ipv4);
+    }
+}

--- a/src/Worms.Cli.Resources/ServiceRegistration.cs
+++ b/src/Worms.Cli.Resources/ServiceRegistration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Worms.Armageddon.Files.Schemes.Random;
 using Worms.Cli.Resources.Local.Folders;
 using Worms.Cli.Resources.Local.Gifs;
+using Worms.Cli.Resources.Local.Network;
 using Worms.Cli.Resources.Local.Replays;
 using Worms.Cli.Resources.Local.Schemes;
 using Worms.Cli.Resources.Remote;
@@ -38,6 +39,7 @@ public static class ServiceRegistration
             .AddScoped<IResourceCreator<LocalGif, LocalGifCreateParameters>, LocalGifCreator>()
             .AddScoped<ITokenStore, TokenStore>()
             .AddScoped<IBrowserLauncher, BrowserLauncher>()
+            .AddScoped<IIpAddressLookup, NetworkInterfaceIpAddressLookup>()
             .AddSingleton(TimeProvider.System)
             .AddScoped<ILoginService, DeviceCodeLoginService>()
             .AddScoped<IAccessTokenRefreshService, AccessTokenRefreshService>()

--- a/src/Worms.Cli.Tests/Commands/GetGameShould.cs
+++ b/src/Worms.Cli.Tests/Commands/GetGameShould.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Resources.Remote.Auth;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class GetGameShould
+{
+    [TestCase("game")]
+    [TestCase("games")]
+    public async Task PrintSingleGameOutputForOneResult(string alias)
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """[{"id":"g1","status":"InProgress","hostMachine":"host-a"}]""");
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", alias);
+
+        exitCode.ShouldBe(0);
+        console.Output.ToString().ShouldContain("wa://host-a");
+    }
+
+    [Test]
+    public async Task PrintTableWhenMultipleGamesReturned()
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """[{"id":"g1","status":"InProgress","hostMachine":"host-a"},{"id":"g2","status":"Complete","hostMachine":"host-b"}]""");
+
+        using var console = new ConsoleOutputScope();
+        var exitCode = await host.Run("get", "game");
+
+        exitCode.ShouldBe(0);
+        var output = console.Output.ToString();
+        output.ShouldContain("g1");
+        output.ShouldContain("g2");
+        output.ShouldContain("host-a");
+        output.ShouldContain("host-b");
+        output.ShouldContain("InProgress");
+        output.ShouldContain("Complete");
+        output.ShouldContain("ID");
+        output.ShouldContain("HOST");
+        output.ShouldContain("STATUS");
+    }
+
+    [Test]
+    public async Task ExitZeroWhenNoGamesReturnedAndNoNameProvided()
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "[]");
+
+        var exitCode = await host.Run("get", "game");
+
+        exitCode.ShouldBe(0);
+        host.Logs.Messages.ShouldAllBe(m => m.Level != LogLevel.Error);
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenNoGameMatchesASpecificName()
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "[]");
+
+        var exitCode = await host.Run("get", "game", "nonexistent");
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task LogWarningWhenUnauthorized()
+    {
+        using var host = new TestHost();
+        // Store tokens so AccessTokenRefreshService can attempt the HTTP refresh call.
+        // Access token must be a valid JWT so Runner.Run can call GetAnonymisedUserId without throwing.
+        host.Services.GetRequiredService<ITokenStore>()
+            .StoreAccessTokens(new AccessTokens(TestJwt.Create("test-user"), "fake-refresh"));
+        host.Http.EnqueueAlways(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+        var exitCode = await host.Run("get", "game");
+
+        exitCode.ShouldBe(0);
+        host.Logs.Messages.ShouldContain(m =>
+            m.Level == LogLevel.Warning &&
+            m.Message.Contains("You don't have access to the Worms Hub"));
+    }
+}

--- a/src/Worms.Cli.Tests/Commands/HostShould.cs
+++ b/src/Worms.Cli.Tests/Commands/HostShould.cs
@@ -146,7 +146,7 @@ internal sealed class HostShould
     public async Task ReturnNonZeroWhenIpAddressNotFound()
     {
         using var host = new TestHost();
-        host.IpAddressLookup.Result = new IpAddressLookupResult.NotFound("No network adapter found for domain: red-gate.com");
+        host.IpAddressLookup.Result = new IpAddressNotFound("No network adapter found for domain: red-gate.com");
 
         var exitCode = await host.Run("host");
 

--- a/src/Worms.Cli.Tests/Commands/HostShould.cs
+++ b/src/Worms.Cli.Tests/Commands/HostShould.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Cli.Resources.Local.Network;
+using Worms.Cli.Tests.Fakes;
+
+namespace Worms.Cli.Tests.Commands;
+
+[TestFixture]
+internal sealed class HostShould
+{
+    private static void EnqueueHostHappyPath(TestHost host)
+    {
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"redgate","name":"Redgate","version":"1.2.3","schemeUrl":"https://example/test.wsc"}""");
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "scheme-bytes", "application/octet-stream");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"InProgress","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"Complete","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"replay-1","name":"replay","status":"Uploaded"}""");
+    }
+
+    [Test]
+    public async Task RunFullFlowWhenNoFlagsSet()
+    {
+        using var host = new TestHost();
+        EnqueueHostHappyPath(host);
+
+        var exitCode = await host.Run("host");
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.HostWasCalled.ShouldBeTrue();
+        host.Http.Requests.Count.ShouldBe(5);
+        host.Http.Requests[0].RequestUri!.AbsolutePath.ShouldEndWith("/api/v1/leagues/redgate");
+        host.Http.Requests[0].Method.ShouldBe(HttpMethod.Get);
+        host.Http.Requests[1].RequestUri!.AbsolutePath.ShouldEndWith("/api/v1/files/schemes/redgate");
+        host.Http.Requests[1].Method.ShouldBe(HttpMethod.Get);
+        host.Http.Requests[2].RequestUri!.AbsolutePath.ShouldEndWith("/api/v1/games");
+        host.Http.Requests[2].Method.ShouldBe(HttpMethod.Post);
+        host.Http.Requests[3].RequestUri!.AbsolutePath.ShouldEndWith("/api/v1/games");
+        host.Http.Requests[3].Method.ShouldBe(HttpMethod.Put);
+        host.Http.Requests[4].RequestUri!.AbsolutePath.ShouldEndWith("/api/v1/replays");
+        host.Http.Requests[4].Method.ShouldBe(HttpMethod.Post);
+    }
+
+    [Test]
+    public async Task PrintWhatWillHappenWhenDryRunSet()
+    {
+        using var host = new TestHost();
+
+        var runTask = host.Run("host", "--dry-run");
+
+        host.Time.Advance(TimeSpan.FromSeconds(6));
+        var exitCode = await runTask;
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.HostWasCalled.ShouldBeFalse();
+        host.Http.Requests.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task SkipSchemeDownloadWhenFlagSet()
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"InProgress","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"Complete","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"replay-1","name":"replay","status":"Uploaded"}""");
+
+        var exitCode = await host.Run("host", "--skip-scheme-download");
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.HostWasCalled.ShouldBeTrue();
+        host.Http.Requests.Count.ShouldBe(3);
+        host.Http.Requests.ShouldAllBe(r =>
+            !r.RequestUri!.AbsolutePath.Contains("leagues") &&
+            !r.RequestUri.AbsolutePath.Contains("files/schemes"));
+    }
+
+    [Test]
+    public async Task SkipReplayUploadWhenSkipUploadSet()
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"redgate","name":"Redgate","version":"1.2.3","schemeUrl":"https://example/test.wsc"}""");
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "scheme-bytes", "application/octet-stream");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"InProgress","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"Complete","hostMachine":"10.0.0.1"}""");
+
+        var exitCode = await host.Run("host", "--skip-upload");
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.HostWasCalled.ShouldBeTrue();
+        host.Http.Requests.ShouldAllBe(r => !r.RequestUri!.AbsolutePath.EndsWith("/api/v1/replays"));
+    }
+
+    [Test]
+    public async Task SkipGameAnnouncementWhenSkipAnnouncementSet()
+    {
+        using var host = new TestHost();
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"redgate","name":"Redgate","version":"1.2.3","schemeUrl":"https://example/test.wsc"}""");
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "scheme-bytes", "application/octet-stream");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"replay-1","name":"replay","status":"Uploaded"}""");
+
+        var exitCode = await host.Run("host", "--skip-announcement");
+
+        exitCode.ShouldBe(0);
+        host.WormsArmageddon.HostWasCalled.ShouldBeTrue();
+        host.Http.Requests.ShouldAllBe(r => !r.RequestUri!.AbsolutePath.EndsWith("/api/v1/games"));
+        host.Http.Requests.ShouldContain(r => r.RequestUri!.AbsolutePath.EndsWith("/api/v1/replays"));
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenWormsArmageddonNotInstalled()
+    {
+        using var host = new TestHost(wormsInstalled: false);
+
+        var exitCode = await host.Run("host");
+
+        exitCode.ShouldBe(1);
+        host.Logs.Messages.ShouldContain(m => m.Message.Contains("Worms Armageddon is not installed"));
+    }
+
+    [Test]
+    public async Task ReturnNonZeroWhenIpAddressNotFound()
+    {
+        using var host = new TestHost();
+        host.IpAddressLookup.Result = new IpAddressLookupResult.NotFound("No network adapter found for domain: red-gate.com");
+
+        var exitCode = await host.Run("host");
+
+        exitCode.ShouldBe(1);
+        host.Logs.Messages.ShouldContain(m => m.Message.Contains("No network adapter found for domain: red-gate.com"));
+    }
+
+    [Test]
+    public async Task LogWarningAndSkipUploadWhenNoReplayExists()
+    {
+        using var host = new TestHost(hostCreatesReplay: false);
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"redgate","name":"Redgate","version":"1.2.3","schemeUrl":"https://example/test.wsc"}""");
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "scheme-bytes", "application/octet-stream");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"InProgress","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"Complete","hostMachine":"10.0.0.1"}""");
+
+        var exitCode = await host.Run("host");
+
+        exitCode.ShouldBe(0);
+        host.Logs.Messages.ShouldContain(m => m.Message.Contains("No replay found to upload"));
+        host.Http.Requests.ShouldAllBe(r => !r.RequestUri!.AbsolutePath.EndsWith("/api/v1/replays"));
+    }
+
+    [Test]
+    public async Task LogWarningAndSkipUploadWhenOnlyOldReplayExists()
+    {
+        using var host = new TestHost(hostCreatesReplay: false);
+        // Write a replay from 2024 — it is always more than 1 hour old relative to the current date.
+        ReplayFixtures.WriteReplay(host, "2024-01-02 10.00.00 [Offline] One, Two");
+
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"redgate","name":"Redgate","version":"1.2.3","schemeUrl":"https://example/test.wsc"}""");
+        host.Http.EnqueueResponse(HttpStatusCode.OK, "scheme-bytes", "application/octet-stream");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"InProgress","hostMachine":"10.0.0.1"}""");
+        host.Http.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"id":"game-1","status":"Complete","hostMachine":"10.0.0.1"}""");
+
+        var exitCode = await host.Run("host");
+
+        exitCode.ShouldBe(0);
+        host.Logs.Messages.ShouldContain(m => m.Level == LogLevel.Warning && m.Message.Contains("No recent replay found to upload"));
+        host.Http.Requests.ShouldAllBe(r => !r.RequestUri!.AbsolutePath.EndsWith("/api/v1/replays"));
+    }
+}

--- a/src/Worms.Cli.Tests/Fakes/RecordingWormsArmageddon.cs
+++ b/src/Worms.Cli.Tests/Fakes/RecordingWormsArmageddon.cs
@@ -8,9 +8,15 @@ internal sealed class RecordingWormsArmageddon(IWormsArmageddon inner) : IWormsA
 
     public List<PlayReplayCall> PlayReplayCalls { get; } = [];
 
+    public bool HostWasCalled { get; private set; }
+
     public GameInfo FindInstallation() => inner.FindInstallation();
 
-    public Task Host() => inner.Host();
+    public Task Host()
+    {
+        HostWasCalled = true;
+        return inner.Host();
+    }
 
     public Task GenerateReplayLog(string replayPath) => inner.GenerateReplayLog(replayPath);
 

--- a/src/Worms.Cli.Tests/Fakes/StubIpAddressLookup.cs
+++ b/src/Worms.Cli.Tests/Fakes/StubIpAddressLookup.cs
@@ -4,7 +4,7 @@ namespace Worms.Cli.Tests.Fakes;
 
 internal sealed class StubIpAddressLookup : IIpAddressLookup
 {
-    public IpAddressLookupResult Result { get; set; } = new IpAddressLookupResult.Found("10.0.0.1");
+    public IpAddressLookupResult Result { get; set; } = new IpAddressFound("10.0.0.1");
 
     public IpAddressLookupResult LookupForDomain(string domain) => Result;
 }

--- a/src/Worms.Cli.Tests/Fakes/StubIpAddressLookup.cs
+++ b/src/Worms.Cli.Tests/Fakes/StubIpAddressLookup.cs
@@ -1,0 +1,10 @@
+using Worms.Cli.Resources.Local.Network;
+
+namespace Worms.Cli.Tests.Fakes;
+
+internal sealed class StubIpAddressLookup : IIpAddressLookup
+{
+    public IpAddressLookupResult Result { get; set; } = new IpAddressLookupResult.Found("10.0.0.1");
+
+    public IpAddressLookupResult LookupForDomain(string domain) => Result;
+}

--- a/src/Worms.Cli.Tests/TestHost.cs
+++ b/src/Worms.Cli.Tests/TestHost.cs
@@ -13,6 +13,7 @@ using Worms.Armageddon.Game.Fake;
 using Worms.Armageddon.Gifs;
 using Worms.Cli.Resources;
 using Worms.Cli.Resources.Local.Folders;
+using Worms.Cli.Resources.Local.Network;
 using Worms.Cli.Resources.Remote.Auth;
 using Worms.Cli.Tests.Fakes;
 
@@ -30,8 +31,9 @@ internal sealed class TestHost : IDisposable
     public CapturingLoggerProvider Logs { get; }
     public RecordingWormsArmageddon WormsArmageddon { get; }
     public RecordingFolderOpener FolderOpener { get; }
+    public StubIpAddressLookup IpAddressLookup { get; } = new();
 
-    public TestHost(bool wormsInstalled = true)
+    public TestHost(bool wormsInstalled = true, bool hostCreatesReplay = true)
     {
         FileSystem = new MockFileSystem();
         Time = new FakeTimeProvider(DateTimeOffset.UtcNow);
@@ -53,7 +55,7 @@ internal sealed class TestHost : IDisposable
 
         if (wormsInstalled)
         {
-            services.AddFakeInstalledWormsArmageddonServices(FileSystem);
+            services.AddFakeInstalledWormsArmageddonServices(FileSystem, hostCreatesReplay: hostCreatesReplay);
         }
         else
         {
@@ -94,6 +96,9 @@ internal sealed class TestHost : IDisposable
 
         services.RemoveAll<TimeProvider>();
         services.AddSingleton<TimeProvider>(Time);
+
+        services.RemoveAll<IIpAddressLookup>();
+        services.AddSingleton<IIpAddressLookup>(IpAddressLookup);
 
         services.AddHttpClient(Options.DefaultName)
             .ConfigurePrimaryHttpMessageHandler(_ => Http);

--- a/src/Worms.Cli/Commands/Host.cs
+++ b/src/Worms.Cli/Commands/Host.cs
@@ -65,8 +65,8 @@ internal sealed class HostHandler(
 
         Validated<string> ipAddress = ipAddressLookup.LookupForDomain(Domain) switch
         {
-            IpAddressLookupResult.Found f => new Valid<string>(f.Address),
-            IpAddressLookupResult.NotFound nf => new Invalid<string>(nf.Error),
+            IpAddressFound f => new Valid<string>(f.Address),
+            IpAddressNotFound nf => new Invalid<string>(nf.Error),
             _ => throw new InvalidOperationException("Unexpected IpAddressLookupResult type")
         };
 

--- a/src/Worms.Cli/Commands/Host.cs
+++ b/src/Worms.Cli/Commands/Host.cs
@@ -1,13 +1,12 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
 using Worms.Armageddon.Game;
 using Worms.Cli.Commands.Validation;
 using Worms.Cli.League;
 using Worms.Cli.Resources;
+using Worms.Cli.Resources.Local.Network;
 using Worms.Cli.Resources.Local.Replays;
 using Worms.Cli.Resources.Remote.Games;
 using Worms.Cli.Resources.Remote.Replays;
@@ -53,6 +52,8 @@ internal sealed class HostHandler(
     IRemoteGameUpdater gameUpdater,
     IResourceRetriever<LocalReplay> localReplayRetriever,
     IResourceCreator<RemoteReplay, RemoteReplayCreateParameters> remoteReplayCreator,
+    IIpAddressLookup ipAddressLookup,
+    TimeProvider timeProvider,
     ILogger<HostHandler> logger) : AsynchronousCommandLineAction
 {
     private const string LeagueName = "redgate";
@@ -62,12 +63,19 @@ internal sealed class HostHandler(
     {
         _ = Activity.Current?.SetTag("name", Telemetry.Spans.Host.SpanName);
 
+        Validated<string> ipAddress = ipAddressLookup.LookupForDomain(Domain) switch
+        {
+            IpAddressLookupResult.Found f => new Valid<string>(f.Address),
+            IpAddressLookupResult.NotFound nf => new Invalid<string>(nf.Error),
+            _ => throw new InvalidOperationException("Unexpected IpAddressLookupResult type")
+        };
+
         var config = new Config(
             parseResult.GetValue(Host.DryRun),
             parseResult.GetValue(Host.SkipSchemeDownload),
             parseResult.GetValue(Host.SkipUpload),
             parseResult.GetValue(Host.SkipAnnouncement),
-            GetIpAddress(Domain),
+            ipAddress,
             wormsArmageddon.FindInstallation());
 
         RecordTelemetryForConfig(config);
@@ -179,7 +187,7 @@ internal sealed class HostHandler(
         }
 
         // Check if the replay was created during this session
-        var timeSinceGameEnded = DateTime.UtcNow - replay.Details.Date;
+        var timeSinceGameEnded = timeProvider.GetUtcNow().DateTime - replay.Details.Date;
         if (timeSinceGameEnded > TimeSpan.FromHours(1))
         {
             logger.LogWarning("No recent replay found to upload");
@@ -198,32 +206,6 @@ internal sealed class HostHandler(
         }
     }
 
-    private static Validated<string> GetIpAddress(string domain)
-    {
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Bind(GetAdaptersForDomain())
-            .Validate(NetworkAdapterExists())
-            .Map(GetIpV4Address())
-            .Validate(IpV4AddressExists())
-            .Map(x => x!);
-
-        Func<NetworkInterface[], NetworkInterface?> GetAdaptersForDomain() =>
-            x => Array.Find(
-                x,
-                a => a.GetIPProperties().DnsSuffix == domain && a.OperationalStatus == OperationalStatus.Up);
-
-        Func<NetworkInterface?, string?> GetIpV4Address() =>
-            x => x!.GetIPProperties()
-                .UnicastAddresses.FirstOrDefault(u => u.Address.AddressFamily == AddressFamily.InterNetwork)
-                ?.Address.ToString();
-
-        List<ValidationRule<NetworkInterface?>> NetworkAdapterExists() =>
-            Valid.Rules<NetworkInterface?>().Must(x => x is not null, $"No network adapter found for domain: {domain}");
-
-        List<ValidationRule<string?>> IpV4AddressExists() =>
-            Valid.Rules<string?>().Must(x => x is not null, $"No IPv4 address found for domain: {domain}");
-    }
-
     private Task DownloadLatestOptions(bool skipSchemeDownload, bool dryRun)
     {
         if (skipSchemeDownload)
@@ -238,7 +220,7 @@ internal sealed class HostHandler(
     private Task StartWorms(bool dryRun, CancellationToken cancellationToken)
     {
         logger.LogInformation("Starting Worms Armageddon");
-        return !dryRun ? wormsArmageddon.Host() : Task.Delay(5000, cancellationToken);
+        return !dryRun ? wormsArmageddon.Host() : Task.Delay(TimeSpan.FromSeconds(5), timeProvider, cancellationToken);
     }
 
     private Task WaitForGameToClose(Task runGame)

--- a/src/Worms.Cli/Commands/Validation/BindExtensions.cs
+++ b/src/Worms.Cli/Commands/Validation/BindExtensions.cs
@@ -4,8 +4,6 @@ namespace Worms.Cli.Commands.Validation;
 
 internal static class BindExtensions
 {
-    public static Validated<TOut> Bind<T, TOut>(this T value, Func<T, TOut> func) => new Valid<TOut>(func(value!));
-
     [UsedImplicitly]
     public static async Task<Validated<TOut>> Bind<T, TOut>(this T value, Func<T, Task<TOut>> asyncFunc) =>
         new Valid<TOut>(await asyncFunc(value!));

--- a/src/Worms.Cli/Commands/Validation/ValidationExtensions.cs
+++ b/src/Worms.Cli/Commands/Validation/ValidationExtensions.cs
@@ -19,7 +19,7 @@ internal static class ValidationExtensions
         return errors.Count > 0 ? new Invalid<T>(errors) : new Valid<T>(value);
     }
 
-    public static Validated<T> Validate<T>(this Validated<T> value, List<ValidationRule<T>> validations) =>
+    private static Validated<T> Validate<T>(this Validated<T> value, List<ValidationRule<T>> validations) =>
         !value.IsValid ? value : value.Value.Validate(validations);
 
     public static async Task<Validated<T>> Validate<T>(


### PR DESCRIPTION
Closes #1368

## What

Adds 15 new unit tests covering `worms host` and `worms get game`, wired into the existing `Worms.Cli.Tests` project and gated on every PR via `make cli.test.unit`.

To make the host command testable without real network interfaces or a real clock, two new seams are extracted:

- **`IIpAddressLookup`** — replaces the inline `GetIpAddress` private method; the production impl (`NetworkInterfaceIpAddressLookup`) scans real network adapters, the test fake (`StubIpAddressLookup`) returns a fixed result. Result type is a discriminated union (`Found`/`NotFound`) to avoid null-bang at the callsite.
- **`TimeProvider`** — injected into `HostHandler`; allows `FakeTimeProvider` to fast-forward the dry-run delay and the replay-age check in tests.

`TestHost` gains a `hostCreatesReplay` parameter so the no-replay and old-replay cases can suppress the fake's automatic `.WAGame` write.

## Tests added

**`HostShould`** (9 tests): happy path (all 5 hub calls in order), `--dry-run`, `--skip-scheme-download`, `--skip-upload`, `--skip-announcement`, WA not installed, no IP found, no replay, old replay.

**`GetGameShould`** (6 tests): happy path + alias (`game`/`games`), multiple games (table output), empty list, name not found (exit 1), 401 unauthorized.

## Commits

1. Extract `IIpAddressLookup` seam and inject `TimeProvider` into `HostHandler`
2. Add test infrastructure (fakes + `TestHost` wiring)
3. Add `HostShould` and `GetGameShould` tests; update `cli.md`
4. Remove validation members orphaned by the seam extraction (InspectCode)