### PR TITLE
fix(ci): exclude CLI test project from release change detection

### DIFF
--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -69,6 +69,7 @@ jobs:
           clis:
             - 'src/Worms.Cli/**'
             - 'src/Worms.Cli.*/**'
+            - '!src/Worms.Cli.Tests/**'
             - 'src/Worms.Armageddon.Files/**'
             - 'src/Worms.Armageddon.Game/**'
             - 'src/Worms.Armageddon.Gifs/**'


### PR DESCRIPTION
## Summary

- Adds `'!src/Worms.Cli.Tests/**'` negation filter to the `clis` paths-filter block in `zz-detect-changes.yml`
- Test-only pushes no longer set `clis-release=true`, preventing unnecessary CLI release pipeline runs
- The `code` filter (and therefore the `build-cli` unit-test job) is unchanged — tests still run on any `src/**` change

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)