### PR TITLE
fix(ci): correct path filters in change detection

### DIFF
--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -63,7 +63,7 @@ jobs:
             - 'build/download-wa-game.sh'
           hub-common:
             - 'src/Directory.Build.props'
-            - '.github/workflows/hub-*.yml'
+            - '.github/workflows/zz-*-hub.yml'
             - 'build/docker/makefile'
             - 'build/*.sh'
           clis:
@@ -74,7 +74,7 @@ jobs:
             - 'src/Worms.Armageddon.Gifs/**'
             - 'src/Directory.Build.props'
             - 'build/cli/**'
-            - '.github/workflows/hub-*.yml'
+            - '.github/workflows/zz-*-cli.yml'
           web:
             - 'src/Worms.Hub.Web/**'
             - 'build/web/**'

--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -88,4 +88,3 @@ jobs:
             - '.github/workflows/zz-build-*.yml'
             - '.github/workflows/zz-release-*.yml'
             - '.github/workflows/zz-detect-changes.yml'
-            - '.github/workflows/zz-inspections.yml'

--- a/.github/workflows/zz-detect-changes.yml
+++ b/.github/workflows/zz-detect-changes.yml
@@ -68,8 +68,7 @@ jobs:
             - 'build/*.sh'
           clis:
             - 'src/Worms.Cli/**'
-            - 'src/Worms.Cli.*/**'
-            - '!src/Worms.Cli.Tests/**'
+            - 'src/Worms.Cli.Resources/**'
             - 'src/Worms.Armageddon.Files/**'
             - 'src/Worms.Armageddon.Game/**'
             - 'src/Worms.Armageddon.Gifs/**'


### PR DESCRIPTION
## What

Fixes several incorrect path globs in the `dorny/paths-filter` change-detection step (`.github/workflows/zz-detect-changes.yml`). The trigger was a Web-only change (a Renovate bump to `src/Worms.Hub.Web/package-lock.json`) incorrectly causing a CLI release; auditing the file surfaced two more stale globs from past workflow renames.

## Changes (commit by commit)

**1. `fix(ci): stop CLI release triggering on unrelated changes`**

The `clis` filter used `'\!src/Worms.Cli.Tests/**'` to try to exclude the test project. But `dorny/paths-filter` combines patterns with **OR** by default, so a negated pattern matches *every file not under* `Worms.Cli.Tests/` — making `clis` true for almost any change, including Web edits. Replaced the `src/Worms.Cli.*/**` wildcard + negation with the explicit `src/Worms.Cli.Resources/**`, so the test project no longer matches (the original intent) and unrelated changes stop triggering the CLI release.

**2. `fix(ci): repair workflow path globs broken by the zz-* rename`**

The hub workflows were renamed (`hub-build.yml`/`hub-release.yml` → `zz-build-hub.yml`/`zz-release-hub.yml`), but two filters still referenced `'.github/workflows/hub-*.yml'`, which now matches nothing:
- `hub-common` → `zz-*-hub.yml` (a shared hub workflow change once again triggers the gateway/wa-runner releases it gates).
- `clis` → `zz-*-cli.yml` (the hub glob was a copy-paste into the CLI filter; pointed at the CLI's own workflows instead).

**3. `chore(ci): drop dead zz-inspections.yml path filter`**

`zz-inspections.yml` was combined into `code-scanning.yml`; that glob matched nothing and `code-scanning.yml` is already covered by `code-*.yml`. Removed the dead line (no functional change).

## Verification

- A Web-only change now reports `clis-release = false` while `web-build` / `gateway-release` stay `true`.
- A real `src/Worms.Cli/` change still reports `clis-release = true`.
- Glob sanity-checked: `zz-*-hub.yml` → `zz-build-hub.yml`, `zz-release-hub.yml`; `zz-*-cli.yml` → `zz-build-cli.yml`, `zz-release-cli.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)