### PR TITLE
Rank games as winner-takes-all

### DIFF
--- a/build/docker/gateway/config.mk
+++ b/build/docker/gateway/config.mk
@@ -1,3 +1,3 @@
-gateway_NEXT_VERSION := 0.9
+gateway_NEXT_VERSION := 0.10
 gateway_TAG_PREFIX := hub/v
 gateway_RELEASE_NAME := Hub Gateway

--- a/src/Worms.Armageddon.Files.Tests/Replays/PlacementCalculatorShould.cs
+++ b/src/Worms.Armageddon.Files.Tests/Replays/PlacementCalculatorShould.cs
@@ -18,62 +18,13 @@ internal sealed class PlacementCalculatorShould
     }
 
     [Test]
-    public void ReturnPlacementsForThreeTeamsEliminatedInDifferentTurns()
+    public void ReturnAllTeamsAtPositionOneForDraw()
     {
-        // Team1 eliminated in turn 0, Team2 in turn 1, Team3 survives
-        const string log = """
-                           Red: "machine1" as "Team1"
-                           Blue: "machine2" as "Team2"
-                           Green: "machine3" as "Team3"
-                           [00:01:00.00] ••• Team3 (machine3) starts turn
-                           [00:01:10.00] ••• Damage dealt: 100 (1 kill) to Team1 (machine1)
-                           [00:01:20.00] ••• Team3 (machine3) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           [00:02:00.00] ••• Team3 (machine3) starts turn
-                           [00:02:10.00] ••• Damage dealt: 100 (1 kill) to Team2 (machine2)
-                           [00:02:20.00] ••• Team3 (machine3) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           Team3 wins the match!
-                           """;
-
-        var replay = _replayTextReader.GetModel(log);
-
-        replay.Placements.Count.ShouldBe(3);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team3" && p.Position == 1);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team2" && p.Position == 2);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 3);
-    }
-
-    [Test]
-    public void ReturnTiedPlacementForTwoTeamsEliminatedInSameTurn()
-    {
-        // Team1 and Team2 both eliminated in turn 0, Team3 survives
-        const string log = """
-                           Red: "machine1" as "Team1"
-                           Blue: "machine2" as "Team2"
-                           Green: "machine3" as "Team3"
-                           [00:01:00.00] ••• Team3 (machine3) starts turn
-                           [00:01:10.00] ••• Damage dealt: 100 (1 kill) to Team1 (machine1), 100 (1 kill) to Team2 (machine2)
-                           [00:01:20.00] ••• Team3 (machine3) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           Team3 wins the match!
-                           """;
-
-        var replay = _replayTextReader.GetModel(log);
-
-        replay.Placements.Count.ShouldBe(3);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team3" && p.Position == 1);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 2);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team2" && p.Position == 2);
-    }
-
-    [Test]
-    public void ReturnAllTeamsAtPositionOneForFullDrawInSameTurn()
-    {
-        // All 3 teams eliminated in the same final turn
         const string log = """
                            Red: "machine1" as "Team1"
                            Blue: "machine2" as "Team2"
                            Green: "machine3" as "Team3"
                            [00:01:00.00] ••• Team1 (machine1) starts turn
-                           [00:01:10.00] ••• Damage dealt: 100 (1 kill) to Team2 (machine2), 100 (1 kill) to Team3 (machine3), 100 (1 kill) to Team1 (machine1)
                            [00:01:20.00] ••• Team1 (machine1) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
                            The round was drawn.
                            """;
@@ -87,34 +38,8 @@ internal sealed class PlacementCalculatorShould
     }
 
     [Test]
-    public void ReturnCorrectPositionsForPartialDrawWhereOneTeamEliminatedEarlier()
+    public void ReturnNullPositionsWhenNoWinnerLine()
     {
-        // Team1 eliminated in turn 0; Team2 and Team3 eliminated in turn 1 (draw)
-        const string log = """
-                           Red: "machine1" as "Team1"
-                           Blue: "machine2" as "Team2"
-                           Green: "machine3" as "Team3"
-                           [00:01:00.00] ••• Team2 (machine2) starts turn
-                           [00:01:10.00] ••• Damage dealt: 100 (1 kill) to Team1 (machine1)
-                           [00:01:20.00] ••• Team2 (machine2) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           [00:02:00.00] ••• Team3 (machine3) starts turn
-                           [00:02:10.00] ••• Damage dealt: 100 (1 kill) to Team2 (machine2), 100 (1 kill) to Team3 (machine3)
-                           [00:02:20.00] ••• Team3 (machine3) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           The round was drawn.
-                           """;
-
-        var replay = _replayTextReader.GetModel(log);
-
-        replay.Placements.Count.ShouldBe(3);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team2" && p.Position == 1);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team3" && p.Position == 1);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 3);
-    }
-
-    [Test]
-    public void ReturnEmptyPlacementsWhenNoWinnerLine()
-    {
-        // Log with turns and kills but no winner/draw line
         const string log = """
                            Red: "machine1" as "Team1"
                            Blue: "machine2" as "Team2"
@@ -131,47 +56,58 @@ internal sealed class PlacementCalculatorShould
     }
 
     [Test]
-    public void ExcessKillsInflateWormsPerTeamAffectingOtherTeams()
+    public void ReturnSoloWinnerAtPositionOne()
     {
-        // 1 worm per team. Team2 kills Team1 in turn 0 and Team3 in turn 1.
-        // An additional kill entry against Team1 appears in turn 0 after the eliminating kill.
-        // Because the extra entry is a separate damage line in the same turn after Team1 already
-        // reached wormsPerTeam=1, the cap in pass 2 skips it. Team1's eliminationTurn is turn 0,
-        // not moved later by the extra entry. Team3 is eliminated in turn 1. Team2 wins.
-        //
-        // wormsPerTeam: uncapped totals are Team1=2 (1 real + 1 excess), Team3=1 → max=2.
-        // Pass 2 with wormsPerTeam=2:
-        //   Team1 turn 0 entry 1: cum=1 < 2. Not yet eliminated.
-        //   Team1 turn 0 entry 2: cum=2 = wormsPerTeam → eliminationTurn[Team1]=0.
-        //   Team3 turn 1: cum=1 < 2. Never reaches 2. No eliminationTurn → survives.
-        //
-        // Result: Team2 pos 1 (no kills against it), Team3 pos 1 (never eliminated),
-        //         Team1 pos 3 (two teams — Team2 and Team3 — have a higher rank key).
-        //
-        // The extra kill for Team1 inflated wormsPerTeam from 1 to 2, causing Team3 to appear
-        // as a survivor rather than being eliminated in turn 1. This is a known limitation of
-        // inferring wormsPerTeam from the uncapped maximum; see learnings.md for details.
-        // The test verifies the algorithm's defined behaviour: excess kills do not cause any
-        // other team to be recorded as eliminated EARLIER than they would otherwise be.
+        const string log = """
+                           Red: "machine1" as "Team1"
+                           [00:01:00.00] ••• Team1 (machine1) starts turn
+                           [00:01:20.00] ••• Team1 (machine1) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
+                           Team1 wins the match!
+                           """;
+
+        var replay = _replayTextReader.GetModel(log);
+
+        replay.Placements.Count.ShouldBe(1);
+        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 1);
+    }
+
+    [Test]
+    public void ReturnAllTeamsAtPositionOneWhenWinnerNameMatchesNoTeam()
+    {
         const string log = """
                            Red: "machine1" as "Team1"
                            Blue: "machine2" as "Team2"
                            Green: "machine3" as "Team3"
-                           [00:01:00.00] ••• Team2 (machine2) starts turn
-                           [00:01:05.00] ••• Damage dealt: 100 (1 kill) to Team1 (machine1)
-                           [00:01:10.00] ••• Damage dealt: 100 (1 kill) to Team1 (machine1)
-                           [00:01:20.00] ••• Team2 (machine2) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           [00:02:00.00] ••• Team2 (machine2) starts turn
-                           [00:02:10.00] ••• Damage dealt: 100 (1 kill) to Team3 (machine3)
-                           [00:02:20.00] ••• Team2 (machine2) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
-                           Team2 wins the match!
+                           [00:01:00.00] ••• Team1 (machine1) starts turn
+                           [00:01:20.00] ••• Team1 (machine1) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
+                           Ghost wins the match!
                            """;
 
         var replay = _replayTextReader.GetModel(log);
 
         replay.Placements.Count.ShouldBe(3);
+        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 1);
         replay.Placements.ShouldContain(p => p.Team.Name == "Team2" && p.Position == 1);
         replay.Placements.ShouldContain(p => p.Team.Name == "Team3" && p.Position == 1);
-        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 3);
+    }
+
+    [Test]
+    public void ReturnWinnerAtPositionOneAndOthersAtPositionTwo()
+    {
+        const string log = """
+                           Red: "machine1" as "Team1"
+                           Blue: "machine2" as "Team2"
+                           Green: "machine3" as "Team3"
+                           [00:01:00.00] ••• Team1 (machine1) starts turn
+                           [00:01:20.00] ••• Team1 (machine1) ends turn; time used: 20.00 sec turn, 3.00 sec retreat
+                           Team3 wins the match!
+                           """;
+
+        var replay = _replayTextReader.GetModel(log);
+
+        replay.Placements.Count.ShouldBe(3);
+        replay.Placements.ShouldContain(p => p.Team.Name == "Team3" && p.Position == 1);
+        replay.Placements.ShouldContain(p => p.Team.Name == "Team1" && p.Position == 2);
+        replay.Placements.ShouldContain(p => p.Team.Name == "Team2" && p.Position == 2);
     }
 }

--- a/src/Worms.Armageddon.Files/Replays/PlacementCalculator.cs
+++ b/src/Worms.Armageddon.Files/Replays/PlacementCalculator.cs
@@ -3,7 +3,6 @@ namespace Worms.Armageddon.Files.Replays;
 internal static class PlacementCalculator
 {
     public static IReadOnlyCollection<Placement> Calculate(
-        IReadOnlyCollection<Turn> turns,
         IReadOnlyCollection<Team> teams,
         string winner)
     {
@@ -12,63 +11,11 @@ internal static class PlacementCalculator
             return teams.Select(t => new Placement(t, null)).ToList();
         }
 
-        // Pass 1: uncapped totals to find wormsPerTeam
-        var uncappedTotals = new Dictionary<Team, uint>();
-        foreach (var turn in turns)
+        if (winner == "Draw" || teams.All(t => t.Name != winner))
         {
-            foreach (var damage in turn.Damage)
-            {
-                uncappedTotals.TryGetValue(damage.Team, out var current);
-                uncappedTotals[damage.Team] = current + damage.WormsKilled;
-            }
+            return teams.Select(t => new Placement(t, 1)).ToList();
         }
 
-        var wormsPerTeam = uncappedTotals.Values.Count > 0 ? uncappedTotals.Values.Max() : 0u;
-
-        if (wormsPerTeam == 0)
-        {
-            return teams.Select(t => new Placement(t, null)).ToList();
-        }
-
-        // Pass 2: capped pass to find elimination turn index per team
-        var cumulativeKills = new Dictionary<Team, uint>();
-        var eliminationTurn = new Dictionary<Team, int>();
-
-        foreach (var (i, turn) in turns.Select((turn, i) => (i, turn)))
-        {
-            foreach (var damage in turn.Damage)
-            {
-                if (damage.WormsKilled == 0)
-                {
-                    continue;
-                }
-
-                cumulativeKills.TryGetValue(damage.Team, out var kills);
-                if (kills >= wormsPerTeam)
-                {
-                    continue;
-                }
-
-                kills += damage.WormsKilled;
-                cumulativeKills[damage.Team] = kills;
-
-                if (kills >= wormsPerTeam)
-                {
-                    eliminationTurn.TryAdd(damage.Team, i);
-                }
-            }
-        }
-
-        // Pass 3: assign positions based on rank key
-        var placements = new List<Placement>(teams.Count);
-        foreach (var team in teams)
-        {
-            var rankKey = eliminationTurn.GetValueOrDefault(team, int.MaxValue);
-            var position = teams.Count(t => eliminationTurn.GetValueOrDefault(t, int.MaxValue) > rankKey) + 1;
-
-            placements.Add(new Placement(team, position));
-        }
-
-        return placements;
+        return teams.Select(t => new Placement(t, t.Name == winner ? 1 : 2)).ToList();
     }
 }

--- a/src/Worms.Armageddon.Files/Replays/ReplayResourceBuilder.cs
+++ b/src/Worms.Armageddon.Files/Replays/ReplayResourceBuilder.cs
@@ -49,7 +49,7 @@ internal sealed class ReplayResourceBuilder
 
     public ReplayResource Build()
     {
-        var placements = PlacementCalculator.Calculate(_turns, _teams, _winner);
+        var placements = PlacementCalculator.Calculate(_teams, _winner);
         return new ReplayResource(_start, true, _winner, _turns, placements, _fullLog);
     }
 }

--- a/src/Worms.Hub.Gateway/Worker/StartupBackfiller.cs
+++ b/src/Worms.Hub.Gateway/Worker/StartupBackfiller.cs
@@ -16,6 +16,7 @@ internal sealed class StartupBackfiller(
     {
         await BackfillPlacements(cancellationToken);
         await BackfillRatings(cancellationToken);
+        await RerankAllGames(cancellationToken);
     }
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types",
@@ -134,5 +135,86 @@ internal sealed class StartupBackfiller(
         }
 
         logger.LogInformation("Ratings backfill complete.");
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Re-rank continues with remaining replays/leagues even if one fails")]
+    private async Task RerankAllGames(CancellationToken _)
+    {
+        using var activity = Telemetry.Source.StartActivity("Winner-Takes-All Re-rank");
+
+        using var scope = serviceProvider.CreateScope();
+        var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
+
+        var connectionString = configuration.GetConnectionString("Database");
+        await using var connection = new NpgsqlConnection(connectionString);
+
+        // The data_fixes table ships in migration V0.10. The gateway may start against an
+        // older schema during a rollout (code deployed before the migration is applied), so
+        // skip gracefully rather than crashing — the re-rank runs on a later startup once the
+        // schema is current.
+        var tableExists = await connection.QuerySingleAsync<string?>(
+            "SELECT to_regclass('public.data_fixes')::text");
+        if (tableExists is null)
+        {
+            logger.LogInformation(
+                "data_fixes table does not exist yet — skipping winner-takes-all re-rank until the schema is migrated.");
+            return;
+        }
+
+        var markerCount = await connection.QuerySingleAsync<long>(
+            "SELECT COUNT(*) FROM data_fixes WHERE name = 'winner-takes-all-rerank'");
+        if (markerCount > 0)
+        {
+            logger.LogInformation("Winner-takes-all re-rank already applied — skipping.");
+            return;
+        }
+
+        logger.LogInformation("Starting winner-takes-all re-rank...");
+
+        var replayRepository = scope.ServiceProvider.GetRequiredService<IReplaysRepository>();
+        var replayTextReader = scope.ServiceProvider.GetRequiredService<IReplayTextReader>();
+        var leaguesRepository = scope.ServiceProvider.GetRequiredService<ILeaguesRepository>();
+        var ratingsCalculator = scope.ServiceProvider.GetRequiredService<RatingsCalculator>();
+
+        foreach (var replay in replayRepository.GetAll().Where(r => r.Status == "Processed"))
+        {
+            if (string.IsNullOrEmpty(replay.FullLog))
+            {
+                logger.LogDebug("Skipping replay {ReplayId} — no full log available.", replay.Id);
+                continue;
+            }
+
+            try
+            {
+                var replayModel = replayTextReader.GetModel(replay.FullLog);
+                var placements = replayModel.Placements
+                    .Select(p => new ReplayPlacement(p.Team.Machine, p.Team.Name, p.Position, null, null, null))
+                    .ToList();
+                replayRepository.Update(replay with { Placements = placements });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to re-rank placements for replay {ReplayId}.", replay.Id);
+            }
+        }
+
+        foreach (var leagueId in leaguesRepository.GetAll().Select(l => l.Id))
+        {
+            try
+            {
+                ratingsCalculator.Calculate(leagueId);
+                logger.LogInformation("Recalculated ELO ratings for league {LeagueId}.", leagueId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to recalculate ELO ratings for league {LeagueId}.", leagueId);
+            }
+        }
+
+        await connection.ExecuteAsync(
+            "INSERT INTO data_fixes (name) VALUES ('winner-takes-all-rerank') ON CONFLICT (name) DO NOTHING");
+
+        logger.LogInformation("Winner-takes-all re-rank complete.");
     }
 }

--- a/src/database/migrations/V0.10__AddDataFixMarker.sql
+++ b/src/database/migrations/V0.10__AddDataFixMarker.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS public.data_fixes (
+    name text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
Closes #1419

## Why

A game-log bug means deaths caused by rising water aren't written to the replay log. The current ranking code infers placements from kills/elimination turns, so teams that drowned can be mis-ranked. While we wait for an official fix to the log output, we switch to a simpler rule that doesn't depend on the missing lines: **assume the winner beats everyone**.

## What

- **`PlacementCalculator`** — replaced the three-pass kill/elimination-turn algorithm with winner-takes-all:
  - Winner → 1st, all other teams → 2nd
  - Draw or unrecognised winner → every team 1st
  - No winner/draw line → every position `null` (game stays unrated)
  - Dropped the now-unused `turns` parameter from `Calculate` (single caller updated).
- **`StartupBackfiller`** — one-shot re-rank of existing games on startup: re-parse every processed replay that still has its full log, rewrite placements, and recalculate ELO per league. Guarded by a new `data_fixes` marker so it runs exactly once, and tolerant of booting against the pre-`V0.10` schema during a rollout (checks for the table via `to_regclass` and skips gracefully).
- **Migration `V0.10`** — adds the `data_fixes` marker table.
- Unit tests rewritten to assert the winner-beats-all behaviour.

## Temporary

The winner-takes-all rule and its startup re-rank are intentionally throwaway — both will be reverted via source control once the official log fix is available. The bumping of `database-version` in `Pulumi.yaml` is a rollout concern and is deliberately left out of this PR.

## Testing

`PlacementCalculatorShould` rewritten and passing (5/5); full unit suite green. `dotnet build` clean for the touched files; `jb inspectcode` reports 0 findings on the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)