### PR TITLE
Run deploy-preview on pull requests so pre-deployment reports post again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   changes:
@@ -14,7 +19,7 @@ jobs:
   deploy-preview:
     name: Deploy Preview
     needs: changes
-    if: needs.changes.outputs.deployment == 'true' && github.ref != 'refs/heads/main'
+    if: needs.changes.outputs.deployment == 'true' && github.event_name == 'pull_request'
     uses: ./.github/workflows/zz-deploy-preview.yml
     secrets: inherit
 
@@ -22,7 +27,7 @@ jobs:
     name: Azure Infrastructure
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.deployment == 'true' && github.ref == 'refs/heads/main'
+    if: needs.changes.outputs.deployment == 'true' && github.event_name == 'push'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What & why

The pre-deployment reports — the Pulumi infrastructure preview comment and the Flyway database drift/changes sticky comment — stopped appearing on PRs. Both rely on commenting actions (`marocchino/sticky-pull-request-comment` and Pulumi's `comment-on-pr: true`) that need a pull request in the event context.

Since commit `1447a389` ("Consolidate branch/main split workflows into unified workflows") removed the `pull_request` trigger that the old `code-branch.yml` had, `deploy.yml` triggered `on: push:` only. On a push there is no associated PR, so the preview still ran but the reports were never posted.

## Changes

- Add a `pull_request: branches: [main]` trigger and scope the existing `push` trigger to `branches: [main]`. Scoping `push` to `main` avoids a double-run: a commit on a PR branch fires only the `pull_request` event (one preview), and a `main` push fires only the `push` event (one prod deploy).
- Switch the job gates from `github.ref` checks to `github.event_name` checks:
  - `deploy-preview` runs only on `github.event_name == 'pull_request'`
  - `deploy` (production `Pulumi Up` + `Flyway Migrate`) runs only on `github.event_name == 'push'` — never on a PR.

Only `deploy.yml` changed. `zz-deploy-preview.yml` has no `github.ref`/`github.event_name` guards, so it needed no edit. The `overall-deploy` gate already treats a *skipped* job as non-failing, so the non-applicable job being skipped per event still passes the gate.

## Notes / limitations

- Fork PRs do not receive secrets and the preview would fail for them — accepted limitation in a single-maintainer repo where PRs come from same-repo branches. A plain `pull_request` trigger (not `pull_request_target`) is used to avoid running untrusted code with secrets.
- No concurrency control added; overlapping read-only previews are accepted as wasteful-but-safe.

Fixes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)