### PR TITLE
Fix the SARIF merge

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -69,7 +69,7 @@ jobs:
           mkdir -p sarif
           dotnet build Worms.sln /p:Sarif=true
           dotnet tool install --local Sarif.Multitool
-          dotnet sarif merge sarif/*.sarif --recurse true --merge-runs --output-file=roslyn.sarif
+          dotnet sarif merge sarif/*.sarif --recurse true --output-file=roslyn.sarif
 
       - name: Remove suppressed results
         run: |


### PR DESCRIPTION
The SARIF merge tool had a breaking change in a recent version of the tool. We seem to float the version of the tool used so all branches are now failing.