### PR TITLE
Gateway Replays endpoints covered

### DIFF
--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -6,6 +6,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using NSubstitute;
 using Worms.Hub.Gateway.Announcers;
+using Worms.Hub.Queues;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Domain;
 
@@ -13,9 +14,17 @@ namespace Worms.Hub.Gateway.Tests;
 
 internal sealed class GatewayTestHost : WebApplicationFactory<Program>
 {
+    private readonly string _tempReplayFolder =
+        Path.Combine(Path.GetTempPath(), "worms-gateway-tests", Guid.NewGuid().ToString("N"));
+
     internal IRepository<Game> GamesRepository { get; } = Substitute.For<IRepository<Game>>();
 
     internal IAnnouncer Announcer { get; } = Substitute.For<IAnnouncer>();
+
+    internal IReplaysRepository ReplaysRepository { get; } = Substitute.For<IReplaysRepository>();
+
+    internal IMessageQueue<ReplayToProcessMessage> ReplayProcessorQueue { get; } =
+        Substitute.For<IMessageQueue<ReplayToProcessMessage>>();
 
     public GatewayTestHost()
     {
@@ -24,6 +33,7 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("WORMS_HUB_DISTRIBUTED", "true");
         Environment.SetEnvironmentVariable("WORMS_HUB_GATEWAY", "true");
         Environment.SetEnvironmentVariable("WORMS_HUB_WORKER", null);
+        Environment.SetEnvironmentVariable("WORMS_STORAGE__TEMPREPLAYFOLDER", _tempReplayFolder);
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -66,6 +76,12 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
 
             services.RemoveAll<IAnnouncer>();
             services.AddSingleton(Announcer);
+
+            services.RemoveAll<IReplaysRepository>();
+            services.AddSingleton(ReplaysRepository);
+
+            services.RemoveAll<IMessageQueue<ReplayToProcessMessage>>();
+            services.AddSingleton(ReplayProcessorQueue);
         });
     }
 
@@ -84,6 +100,15 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
         {
             Environment.SetEnvironmentVariable("WORMS_HUB_DISTRIBUTED", null);
             Environment.SetEnvironmentVariable("WORMS_HUB_GATEWAY", null);
+            Environment.SetEnvironmentVariable("WORMS_STORAGE__TEMPREPLAYFOLDER", null);
+            try
+            {
+                if (Directory.Exists(_tempReplayFolder))
+                {
+                    Directory.Delete(_tempReplayFolder, recursive: true);
+                }
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException) { /* best-effort cleanup */ }
         }
 
         base.Dispose(disposing);

--- a/src/Worms.Hub.Gateway.Tests/ReplaysAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysAuthShould.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Headers;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Gateway.Tests;
+
+[TestFixture]
+[SuppressMessage("Design", "CA1001", Justification = "Disposed in TearDown")]
+internal sealed class ReplaysAuthShould
+{
+    private static readonly Uri ReplaysUri = new("api/v1/replays", UriKind.Relative);
+
+    // A minimal valid replay: correct .wagame extension, WA signature
+    private static readonly byte[] ValidReplayBytes = BuildValidReplayBytes();
+
+    private static byte[] BuildValidReplayBytes()
+    {
+        var bytes = new byte[64];
+        bytes[0] = (byte)'W';
+        bytes[1] = (byte)'A';
+        return bytes;
+    }
+
+    private GatewayTestHost _host = null!;
+
+    [SetUp]
+    public void SetUp() => _host = new GatewayTestHost();
+
+    [TearDown]
+    public void TearDown() => _host.Dispose();
+
+    [Test]
+    public async Task Return401WhenNoTokenIsSupplied()
+    {
+        using var client = _host.CreateClient();
+        using var content = BuildEmptyForm();
+
+        var response = await client.PostAsync(ReplaysUri, content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Return401WhenTokenIsInvalid()
+    {
+        using var client = _host.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", "not-a-jwt");
+        using var content = BuildEmptyForm();
+
+        var response = await client.PostAsync(ReplaysUri, content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Return403WhenTokenLacksAccessRole()
+    {
+        using var client = _host.CreateClient(TestJwt.WithoutAccessRole());
+        using var content = BuildEmptyForm();
+
+        var response = await client.PostAsync(ReplaysUri, content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Return200WhenTokenHasAccessRole()
+    {
+        var created = new Replay("1", "Game", "Pending", "file.dat", null, "redgate", null, null, null, null);
+        _host.ReplaysRepository.Create(Arg.Any<Replay>()).Returns(created);
+
+        using var client = _host.CreateClient(TestJwt.WithAccessRole());
+        using var content = BuildUpload("Game", ValidReplayBytes, "game.WAGame");
+
+        var response = await client.PostAsync(ReplaysUri, content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static MultipartFormDataContent BuildEmptyForm() => new();
+
+    [SuppressMessage("Reliability", "CA2000", Justification = "MultipartFormDataContent disposes its children")]
+    private static MultipartFormDataContent BuildUpload(string name, byte[] fileBytes, string fileName)
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(name), "Name");
+        var fileContent = new ByteArrayContent(fileBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "ReplayFile", fileName);
+        return content;
+    }
+}

--- a/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Headers;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Hub.Gateway.API.DTOs;
+using Worms.Hub.Queues;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Gateway.Tests;
+
+[TestFixture]
+[SuppressMessage("Design", "CA1001", Justification = "Disposed in TearDown")]
+internal sealed class ReplaysEndpointShould
+{
+    private const string ReplaysUrl = "api/v1/replays";
+
+    private GatewayTestHost _host = null!;
+    private HttpClient _client = null!;
+
+    // A minimal valid replay: correct .wagame extension, WA signature
+    private static readonly byte[] ValidReplayBytes = BuildValidReplayBytes();
+
+    private static byte[] BuildValidReplayBytes()
+    {
+        var bytes = new byte[64];
+        bytes[0] = (byte)'W';
+        bytes[1] = (byte)'A';
+        return bytes;
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _host = new GatewayTestHost();
+        _client = _host.CreateClient(TestJwt.WithAccessRole());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client.Dispose();
+        _host.Dispose();
+    }
+
+    [Test]
+    public async Task AcceptAValidReplayUpload()
+    {
+        var created = new Replay("99", "My Game", "Pending", "temp-file.dat", null, "redgate", null, null, null, null);
+        _host.ReplaysRepository.Create(Arg.Any<Replay>()).Returns(created);
+
+        using var content = BuildUpload("My Game", ValidReplayBytes, "game.WAGame");
+        var response = await _client.PostAsync(new Uri(ReplaysUrl, UriKind.Relative), content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var dto = await response.Content.ReadFromJsonAsync<ReplayDto>();
+        dto.ShouldNotBeNull();
+        dto.Id.ShouldBe("99");
+        dto.Name.ShouldBe("My Game");
+        dto.Status.ShouldBe("Pending");
+
+        _host.ReplaysRepository.Received(1).Create(
+            Arg.Is<Replay>(r =>
+                r.Name == "My Game" &&
+                r.Status == "Pending" &&
+                r.Id == "0" &&
+                r.LeagueId == "redgate"));
+
+        await _host.ReplayProcessorQueue.Received(1).EnqueueMessage(
+            Arg.Is<ReplayToProcessMessage>(m => m.ReplayFileName == created.Filename));
+    }
+
+    [Test]
+    public async Task RejectAnUploadWithBadSignature()
+    {
+        using var content = BuildUpload("My Game", "\0\0\0"u8.ToArray(), "game.WAGame");
+        var response = await _client.PostAsync(new Uri(ReplaysUrl, UriKind.Relative), content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        _host.ReplaysRepository.DidNotReceive().Create(Arg.Any<Replay>());
+        await _host.ReplayProcessorQueue.DidNotReceive().EnqueueMessage(Arg.Any<ReplayToProcessMessage>());
+    }
+
+    [Test]
+    public async Task RejectAnUploadWithTheWrongExtension()
+    {
+        using var content = BuildUpload("My Game", ValidReplayBytes, "game.txt");
+        var response = await _client.PostAsync(new Uri(ReplaysUrl, UriKind.Relative), content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        _host.ReplaysRepository.DidNotReceive().Create(Arg.Any<Replay>());
+        await _host.ReplayProcessorQueue.DidNotReceive().EnqueueMessage(Arg.Any<ReplayToProcessMessage>());
+    }
+
+    [SuppressMessage("Reliability", "CA2000", Justification = "MultipartFormDataContent disposes its children")]
+    private static MultipartFormDataContent BuildUpload(string name, byte[] fileBytes, string fileName)
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(name), "Name");
+        var fileContent = new ByteArrayContent(fileBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "ReplayFile", fileName);
+        return content;
+    }
+}


### PR DESCRIPTION
Closes #1371

## What

End-to-end tests for `POST api/v1/replays` using the test-only JWT issuer and faked repository/queue seams, consistent with the Games endpoint tests from #1370.

## Changes

- **`GatewayTestHost`** — adds `IReplaysRepository` and `IMessageQueue<ReplayToProcessMessage>` NSubstitute fakes; provisions a per-run temp directory via `WORMS_STORAGE__TEMPREPLAYFOLDER` so `ReplayFiles` (concrete, non-virtual) has somewhere to write and is cleaned up in `Dispose`
- **`ReplaysEndpointShould`** — 3 tests: valid upload → 200 + correct DTO + fakes called once; bad signature → 400; wrong extension → 400
- **`ReplaysAuthShould`** — 4 tests: no token → 401; garbage token → 401; valid JWT without `access` role → 403; valid JWT with `access` role → 200

All 18 Gateway tests pass. No production code changed.