### PR TITLE
Gateway Leagues endpoints covered

### DIFF
--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -26,6 +26,13 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
     internal IMessageQueue<ReplayToProcessMessage> ReplayProcessorQueue { get; } =
         Substitute.For<IMessageQueue<ReplayToProcessMessage>>();
 
+    internal ILeaguesRepository LeaguesRepository { get; } = Substitute.For<ILeaguesRepository>();
+
+    internal IRatingsRepository RatingsRepository { get; } = Substitute.For<IRatingsRepository>();
+
+    internal string SchemesFolder { get; } =
+        Path.Combine(Path.GetTempPath(), "worms-gateway-tests-schemes", Guid.NewGuid().ToString("N"));
+
     public GatewayTestHost()
     {
         // Boot only the gateway (not the worker) so no hosted services are started
@@ -34,6 +41,8 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("WORMS_HUB_GATEWAY", "true");
         Environment.SetEnvironmentVariable("WORMS_HUB_WORKER", null);
         Environment.SetEnvironmentVariable("WORMS_STORAGE__TEMPREPLAYFOLDER", _tempReplayFolder);
+        Directory.CreateDirectory(SchemesFolder);
+        Environment.SetEnvironmentVariable("WORMS_STORAGE__SCHEMESFOLDER", SchemesFolder);
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -82,6 +91,12 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
 
             services.RemoveAll<IMessageQueue<ReplayToProcessMessage>>();
             services.AddSingleton(ReplayProcessorQueue);
+
+            services.RemoveAll<ILeaguesRepository>();
+            services.AddSingleton(LeaguesRepository);
+
+            services.RemoveAll<IRatingsRepository>();
+            services.AddSingleton(RatingsRepository);
         });
     }
 
@@ -101,16 +116,23 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
             Environment.SetEnvironmentVariable("WORMS_HUB_DISTRIBUTED", null);
             Environment.SetEnvironmentVariable("WORMS_HUB_GATEWAY", null);
             Environment.SetEnvironmentVariable("WORMS_STORAGE__TEMPREPLAYFOLDER", null);
-            try
-            {
-                if (Directory.Exists(_tempReplayFolder))
-                {
-                    Directory.Delete(_tempReplayFolder, recursive: true);
-                }
-            }
-            catch (Exception e) when (e is IOException or UnauthorizedAccessException) { /* best-effort cleanup */ }
+            Environment.SetEnvironmentVariable("WORMS_STORAGE__SCHEMESFOLDER", null);
+            TryDeleteFolder(_tempReplayFolder);
+            TryDeleteFolder(SchemesFolder);
         }
 
         base.Dispose(disposing);
+    }
+
+    private static void TryDeleteFolder(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException) { /* best-effort cleanup */ }
     }
 }

--- a/src/Worms.Hub.Gateway.Tests/LeaguesAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesAuthShould.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Headers;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Hub.Storage.Database;
+
+namespace Worms.Hub.Gateway.Tests;
+
+[TestFixture]
+[SuppressMessage("Design", "CA1001", Justification = "Disposed in TearDown")]
+internal sealed class LeaguesAuthShould
+{
+    private static readonly Uri LeaguesUri = new("api/v1/leagues", UriKind.Relative);
+
+    private GatewayTestHost _host = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _host = new GatewayTestHost();
+        _host.LeaguesRepository.GetAll().Returns(Array.Empty<LeagueDb>());
+    }
+
+    [TearDown]
+    public void TearDown() => _host.Dispose();
+
+    [Test]
+    public async Task Return401WhenNoTokenIsSupplied()
+    {
+        using var client = _host.CreateClient();
+
+        var response = await client.GetAsync(LeaguesUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Return401WhenTokenIsInvalid()
+    {
+        using var client = _host.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", "not-a-jwt");
+
+        var response = await client.GetAsync(LeaguesUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Return403WhenTokenLacksAccessRole()
+    {
+        using var client = _host.CreateClient(TestJwt.WithoutAccessRole());
+
+        var response = await client.GetAsync(LeaguesUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Return200WhenTokenHasAccessRole()
+    {
+        using var client = _host.CreateClient(TestJwt.WithAccessRole());
+
+        var response = await client.GetAsync(LeaguesUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Net.Http.Json;
 using NSubstitute;
 using NUnit.Framework;
 using Shouldly;

--- a/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
@@ -1,0 +1,244 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Hub.Gateway.API.DTOs;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Gateway.Tests;
+
+[TestFixture]
+[SuppressMessage("Design", "CA1001", Justification = "Disposed in TearDown")]
+internal sealed class LeaguesEndpointShould
+{
+    private const string LeaguesUrl = "api/v1/leagues";
+
+    private GatewayTestHost _host = null!;
+    private HttpClient _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _host = new GatewayTestHost();
+        _client = _host.CreateClient(TestJwt.WithAccessRole());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client.Dispose();
+        _host.Dispose();
+    }
+
+    private void WriteVersionFile(string leagueId, string version) =>
+        File.WriteAllText(Path.Combine(_host.SchemesFolder, $"{leagueId}-version.txt"), version);
+
+    // GET /api/v1/leagues
+
+    [Test]
+    public async Task ReturnEmptyListWhenNoLeaguesExist()
+    {
+        _host.LeaguesRepository.GetAll().Returns([]);
+
+        var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var leagues = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<LeagueDto>>();
+        leagues.ShouldNotBeNull();
+        leagues.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task ReturnAllLeaguesWithStandings()
+    {
+        _host.LeaguesRepository.GetAll().Returns(
+        [
+            new LeagueDb("redgate", "Red Gate"),
+            new LeagueDb("other", "Other")
+        ]);
+        _host.RatingsRepository.GetByLeagueId("redgate").Returns(
+        [
+            new PlayerRating("sub1", "Alice", "redgate", 1500, 10),
+            new PlayerRating("sub2", "Bob", "redgate", 1400, 8)
+        ]);
+        _host.RatingsRepository.GetByLeagueId("other").Returns([]);
+
+        var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var leagues = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<LeagueDto>>();
+        leagues.ShouldNotBeNull();
+        leagues.Count.ShouldBe(2);
+        var redgate = leagues.FirstOrDefault(l => l.Id == "redgate");
+        redgate.ShouldNotBeNull();
+        redgate.Name.ShouldBe("Red Gate");
+        redgate.Standings.Count.ShouldBe(2);
+        redgate.Standings.ShouldContain(s => s.PlayerName == "Alice" && s.Elo == 1500 && s.GamesPlayed == 10);
+        redgate.Standings.ShouldContain(s => s.PlayerName == "Bob" && s.Elo == 1400 && s.GamesPlayed == 8);
+    }
+
+    [Test]
+    public async Task ReturnNullVersionAndSchemeUrlWhenNoVersionFileExists()
+    {
+        _host.LeaguesRepository.GetAll().Returns([new LeagueDb("redgate", "Red Gate")]);
+        _host.RatingsRepository.GetByLeagueId("redgate").Returns([]);
+
+        var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var leagues = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<LeagueDto>>();
+        leagues.ShouldNotBeNull();
+        var redgate = leagues.FirstOrDefault(l => l.Id == "redgate");
+        redgate.ShouldNotBeNull();
+        redgate.Version.ShouldBeNull();
+        redgate.SchemeUrl.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ReturnVersionAndSchemeUrlWhenVersionFileExists()
+    {
+        _host.LeaguesRepository.GetAll().Returns([new LeagueDb("redgate", "Red Gate")]);
+        _host.RatingsRepository.GetByLeagueId("redgate").Returns([]);
+        WriteVersionFile("redgate", "1.2.3");
+
+        var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var leagues = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<LeagueDto>>();
+        leagues.ShouldNotBeNull();
+        var redgate = leagues.FirstOrDefault(l => l.Id == "redgate");
+        redgate.ShouldNotBeNull();
+        redgate.Version.ShouldNotBeNull();
+        redgate.Version!.ToString().ShouldBe("1.2.3");
+        redgate.SchemeUrl.ShouldNotBeNull();
+        redgate.SchemeUrl!.ToString().ShouldEndWith("api/v1/files/schemes/redgate");
+    }
+
+    // GET /api/v1/leagues/{id}
+
+    [Test]
+    public async Task ReturnLeagueByIdWhenItExists()
+    {
+        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
+        _host.RatingsRepository.GetByLeagueId("redgate").Returns(
+        [
+            new PlayerRating("sub1", "Alice", "redgate", 1500, 10)
+        ]);
+        WriteVersionFile("redgate", "1.0.0");
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<LeagueDto>();
+        dto.ShouldNotBeNull();
+        dto.Id.ShouldBe("redgate");
+        dto.Name.ShouldBe("Red Gate");
+        dto.Standings.Count.ShouldBe(1);
+        dto.Standings[0].PlayerName.ShouldBe("Alice");
+        dto.Version.ShouldNotBeNull();
+        dto.SchemeUrl.ShouldNotBeNull();
+    }
+
+    [Test]
+    public async Task Return404WhenLeagueByIdDoesNotExist()
+    {
+        _host.LeaguesRepository.GetById("missing").Returns((LeagueDb?)null);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // GET /api/v1/leagues/{id}/replays
+
+    [Test]
+    public async Task ReturnEmptyReplaysWhenLeagueHasNone()
+    {
+        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
+        _host.ReplaysRepository.GetByLeagueId("redgate").Returns([]);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var replays = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ReplayDetailDto>>();
+        replays.ShouldNotBeNull();
+        replays.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task ReturnReplaysWhenLeagueHasThem()
+    {
+        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
+        _host.ReplaysRepository.GetByLeagueId("redgate").Returns(
+        [
+            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null)
+        ]);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var replays = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ReplayDetailDto>>();
+        replays.ShouldNotBeNull();
+        replays.Count.ShouldBe(1);
+        var replay = replays.First();
+        replay.Id.ShouldBe("99");
+        replay.Name.ShouldBe("My Game");
+        replay.Status.ShouldBe("Processed");
+    }
+
+    [Test]
+    public async Task Return404ForReplaysWhenLeagueIdIsUnknown()
+    {
+        _host.LeaguesRepository.GetById("missing").Returns((LeagueDb?)null);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing/replays", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // GET /api/v1/leagues/{id}/replays/{replayId}
+
+    [Test]
+    public async Task ReturnReplayWhenLeagueAndReplayExist()
+    {
+        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
+        _host.ReplaysRepository.GetByLeagueId("redgate").Returns(
+        [
+            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null)
+        ]);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays/99", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<ReplayDetailDto>();
+        dto.ShouldNotBeNull();
+        dto.Id.ShouldBe("99");
+    }
+
+    [Test]
+    public async Task Return404ForReplayWhenLeagueIdIsUnknown()
+    {
+        _host.LeaguesRepository.GetById("missing").Returns((LeagueDb?)null);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing/replays/99", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task Return404ForReplayWhenReplayIdIsNotFound()
+    {
+        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
+        _host.ReplaysRepository.GetByLeagueId("redgate").Returns(
+        [
+            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null)
+        ]);
+
+        var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays/123", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
Closes #1372

## Summary

- Extends `GatewayTestHost` with `ILeaguesRepository` and `IRatingsRepository` NSubstitute fakes and a per-instance temp schemes folder wired via `WORMS_STORAGE__SCHEMESFOLDER`, following the same pattern as the existing Games/Replays seams. Adds a `TryDeleteFolder` helper to deduplicate the best-effort cleanup on Dispose.
- Adds 4 auth tests for `GET /api/v1/leagues` (no token → 401, invalid token → 401, no role → 403, with role → 200).
- Adds 12 behaviour tests across all four Leagues endpoints covering standings, version/schemeUrl presence and absence, replay listing, and 404s for unknown IDs.

No production code is changed. All tests run in the existing unit-tier CI on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)