### PR TITLE
Cover Gateway Teams endpoints end-to-end

### DIFF
--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -6,6 +6,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using NSubstitute;
 using Worms.Hub.Gateway.Announcers;
+using Worms.Hub.Gateway.Ratings;
 using Worms.Hub.Queues;
 using Worms.Hub.Storage.Database;
 using Worms.Hub.Storage.Domain;
@@ -29,6 +30,12 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
     internal ILeaguesRepository LeaguesRepository { get; } = Substitute.For<ILeaguesRepository>();
 
     internal IRatingsRepository RatingsRepository { get; } = Substitute.For<IRatingsRepository>();
+
+    internal ITeamsRepository TeamsRepository { get; } = Substitute.For<ITeamsRepository>();
+
+    internal IPlayersRepository PlayersRepository { get; } = Substitute.For<IPlayersRepository>();
+
+    internal IRatingsCalculator RatingsCalculator { get; } = Substitute.For<IRatingsCalculator>();
 
     internal string SchemesFolder { get; } =
         Path.Combine(Path.GetTempPath(), "worms-gateway-tests-schemes", Guid.NewGuid().ToString("N"));
@@ -97,6 +104,15 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
 
             services.RemoveAll<IRatingsRepository>();
             services.AddSingleton(RatingsRepository);
+
+            services.RemoveAll<ITeamsRepository>();
+            services.AddSingleton(TeamsRepository);
+
+            services.RemoveAll<IPlayersRepository>();
+            services.AddSingleton(PlayersRepository);
+
+            services.RemoveAll<IRatingsCalculator>();
+            services.AddSingleton(RatingsCalculator);
         });
     }
 

--- a/src/Worms.Hub.Gateway.Tests/TeamsAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/TeamsAuthShould.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Headers;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Gateway.Tests;
+
+[TestFixture]
+[SuppressMessage("Design", "CA1001", Justification = "Disposed in TearDown")]
+internal sealed class TeamsAuthShould
+{
+    private static readonly Uri TeamsUri = new("api/v1/teams", UriKind.Relative);
+
+    private GatewayTestHost _host = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _host = new GatewayTestHost();
+        _host.TeamsRepository.GetAll().Returns(Array.Empty<Team>());
+    }
+
+    [TearDown]
+    public void TearDown() => _host.Dispose();
+
+    [Test]
+    public async Task Return401WhenNoTokenIsSupplied()
+    {
+        using var client = _host.CreateClient();
+
+        var response = await client.GetAsync(TeamsUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Return401WhenTokenIsInvalid()
+    {
+        using var client = _host.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", "not-a-jwt");
+
+        var response = await client.GetAsync(TeamsUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Return403WhenTokenLacksAccessRole()
+    {
+        using var client = _host.CreateClient(TestJwt.WithoutAccessRole());
+
+        var response = await client.GetAsync(TeamsUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Return200WhenTokenHasAccessRole()
+    {
+        using var client = _host.CreateClient(TestJwt.WithAccessRole());
+
+        var response = await client.GetAsync(TeamsUri);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/Worms.Hub.Gateway.Tests/TeamsEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/TeamsEndpointShould.cs
@@ -1,0 +1,278 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+using Worms.Hub.Gateway.API.DTOs;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Gateway.Tests;
+
+[TestFixture]
+[SuppressMessage("Design", "CA1001", Justification = "Disposed in TearDown")]
+internal sealed class TeamsEndpointShould
+{
+    private const string TeamsUrl = "api/v1/teams";
+
+    private GatewayTestHost _host = null!;
+    private HttpClient _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _host = new GatewayTestHost();
+        _client = _host.CreateClient(TestJwt.WithAccessRole());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client.Dispose();
+        _host.Dispose();
+    }
+
+    // ── GET /api/v1/teams ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ReturnEmptyListWhenNoTeamsExist()
+    {
+        _host.TeamsRepository.GetAll().Returns([]);
+
+        var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var teams = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<TeamDto>>();
+        teams.ShouldNotBeNull();
+        teams.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task ReturnAllTeamsMappingFields()
+    {
+        _host.TeamsRepository.GetAll().Returns(
+        [
+            new Team(1, "Machine1", "TeamA", null, null),
+            new Team(2, "Machine2", "TeamB", "Alice", "test-user"),
+            new Team(3, "Machine3", "TeamC", "Bob", "other-user")
+        ]);
+
+        var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var teams = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<TeamDto>>();
+        teams.ShouldNotBeNull();
+        teams.Count.ShouldBe(3);
+
+        var unclaimed = teams.FirstOrDefault(t => t.Id == 1);
+        unclaimed.ShouldNotBeNull();
+        unclaimed.Machine.ShouldBe("Machine1");
+        unclaimed.TeamName.ShouldBe("TeamA");
+        unclaimed.ClaimedBy.ShouldBeNull();
+
+        var mine = teams.FirstOrDefault(t => t.Id == 2);
+        mine.ShouldNotBeNull();
+        mine.Machine.ShouldBe("Machine2");
+        mine.TeamName.ShouldBe("TeamB");
+        mine.ClaimedBy.ShouldBe("Alice");
+
+        var another = teams.FirstOrDefault(t => t.Id == 3);
+        another.ShouldNotBeNull();
+        another.Machine.ShouldBe("Machine3");
+        another.TeamName.ShouldBe("TeamC");
+        another.ClaimedBy.ShouldBe("Bob");
+    }
+
+    [Test]
+    public async Task SetIsMyTeamTrueOnlyForTeamsClaimedByCaller()
+    {
+        _host.TeamsRepository.GetAll().Returns(
+        [
+            new Team(1, "M1", "T1", null, null),
+            new Team(2, "M2", "T2", "Alice", "test-user"),
+            new Team(3, "M3", "T3", "Bob", "other-user")
+        ]);
+
+        var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var teams = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<TeamDto>>();
+        teams.ShouldNotBeNull();
+
+        teams.First(t => t.Id == 1).IsMyTeam.ShouldBeFalse();
+        teams.First(t => t.Id == 2).IsMyTeam.ShouldBeTrue();
+        teams.First(t => t.Id == 3).IsMyTeam.ShouldBeFalse();
+    }
+
+    // ── PUT /api/v1/teams ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Return404WhenTeamDoesNotExist()
+    {
+        _host.TeamsRepository.GetById(999).Returns((Team?)null);
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(999, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        _host.PlayersRepository.DidNotReceive().Create(Arg.Any<Player>());
+        _host.TeamsRepository.DidNotReceive().SetPlayerClaim(Arg.Any<int>(), Arg.Any<string?>());
+        _host.RatingsCalculator.DidNotReceive().CalculateForTeam(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task CreatePlayerAndClaimWhenUnclaimedAndNoPlayerExists_BodyDisplayName()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject("test-user").Returns((Player?)null);
+        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, "Body Name"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.PlayersRepository.Received()
+            .Create(Arg.Is<Player>(p => p.AuthSubject == "test-user" && p.DisplayName == "Body Name"));
+        _host.TeamsRepository.Received().SetPlayerClaim(1, "test-user");
+    }
+
+    [Test]
+    public async Task FallsBackToNicknameClaim()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject("test-user").Returns((Player?)null);
+        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+
+        using var client = _host.CreateClient(TestJwt.WithAccessRole(nickname: "NickFromToken"));
+
+        var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.PlayersRepository.Received()
+            .Create(Arg.Is<Player>(p => p.AuthSubject == "test-user" && p.DisplayName == "NickFromToken"));
+    }
+
+    [Test]
+    public async Task FallsBackToNameClaimWhenNoNickname()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject("test-user").Returns((Player?)null);
+        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+
+        using var client = _host.CreateClient(TestJwt.WithAccessRole(name: "NameFromToken"));
+
+        var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.PlayersRepository.Received()
+            .Create(Arg.Is<Player>(p => p.AuthSubject == "test-user" && p.DisplayName == "NameFromToken"));
+    }
+
+    [Test]
+    public async Task FallsBackToSubjectWhenNoNicknameOrName()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject("subject-xyz").Returns((Player?)null);
+        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+
+        using var client = _host.CreateClient(TestJwt.WithAccessRole(subject: "subject-xyz"));
+
+        var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.PlayersRepository.Received()
+            .Create(Arg.Is<Player>(p => p.AuthSubject == "subject-xyz" && p.DisplayName == "subject-xyz"));
+        _host.TeamsRepository.Received().SetPlayerClaim(1, "subject-xyz");
+    }
+
+    [Test]
+    public async Task FallsBackToUnknownWhenNoClaimsPresent()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject(Arg.Any<string>()).Returns((Player?)null);
+        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+
+        using var client = _host.CreateClient(TestJwt.WithAccessRole(subject: null));
+
+        var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.PlayersRepository.Received()
+            .Create(Arg.Is<Player>(p => p.DisplayName == "Unknown"));
+    }
+
+    [Test]
+    public async Task UseExistingPlayerWhenOneAlreadyExists()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject("test-user")
+            .Returns(new Player("test-user", "Existing"));
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.PlayersRepository.DidNotReceive().Create(Arg.Any<Player>());
+        _host.TeamsRepository.Received().SetPlayerClaim(1, "test-user");
+    }
+
+    [Test]
+    public async Task Return409WhenTeamClaimedByAnotherUser_OnClaim()
+    {
+        _host.TeamsRepository.GetById(1)
+            .Returns(new Team(1, "M1", "T1", "Bob", "other-user"));
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+        _host.PlayersRepository.DidNotReceive().Create(Arg.Any<Player>());
+        _host.TeamsRepository.DidNotReceive().SetPlayerClaim(Arg.Any<int>(), Arg.Any<string?>());
+        _host.RatingsCalculator.DidNotReceive().CalculateForTeam(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task ClearClaimWhenUnclaimedByOwner()
+    {
+        _host.TeamsRepository.GetById(1)
+            .Returns(new Team(1, "M1", "T1", "Alice", "test-user"));
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, false, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.TeamsRepository.Received().SetPlayerClaim(1, null);
+    }
+
+    [Test]
+    public async Task Return403WhenUnclaimingTeamClaimedByAnother()
+    {
+        _host.TeamsRepository.GetById(1)
+            .Returns(new Team(1, "M1", "T1", "Bob", "other-user"));
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, false, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        _host.TeamsRepository.DidNotReceive().SetPlayerClaim(Arg.Any<int>(), Arg.Any<string?>());
+        _host.RatingsCalculator.DidNotReceive().CalculateForTeam(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task TriggerRecalculationOnSuccessfulClaim()
+    {
+        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
+        _host.PlayersRepository.GetByAuthSubject("test-user")
+            .Returns(new Player("test-user", "Alice"));
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.RatingsCalculator.Received(1).CalculateForTeam("M1", "T1");
+    }
+
+    [Test]
+    public async Task TriggerRecalculationOnSuccessfulUnclaim()
+    {
+        _host.TeamsRepository.GetById(1)
+            .Returns(new Team(1, "M2", "T2", "Alice", "test-user"));
+
+        var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, false, null));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _host.RatingsCalculator.Received(1).CalculateForTeam("M2", "T2");
+    }
+}

--- a/src/Worms.Hub.Gateway.Tests/TestJwt.cs
+++ b/src/Worms.Hub.Gateway.Tests/TestJwt.cs
@@ -18,13 +18,43 @@ internal static class TestJwt
 
     private static readonly JsonWebTokenHandler Handler = new();
 
-    /// <summary>Mint a token with the 'access' role — passes the [Authorize(Roles="access")] gate.</summary>
-    internal static string WithAccessRole() => Mint(new Claim("permissions", "access"));
+    private const string NameIdentifierClaimType =
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
+
+    /// <summary>
+    /// Mint a token with the 'access' role and a controllable display-name ladder:
+    /// optional subject (nameidentifier), nickname, and name claims. A null subject omits
+    /// the nameidentifier claim entirely so the subject-absent rungs can be exercised.
+    /// </summary>
+    internal static string WithAccessRole(
+        string? subject = "test-user",
+        string? nickname = null,
+        string? name = null)
+    {
+        var claims = new List<Claim> { new("permissions", "access") };
+        if (subject is not null)
+        {
+            claims.Add(new Claim(NameIdentifierClaimType, subject));
+        }
+
+        if (nickname is not null)
+        {
+            claims.Add(new Claim("nickname", nickname));
+        }
+
+        if (name is not null)
+        {
+            claims.Add(new Claim("name", name));
+        }
+
+        return Mint(claims);
+    }
 
     /// <summary>Mint a valid token that has no 'access' role — hits the 403 path.</summary>
-    internal static string WithoutAccessRole() => Mint(new Claim("permissions", "other"));
+    internal static string WithoutAccessRole() =>
+        Mint([new Claim(NameIdentifierClaimType, "test-user"), new Claim("permissions", "other")]);
 
-    private static string Mint(params Claim[] extraClaims)
+    private static string Mint(IEnumerable<Claim> claims)
     {
         var descriptor = new SecurityTokenDescriptor
         {
@@ -32,15 +62,8 @@ internal static class TestJwt
             Audience = Audience,
             Expires = DateTime.UtcNow.AddHours(1),
             SigningCredentials = Credentials,
-            Subject = new ClaimsIdentity(
-                new Claim[]
-                {
-                    new(
-                        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
-                        "test-user")
-                }.Concat(extraClaims))
+            Subject = new ClaimsIdentity(claims)
         };
-
         return Handler.CreateToken(descriptor);
     }
 }

--- a/src/Worms.Hub.Gateway/API/Controllers/TeamsController.cs
+++ b/src/Worms.Hub.Gateway/API/Controllers/TeamsController.cs
@@ -10,7 +10,7 @@ namespace Worms.Hub.Gateway.API.Controllers;
 internal sealed class TeamsController(
     ITeamsRepository teamsRepository,
     IPlayersRepository playersRepository,
-    RatingsCalculator ratingsCalculator) : V1ApiController
+    IRatingsCalculator ratingsCalculator) : V1ApiController
 {
     [HttpGet]
     public ActionResult<IReadOnlyList<TeamDto>> GetAll()

--- a/src/Worms.Hub.Gateway/Ratings/IRatingsCalculator.cs
+++ b/src/Worms.Hub.Gateway/Ratings/IRatingsCalculator.cs
@@ -1,0 +1,7 @@
+namespace Worms.Hub.Gateway.Ratings;
+
+internal interface IRatingsCalculator
+{
+    LeagueRatingsChange Calculate(string leagueId);
+    void CalculateForTeam(string machine, string teamName);
+}

--- a/src/Worms.Hub.Gateway/Ratings/RatingsCalculator.cs
+++ b/src/Worms.Hub.Gateway/Ratings/RatingsCalculator.cs
@@ -11,7 +11,7 @@ internal sealed class RatingsCalculator(
     IReplaysRepository replaysRepository,
     ITeamsRepository teamsRepository,
     IRatingsRepository ratingsRepository,
-    ILogger<RatingsCalculator> logger)
+    ILogger<RatingsCalculator> logger) : IRatingsCalculator
 {
     private sealed record Selection(string AuthSubject, string Machine, string TeamName);
 

--- a/src/Worms.Hub.Gateway/ServiceRegistration.cs
+++ b/src/Worms.Hub.Gateway/ServiceRegistration.cs
@@ -19,7 +19,7 @@ internal static class ServiceRegistration
             .AddScoped<IAnnouncer, Announcer>()
             .AddScoped<ReplayFileValidator>()
             .AddScoped<CliFileValidator>();
-        builder.TryAddScoped<RatingsCalculator>();
+        builder.TryAddScoped<IRatingsCalculator, RatingsCalculator>();
         return builder;
     }
 
@@ -32,7 +32,7 @@ internal static class ServiceRegistration
             .AddScoped<Processor>()
             .AddScoped<IAnnouncer, Announcer>()
             .AddSingleton<StartupBackfiller>();
-        builder.TryAddScoped<RatingsCalculator>();
+        builder.TryAddScoped<IRatingsCalculator, RatingsCalculator>();
         return builder;
     }
 }

--- a/src/Worms.Hub.Gateway/Worker/Processor.cs
+++ b/src/Worms.Hub.Gateway/Worker/Processor.cs
@@ -17,7 +17,7 @@ internal sealed class Processor(
     ReplayFiles replayFiles,
     IAnnouncer announcer,
     IReplayTextReader replayTextReader,
-    RatingsCalculator ratingsCalculator,
+    IRatingsCalculator ratingsCalculator,
     ILogger<Processor> logger)
 {
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "ELO calculation failure must not block replay processing")]

--- a/src/Worms.Hub.Gateway/Worker/StartupBackfiller.cs
+++ b/src/Worms.Hub.Gateway/Worker/StartupBackfiller.cs
@@ -79,7 +79,7 @@ internal sealed class StartupBackfiller(
         await using var connection = new NpgsqlConnection(connectionString);
 
         var leaguesRepository = scope.ServiceProvider.GetRequiredService<ILeaguesRepository>();
-        var ratingsCalculator = scope.ServiceProvider.GetRequiredService<RatingsCalculator>();
+        var ratingsCalculator = scope.ServiceProvider.GetRequiredService<IRatingsCalculator>();
 
         var ratingsCount = await connection.QuerySingleAsync<long>("SELECT COUNT(*) FROM player_ratings");
 
@@ -175,7 +175,7 @@ internal sealed class StartupBackfiller(
         var replayRepository = scope.ServiceProvider.GetRequiredService<IReplaysRepository>();
         var replayTextReader = scope.ServiceProvider.GetRequiredService<IReplayTextReader>();
         var leaguesRepository = scope.ServiceProvider.GetRequiredService<ILeaguesRepository>();
-        var ratingsCalculator = scope.ServiceProvider.GetRequiredService<RatingsCalculator>();
+        var ratingsCalculator = scope.ServiceProvider.GetRequiredService<IRatingsCalculator>();
 
         foreach (var replay in replayRepository.GetAll().Where(r => r.Status == "Processed"))
         {


### PR DESCRIPTION
## What

Adds end-to-end test coverage for the Gateway's Teams endpoints, exercised against the test-only JWT issuer and faked repository/calculator seams, gated on every PR.

Closes #1373.

## How

- **Interface extraction (no behaviour change):** introduce `internal IRatingsCalculator` and rebind the three consumers (`TeamsController`, Worker `Processor`, `StartupBackfiller`) and both DI registrations to it, so the controller can be tested without running real rating computation.
- **Test seams:** extend `GatewayTestHost` with faked `ITeamsRepository`, `IPlayersRepository`, `IRatingsCalculator`; give `TestJwt` controllable subject/nickname/name minting to drive the display-name resolution ladder.
- **Tests:** `TeamsAuthShould` (401/403/200 authorization matrix) and `TeamsEndpointShould` (GET mapping + `IsMyTeam`, PUT claim/unclaim, display-name ladder one test per rung, rating-recalculation triggers).

## Testing

All 19 Teams tests pass; both touched projects build clean under `--warnaserror` and InspectCode is clean solution-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)