### PR TITLE
Add in-memory Storage fakes for Gateway repository seams

### DIFF
--- a/Worms.sln
+++ b/Worms.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Cli.Tests", "src\Worm
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.Gateway.Tests", "src\Worms.Hub.Gateway.Tests\Worms.Hub.Gateway.Tests.csproj", "{5028A683-AF04-4503-8321-562CA5469267}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worms.Hub.Storage.Fake", "src\Worms.Hub.Storage.Fake\Worms.Hub.Storage.Fake.csproj", "{DB544DBD-65B4-42AD-9150-07B467267767}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -253,6 +255,18 @@ Global
 		{5028A683-AF04-4503-8321-562CA5469267}.Release|x64.Build.0 = Release|Any CPU
 		{5028A683-AF04-4503-8321-562CA5469267}.Release|x86.ActiveCfg = Release|Any CPU
 		{5028A683-AF04-4503-8321-562CA5469267}.Release|x86.Build.0 = Release|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Debug|x64.Build.0 = Debug|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Debug|x86.Build.0 = Debug|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Release|x64.ActiveCfg = Release|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Release|x64.Build.0 = Release|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Release|x86.ActiveCfg = Release|Any CPU
+		{DB544DBD-65B4-42AD-9150-07B467267767}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -263,5 +277,6 @@ Global
 		{49C6C918-F9CE-4E18-9A07-426448C00F57} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{E0319E1E-25D0-4551-BF3E-61B7A1CBBA4B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{5028A683-AF04-4503-8321-562CA5469267} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{DB544DBD-65B4-42AD-9150-07B467267767} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/Worms.Hub.Gateway.Tests/GamesAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/GamesAuthShould.cs
@@ -17,7 +17,6 @@ internal sealed class GamesAuthShould
     public void SetUp()
     {
         _host = new GatewayTestHost();
-        // Fake returns empty by default — no arrange needed for auth tests
     }
 
     [TearDown]

--- a/src/Worms.Hub.Gateway.Tests/GamesAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/GamesAuthShould.cs
@@ -1,9 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using NUnit.Framework;
-using NSubstitute;
 using Shouldly;
-using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.Tests;
 
@@ -19,8 +17,7 @@ internal sealed class GamesAuthShould
     public void SetUp()
     {
         _host = new GatewayTestHost();
-        // Always return an empty list so auth tests that reach the endpoint get 200
-        _host.GamesRepository.GetAll().Returns(Array.Empty<Game>());
+        // Fake returns empty by default — no arrange needed for auth tests
     }
 
     [TearDown]

--- a/src/Worms.Hub.Gateway.Tests/GamesEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/GamesEndpointShould.cs
@@ -33,7 +33,7 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task ReturnEmptyListWhenNoGamesExist()
     {
-        _host.GamesRepository.GetAll().Returns([]);
+        // Fake returns empty by default — no arrange needed
 
         var response = await _client.GetAsync(new Uri(GamesUrl, UriKind.Relative));
 
@@ -48,7 +48,7 @@ internal sealed class GamesEndpointShould
     {
         var gameA = new Game("1", "Pending", "HOST-A");
         var gameB = new Game("2", "Complete", "HOST-B");
-        _host.GamesRepository.GetAll().Returns([gameA, gameB]);
+        _host.Storage.Games.Seed(gameA, gameB);
 
         var response = await _client.GetAsync(new Uri(GamesUrl, UriKind.Relative));
 
@@ -64,7 +64,7 @@ internal sealed class GamesEndpointShould
     public async Task ReturnGameByIdWhenItExists()
     {
         var game = new Game("42", "Pending", "HOST-1");
-        _host.GamesRepository.GetAll().Returns([game]);
+        _host.Storage.Games.Seed(game);
 
         var response = await _client.GetAsync(new Uri($"{GamesUrl}/42", UriKind.Relative));
 
@@ -79,7 +79,7 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task Return404WhenGameByIdDoesNotExist()
     {
-        _host.GamesRepository.GetAll().Returns([]);
+        // Fake returns empty by default — no arrange needed
 
         var response = await _client.GetAsync(new Uri($"{GamesUrl}/999", UriKind.Relative));
 
@@ -89,45 +89,43 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task CreateGameAndAnnounceGameStarting()
     {
-        var createdGame = new Game("42", "Pending", "HOST-1");
-        _host.GamesRepository
-            .Create(Arg.Any<Game>())
-            .Returns(createdGame);
+        // The fake assigns an id and stores the game automatically
 
         var response = await _client.PostAsJsonAsync(GamesUrl, new CreateGameDto("HOST-1"));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var dto = await response.Content.ReadFromJsonAsync<GameDto>();
         dto.ShouldNotBeNull();
-        dto.Id.ShouldBe("42");
         dto.Status.ShouldBe("Pending");
         dto.HostMachine.ShouldBe("HOST-1");
+        dto.Id.ShouldNotBeNullOrEmpty();
+
+        var stored = _host.Storage.Games.GetAll();
+        stored.Count.ShouldBe(1);
+        stored.ShouldContain(g => g.HostMachine == "HOST-1" && g.Status == "Pending");
 
         await _host.Announcer.Received(1).AnnounceGameStarting("HOST-1");
-        _host.GamesRepository.Received(1).Create(
-            Arg.Is<Game>(g => g.HostMachine == "HOST-1" && g.Status == "Pending" && g.Id == "0"));
     }
 
     [Test]
     public async Task UpdateGameWhenItExists()
     {
-        var existing = new Game("7", "Pending", "HOST-X");
-        _host.GamesRepository.GetAll().Returns([existing]);
+        _host.Storage.Games.Seed(new Game("7", "Pending", "HOST-X"));
 
         var response = await _client.PutAsJsonAsync(GamesUrl, new GameDto("7", "Complete", "HOST-X"));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.GamesRepository.Received(1).Update(Arg.Is<Game>(g => g.Id == "7"));
+        _host.Storage.Games.GetAll().Single(g => g.Id == "7").Status.ShouldBe("Complete");
     }
 
     [Test]
     public async Task Return404WhenUpdatingGameThatDoesNotExist()
     {
-        _host.GamesRepository.GetAll().Returns([]);
+        // Fake is empty — no arrange needed
 
         var response = await _client.PutAsJsonAsync(GamesUrl, new GameDto("999", "Complete", "HOST-X"));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
-        _host.GamesRepository.DidNotReceive().Update(Arg.Any<Game>());
+        _host.Storage.Games.GetAll().ShouldBeEmpty();
     }
 }

--- a/src/Worms.Hub.Gateway.Tests/GamesEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/GamesEndpointShould.cs
@@ -33,8 +33,6 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task ReturnEmptyListWhenNoGamesExist()
     {
-        // Fake returns empty by default — no arrange needed
-
         var response = await _client.GetAsync(new Uri(GamesUrl, UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -79,8 +77,6 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task Return404WhenGameByIdDoesNotExist()
     {
-        // Fake returns empty by default — no arrange needed
-
         var response = await _client.GetAsync(new Uri($"{GamesUrl}/999", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -89,8 +85,6 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task CreateGameAndAnnounceGameStarting()
     {
-        // The fake assigns an id and stores the game automatically
-
         var response = await _client.PostAsJsonAsync(GamesUrl, new CreateGameDto("HOST-1"));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -121,8 +115,6 @@ internal sealed class GamesEndpointShould
     [Test]
     public async Task Return404WhenUpdatingGameThatDoesNotExist()
     {
-        // Fake is empty — no arrange needed
-
         var response = await _client.PutAsJsonAsync(GamesUrl, new GameDto("999", "Complete", "HOST-X"));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);

--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -76,7 +76,6 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
                     };
                 });
 
-            // ── Fake the seams ────────────────────────────────────────────────
             services.AddFakeHubStorageServices();
 
             services.RemoveAll<IAnnouncer>();
@@ -90,7 +89,6 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
         });
     }
 
-    /// <summary>Create an <see cref="HttpClient"/> that sends <paramref name="bearerToken"/> on every request.</summary>
     internal HttpClient CreateClient(string bearerToken)
     {
         var client = CreateClient();

--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
@@ -8,8 +9,7 @@ using NSubstitute;
 using Worms.Hub.Gateway.Announcers;
 using Worms.Hub.Gateway.Ratings;
 using Worms.Hub.Queues;
-using Worms.Hub.Storage.Database;
-using Worms.Hub.Storage.Domain;
+using Worms.Hub.Storage.Fake;
 
 namespace Worms.Hub.Gateway.Tests;
 
@@ -18,24 +18,14 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
     private readonly string _tempReplayFolder =
         Path.Combine(Path.GetTempPath(), "worms-gateway-tests", Guid.NewGuid().ToString("N"));
 
-    internal IRepository<Game> GamesRepository { get; } = Substitute.For<IRepository<Game>>();
-
     internal IAnnouncer Announcer { get; } = Substitute.For<IAnnouncer>();
-
-    internal IReplaysRepository ReplaysRepository { get; } = Substitute.For<IReplaysRepository>();
 
     internal IMessageQueue<ReplayToProcessMessage> ReplayProcessorQueue { get; } =
         Substitute.For<IMessageQueue<ReplayToProcessMessage>>();
 
-    internal ILeaguesRepository LeaguesRepository { get; } = Substitute.For<ILeaguesRepository>();
-
-    internal IRatingsRepository RatingsRepository { get; } = Substitute.For<IRatingsRepository>();
-
-    internal ITeamsRepository TeamsRepository { get; } = Substitute.For<ITeamsRepository>();
-
-    internal IPlayersRepository PlayersRepository { get; } = Substitute.For<IPlayersRepository>();
-
     internal IRatingsCalculator RatingsCalculator { get; } = Substitute.For<IRatingsCalculator>();
+
+    internal FakeHubStorage Storage => Services.GetRequiredService<FakeHubStorage>();
 
     internal string SchemesFolder { get; } =
         Path.Combine(Path.GetTempPath(), "worms-gateway-tests-schemes", Guid.NewGuid().ToString("N"));
@@ -87,29 +77,13 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
                 });
 
             // ── Fake the seams ────────────────────────────────────────────────
-            services.RemoveAll<IRepository<Game>>();
-            services.AddSingleton(GamesRepository);
+            services.AddFakeHubStorageServices();
 
             services.RemoveAll<IAnnouncer>();
             services.AddSingleton(Announcer);
 
-            services.RemoveAll<IReplaysRepository>();
-            services.AddSingleton(ReplaysRepository);
-
             services.RemoveAll<IMessageQueue<ReplayToProcessMessage>>();
             services.AddSingleton(ReplayProcessorQueue);
-
-            services.RemoveAll<ILeaguesRepository>();
-            services.AddSingleton(LeaguesRepository);
-
-            services.RemoveAll<IRatingsRepository>();
-            services.AddSingleton(RatingsRepository);
-
-            services.RemoveAll<ITeamsRepository>();
-            services.AddSingleton(TeamsRepository);
-
-            services.RemoveAll<IPlayersRepository>();
-            services.AddSingleton(PlayersRepository);
 
             services.RemoveAll<IRatingsCalculator>();
             services.AddSingleton(RatingsCalculator);

--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;

--- a/src/Worms.Hub.Gateway.Tests/LeaguesAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesAuthShould.cs
@@ -18,7 +18,6 @@ internal sealed class LeaguesAuthShould
     public void SetUp()
     {
         _host = new GatewayTestHost();
-        // Fake returns empty by default — no arrange needed for auth tests
     }
 
     [TearDown]

--- a/src/Worms.Hub.Gateway.Tests/LeaguesAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesAuthShould.cs
@@ -1,10 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
-using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
-using Worms.Hub.Storage.Database;
 
 namespace Worms.Hub.Gateway.Tests;
 
@@ -20,7 +18,7 @@ internal sealed class LeaguesAuthShould
     public void SetUp()
     {
         _host = new GatewayTestHost();
-        _host.LeaguesRepository.GetAll().Returns(Array.Empty<LeagueDb>());
+        // Fake returns empty by default — no arrange needed for auth tests
     }
 
     [TearDown]

--- a/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
@@ -39,8 +39,6 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnEmptyListWhenNoLeaguesExist()
     {
-        // Fake returns empty by default — no arrange needed
-
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -58,7 +56,6 @@ internal sealed class LeaguesEndpointShould
         _host.Storage.Ratings.Seed("redgate",
             new PlayerRating("sub1", "Alice", "redgate", 1500, 10),
             new PlayerRating("sub2", "Bob", "redgate", 1400, 8));
-        // "other" has no ratings seeded — empty by default
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
 
@@ -78,7 +75,6 @@ internal sealed class LeaguesEndpointShould
     public async Task ReturnNullVersionAndSchemeUrlWhenNoVersionFileExists()
     {
         _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
-        // no ratings seeded — empty by default
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
 
@@ -95,7 +91,6 @@ internal sealed class LeaguesEndpointShould
     public async Task ReturnVersionAndSchemeUrlWhenVersionFileExists()
     {
         _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
-        // no ratings seeded — empty by default
         WriteVersionFile("redgate", "1.2.3");
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
@@ -137,8 +132,6 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404WhenLeagueByIdDoesNotExist()
     {
-        // "missing" league not seeded — fake returns null for GetById
-
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -150,7 +143,6 @@ internal sealed class LeaguesEndpointShould
     public async Task ReturnEmptyReplaysWhenLeagueHasNone()
     {
         _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
-        // no replays seeded for "redgate" — fake GetByLeagueId returns empty
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays", UriKind.Relative));
 
@@ -182,8 +174,6 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404ForReplaysWhenLeagueIdIsUnknown()
     {
-        // "missing" league not seeded
-
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing/replays", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -209,8 +199,6 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404ForReplayWhenLeagueIdIsUnknown()
     {
-        // "missing" league not seeded
-
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing/replays/99", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);

--- a/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/LeaguesEndpointShould.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
 using Worms.Hub.Gateway.API.DTOs;
@@ -40,7 +39,7 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnEmptyListWhenNoLeaguesExist()
     {
-        _host.LeaguesRepository.GetAll().Returns([]);
+        // Fake returns empty by default — no arrange needed
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
 
@@ -53,17 +52,13 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnAllLeaguesWithStandings()
     {
-        _host.LeaguesRepository.GetAll().Returns(
-        [
+        _host.Storage.Leagues.Seed(
             new LeagueDb("redgate", "Red Gate"),
-            new LeagueDb("other", "Other")
-        ]);
-        _host.RatingsRepository.GetByLeagueId("redgate").Returns(
-        [
+            new LeagueDb("other", "Other"));
+        _host.Storage.Ratings.Seed("redgate",
             new PlayerRating("sub1", "Alice", "redgate", 1500, 10),
-            new PlayerRating("sub2", "Bob", "redgate", 1400, 8)
-        ]);
-        _host.RatingsRepository.GetByLeagueId("other").Returns([]);
+            new PlayerRating("sub2", "Bob", "redgate", 1400, 8));
+        // "other" has no ratings seeded — empty by default
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
 
@@ -82,8 +77,8 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnNullVersionAndSchemeUrlWhenNoVersionFileExists()
     {
-        _host.LeaguesRepository.GetAll().Returns([new LeagueDb("redgate", "Red Gate")]);
-        _host.RatingsRepository.GetByLeagueId("redgate").Returns([]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        // no ratings seeded — empty by default
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
 
@@ -99,8 +94,8 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnVersionAndSchemeUrlWhenVersionFileExists()
     {
-        _host.LeaguesRepository.GetAll().Returns([new LeagueDb("redgate", "Red Gate")]);
-        _host.RatingsRepository.GetByLeagueId("redgate").Returns([]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        // no ratings seeded — empty by default
         WriteVersionFile("redgate", "1.2.3");
 
         var response = await _client.GetAsync(new Uri(LeaguesUrl, UriKind.Relative));
@@ -121,11 +116,9 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnLeagueByIdWhenItExists()
     {
-        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
-        _host.RatingsRepository.GetByLeagueId("redgate").Returns(
-        [
-            new PlayerRating("sub1", "Alice", "redgate", 1500, 10)
-        ]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        _host.Storage.Ratings.Seed("redgate",
+            new PlayerRating("sub1", "Alice", "redgate", 1500, 10));
         WriteVersionFile("redgate", "1.0.0");
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate", UriKind.Relative));
@@ -144,7 +137,7 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404WhenLeagueByIdDoesNotExist()
     {
-        _host.LeaguesRepository.GetById("missing").Returns((LeagueDb?)null);
+        // "missing" league not seeded — fake returns null for GetById
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing", UriKind.Relative));
 
@@ -156,8 +149,8 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnEmptyReplaysWhenLeagueHasNone()
     {
-        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
-        _host.ReplaysRepository.GetByLeagueId("redgate").Returns([]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        // no replays seeded for "redgate" — fake GetByLeagueId returns empty
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays", UriKind.Relative));
 
@@ -170,11 +163,9 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnReplaysWhenLeagueHasThem()
     {
-        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
-        _host.ReplaysRepository.GetByLeagueId("redgate").Returns(
-        [
-            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null)
-        ]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        _host.Storage.Replays.Seed(
+            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null));
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays", UriKind.Relative));
 
@@ -191,7 +182,7 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404ForReplaysWhenLeagueIdIsUnknown()
     {
-        _host.LeaguesRepository.GetById("missing").Returns((LeagueDb?)null);
+        // "missing" league not seeded
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing/replays", UriKind.Relative));
 
@@ -203,11 +194,9 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task ReturnReplayWhenLeagueAndReplayExist()
     {
-        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
-        _host.ReplaysRepository.GetByLeagueId("redgate").Returns(
-        [
-            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null)
-        ]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        _host.Storage.Replays.Seed(
+            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null));
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays/99", UriKind.Relative));
 
@@ -220,7 +209,7 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404ForReplayWhenLeagueIdIsUnknown()
     {
-        _host.LeaguesRepository.GetById("missing").Returns((LeagueDb?)null);
+        // "missing" league not seeded
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/missing/replays/99", UriKind.Relative));
 
@@ -230,11 +219,9 @@ internal sealed class LeaguesEndpointShould
     [Test]
     public async Task Return404ForReplayWhenReplayIdIsNotFound()
     {
-        _host.LeaguesRepository.GetById("redgate").Returns(new LeagueDb("redgate", "Red Gate"));
-        _host.ReplaysRepository.GetByLeagueId("redgate").Returns(
-        [
-            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null)
-        ]);
+        _host.Storage.Leagues.Seed(new LeagueDb("redgate", "Red Gate"));
+        _host.Storage.Replays.Seed(
+            new Replay("99", "My Game", "Processed", "file.dat", null, "redgate", null, null, null, null));
 
         var response = await _client.GetAsync(new Uri($"{LeaguesUrl}/redgate/replays/123", UriKind.Relative));
 

--- a/src/Worms.Hub.Gateway.Tests/ReplaysAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysAuthShould.cs
@@ -69,8 +69,6 @@ internal sealed class ReplaysAuthShould
     [Test]
     public async Task Return200WhenTokenHasAccessRole()
     {
-        // Fake handles Create automatically — no stub needed
-
         using var client = _host.CreateClient(TestJwt.WithAccessRole());
         using var content = BuildUpload("Game", ValidReplayBytes, "game.WAGame");
 

--- a/src/Worms.Hub.Gateway.Tests/ReplaysAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysAuthShould.cs
@@ -1,10 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
-using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
-using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.Tests;
 
@@ -71,8 +69,7 @@ internal sealed class ReplaysAuthShould
     [Test]
     public async Task Return200WhenTokenHasAccessRole()
     {
-        var created = new Replay("1", "Game", "Pending", "file.dat", null, "redgate", null, null, null, null);
-        _host.ReplaysRepository.Create(Arg.Any<Replay>()).Returns(created);
+        // Fake handles Create automatically — no stub needed
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole());
         using var content = BuildUpload("Game", ValidReplayBytes, "game.WAGame");

--- a/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using Shouldly;
 using Worms.Hub.Gateway.API.DTOs;
 using Worms.Hub.Queues;
-using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.Tests;
 
@@ -47,8 +46,7 @@ internal sealed class ReplaysEndpointShould
     [Test]
     public async Task AcceptAValidReplayUpload()
     {
-        var created = new Replay("99", "My Game", "Pending", "temp-file.dat", null, "redgate", null, null, null, null);
-        _host.ReplaysRepository.Create(Arg.Any<Replay>()).Returns(created);
+        // Fake assigns the id and stores the replay automatically
 
         using var content = BuildUpload("My Game", ValidReplayBytes, "game.WAGame");
         var response = await _client.PostAsync(new Uri(ReplaysUrl, UriKind.Relative), content);
@@ -57,19 +55,17 @@ internal sealed class ReplaysEndpointShould
 
         var dto = await response.Content.ReadFromJsonAsync<ReplayDto>();
         dto.ShouldNotBeNull();
-        dto.Id.ShouldBe("99");
         dto.Name.ShouldBe("My Game");
         dto.Status.ShouldBe("Pending");
+        dto.Id.ShouldNotBeNullOrEmpty();
 
-        _host.ReplaysRepository.Received(1).Create(
-            Arg.Is<Replay>(r =>
-                r.Name == "My Game" &&
-                r.Status == "Pending" &&
-                r.Id == "0" &&
-                r.LeagueId == "redgate"));
+        var stored = _host.Storage.Replays.GetAll().Single();
+        stored.Name.ShouldBe("My Game");
+        stored.Status.ShouldBe("Pending");
+        stored.LeagueId.ShouldBe("redgate");
 
         await _host.ReplayProcessorQueue.Received(1).EnqueueMessage(
-            Arg.Is<ReplayToProcessMessage>(m => m.ReplayFileName == created.Filename));
+            Arg.Is<ReplayToProcessMessage>(m => m.ReplayFileName == stored.Filename));
     }
 
     [Test]
@@ -80,7 +76,7 @@ internal sealed class ReplaysEndpointShould
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
 
-        _host.ReplaysRepository.DidNotReceive().Create(Arg.Any<Replay>());
+        _host.Storage.Replays.GetAll().ShouldBeEmpty();
         await _host.ReplayProcessorQueue.DidNotReceive().EnqueueMessage(Arg.Any<ReplayToProcessMessage>());
     }
 
@@ -92,7 +88,7 @@ internal sealed class ReplaysEndpointShould
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
 
-        _host.ReplaysRepository.DidNotReceive().Create(Arg.Any<Replay>());
+        _host.Storage.Replays.GetAll().ShouldBeEmpty();
         await _host.ReplayProcessorQueue.DidNotReceive().EnqueueMessage(Arg.Any<ReplayToProcessMessage>());
     }
 

--- a/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
@@ -46,8 +46,6 @@ internal sealed class ReplaysEndpointShould
     [Test]
     public async Task AcceptAValidReplayUpload()
     {
-        // Fake assigns the id and stores the replay automatically
-
         using var content = BuildUpload("My Game", ValidReplayBytes, "game.WAGame");
         var response = await _client.PostAsync(new Uri(ReplaysUrl, UriKind.Relative), content);
 

--- a/src/Worms.Hub.Gateway.Tests/TeamsAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/TeamsAuthShould.cs
@@ -1,10 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
-using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
-using Worms.Hub.Storage.Domain;
 
 namespace Worms.Hub.Gateway.Tests;
 
@@ -20,7 +18,7 @@ internal sealed class TeamsAuthShould
     public void SetUp()
     {
         _host = new GatewayTestHost();
-        _host.TeamsRepository.GetAll().Returns(Array.Empty<Team>());
+        // Fake returns empty by default — no arrange needed for auth tests
     }
 
     [TearDown]

--- a/src/Worms.Hub.Gateway.Tests/TeamsAuthShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/TeamsAuthShould.cs
@@ -18,7 +18,6 @@ internal sealed class TeamsAuthShould
     public void SetUp()
     {
         _host = new GatewayTestHost();
-        // Fake returns empty by default — no arrange needed for auth tests
     }
 
     [TearDown]

--- a/src/Worms.Hub.Gateway.Tests/TeamsEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/TeamsEndpointShould.cs
@@ -36,7 +36,7 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task ReturnEmptyListWhenNoTeamsExist()
     {
-        _host.TeamsRepository.GetAll().Returns([]);
+        // Fake returns empty by default — no arrange needed
 
         var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
 
@@ -49,12 +49,10 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task ReturnAllTeamsMappingFields()
     {
-        _host.TeamsRepository.GetAll().Returns(
-        [
+        _host.Storage.Teams.Seed(
             new Team(1, "Machine1", "TeamA", null, null),
             new Team(2, "Machine2", "TeamB", "Alice", "test-user"),
-            new Team(3, "Machine3", "TeamC", "Bob", "other-user")
-        ]);
+            new Team(3, "Machine3", "TeamC", "Bob", "other-user"));
 
         var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
 
@@ -85,12 +83,10 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task SetIsMyTeamTrueOnlyForTeamsClaimedByCaller()
     {
-        _host.TeamsRepository.GetAll().Returns(
-        [
+        _host.Storage.Teams.Seed(
             new Team(1, "M1", "T1", null, null),
             new Team(2, "M2", "T2", "Alice", "test-user"),
-            new Team(3, "M3", "T3", "Bob", "other-user")
-        ]);
+            new Team(3, "M3", "T3", "Bob", "other-user"));
 
         var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
 
@@ -108,155 +104,153 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task Return404WhenTeamDoesNotExist()
     {
-        _host.TeamsRepository.GetById(999).Returns((Team?)null);
+        // Team 999 not seeded — fake returns null for GetById(999)
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(999, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
-        _host.PlayersRepository.DidNotReceive().Create(Arg.Any<Player>());
-        _host.TeamsRepository.DidNotReceive().SetPlayerClaim(Arg.Any<int>(), Arg.Any<string?>());
+        _host.Storage.Players.GetByAuthSubject("test-user").ShouldBeNull();
+        _host.Storage.Teams.GetById(999).ShouldBeNull();
         _host.RatingsCalculator.DidNotReceive().CalculateForTeam(Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Test]
     public async Task CreatePlayerAndClaimWhenUnclaimedAndNoPlayerExists_BodyDisplayName()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject("test-user").Returns((Player?)null);
-        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        // No player seeded for "test-user"
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, "Body Name"));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.PlayersRepository.Received()
-            .Create(Arg.Is<Player>(p => p.AuthSubject == "test-user" && p.DisplayName == "Body Name"));
-        _host.TeamsRepository.Received().SetPlayerClaim(1, "test-user");
+        var player = _host.Storage.Players.GetByAuthSubject("test-user");
+        player.ShouldNotBeNull();
+        player.DisplayName.ShouldBe("Body Name");
+        _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBe("test-user");
     }
 
     [Test]
     public async Task FallsBackToNicknameClaim()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject("test-user").Returns((Player?)null);
-        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        // No player seeded
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(nickname: "NickFromToken"));
 
         var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.PlayersRepository.Received()
-            .Create(Arg.Is<Player>(p => p.AuthSubject == "test-user" && p.DisplayName == "NickFromToken"));
+        var player = _host.Storage.Players.GetByAuthSubject("test-user");
+        player.ShouldNotBeNull();
+        player.DisplayName.ShouldBe("NickFromToken");
     }
 
     [Test]
     public async Task FallsBackToNameClaimWhenNoNickname()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject("test-user").Returns((Player?)null);
-        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        // No player seeded
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(name: "NameFromToken"));
 
         var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.PlayersRepository.Received()
-            .Create(Arg.Is<Player>(p => p.AuthSubject == "test-user" && p.DisplayName == "NameFromToken"));
+        var player = _host.Storage.Players.GetByAuthSubject("test-user");
+        player.ShouldNotBeNull();
+        player.DisplayName.ShouldBe("NameFromToken");
     }
 
     [Test]
     public async Task FallsBackToSubjectWhenNoNicknameOrName()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject("subject-xyz").Returns((Player?)null);
-        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        // No player seeded for "subject-xyz"
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(subject: "subject-xyz"));
 
         var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.PlayersRepository.Received()
-            .Create(Arg.Is<Player>(p => p.AuthSubject == "subject-xyz" && p.DisplayName == "subject-xyz"));
-        _host.TeamsRepository.Received().SetPlayerClaim(1, "subject-xyz");
+        var player = _host.Storage.Players.GetByAuthSubject("subject-xyz");
+        player.ShouldNotBeNull();
+        player.DisplayName.ShouldBe("subject-xyz");
+        _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBe("subject-xyz");
     }
 
     [Test]
     public async Task FallsBackToUnknownWhenNoClaimsPresent()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject(Arg.Any<string>()).Returns((Player?)null);
-        _host.PlayersRepository.Create(Arg.Any<Player>()).Returns(ci => ci.Arg<Player>());
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        // No player seeded; token has null subject
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(subject: null));
 
         var response = await client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.PlayersRepository.Received()
-            .Create(Arg.Is<Player>(p => p.DisplayName == "Unknown"));
+        // Assert via snapshot — subject is null so we can't key into the player store
+        var allPlayers = _host.Storage.Players.All;
+        allPlayers.Count.ShouldBe(1);
+        allPlayers.Single().DisplayName.ShouldBe("Unknown");
     }
 
     [Test]
     public async Task UseExistingPlayerWhenOneAlreadyExists()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject("test-user")
-            .Returns(new Player("test-user", "Existing"));
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        _host.Storage.Players.Seed(new Player("test-user", "Existing"));
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.PlayersRepository.DidNotReceive().Create(Arg.Any<Player>());
-        _host.TeamsRepository.Received().SetPlayerClaim(1, "test-user");
+        // Only the one seeded player — no second player created
+        _host.Storage.Players.All.Count.ShouldBe(1);
+        _host.Storage.Players.All.Single().DisplayName.ShouldBe("Existing");
+        _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBe("test-user");
     }
 
     [Test]
     public async Task Return409WhenTeamClaimedByAnotherUser_OnClaim()
     {
-        _host.TeamsRepository.GetById(1)
-            .Returns(new Team(1, "M1", "T1", "Bob", "other-user"));
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", "Bob", "other-user"));
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
-        _host.PlayersRepository.DidNotReceive().Create(Arg.Any<Player>());
-        _host.TeamsRepository.DidNotReceive().SetPlayerClaim(Arg.Any<int>(), Arg.Any<string?>());
+        _host.Storage.Players.All.ShouldBeEmpty();
+        _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBe("other-user");
         _host.RatingsCalculator.DidNotReceive().CalculateForTeam(Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Test]
     public async Task ClearClaimWhenUnclaimedByOwner()
     {
-        _host.TeamsRepository.GetById(1)
-            .Returns(new Team(1, "M1", "T1", "Alice", "test-user"));
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", "Alice", "test-user"));
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, false, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        _host.TeamsRepository.Received().SetPlayerClaim(1, null);
+        _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBeNull();
     }
 
     [Test]
     public async Task Return403WhenUnclaimingTeamClaimedByAnother()
     {
-        _host.TeamsRepository.GetById(1)
-            .Returns(new Team(1, "M1", "T1", "Bob", "other-user"));
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", "Bob", "other-user"));
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, false, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
-        _host.TeamsRepository.DidNotReceive().SetPlayerClaim(Arg.Any<int>(), Arg.Any<string?>());
+        _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBe("other-user");
         _host.RatingsCalculator.DidNotReceive().CalculateForTeam(Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Test]
     public async Task TriggerRecalculationOnSuccessfulClaim()
     {
-        _host.TeamsRepository.GetById(1).Returns(new Team(1, "M1", "T1", null, null));
-        _host.PlayersRepository.GetByAuthSubject("test-user")
-            .Returns(new Player("test-user", "Alice"));
+        _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
+        _host.Storage.Players.Seed(new Player("test-user", "Alice"));
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
@@ -267,8 +261,7 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task TriggerRecalculationOnSuccessfulUnclaim()
     {
-        _host.TeamsRepository.GetById(1)
-            .Returns(new Team(1, "M2", "T2", "Alice", "test-user"));
+        _host.Storage.Teams.Seed(new Team(1, "M2", "T2", "Alice", "test-user"));
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, false, null));
 

--- a/src/Worms.Hub.Gateway.Tests/TeamsEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/TeamsEndpointShould.cs
@@ -36,8 +36,6 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task ReturnEmptyListWhenNoTeamsExist()
     {
-        // Fake returns empty by default — no arrange needed
-
         var response = await _client.GetAsync(new Uri(TeamsUrl, UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -104,8 +102,6 @@ internal sealed class TeamsEndpointShould
     [Test]
     public async Task Return404WhenTeamDoesNotExist()
     {
-        // Team 999 not seeded — fake returns null for GetById(999)
-
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(999, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -118,7 +114,6 @@ internal sealed class TeamsEndpointShould
     public async Task CreatePlayerAndClaimWhenUnclaimedAndNoPlayerExists_BodyDisplayName()
     {
         _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
-        // No player seeded for "test-user"
 
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, "Body Name"));
 
@@ -133,7 +128,6 @@ internal sealed class TeamsEndpointShould
     public async Task FallsBackToNicknameClaim()
     {
         _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
-        // No player seeded
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(nickname: "NickFromToken"));
 
@@ -149,7 +143,6 @@ internal sealed class TeamsEndpointShould
     public async Task FallsBackToNameClaimWhenNoNickname()
     {
         _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
-        // No player seeded
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(name: "NameFromToken"));
 
@@ -165,7 +158,6 @@ internal sealed class TeamsEndpointShould
     public async Task FallsBackToSubjectWhenNoNicknameOrName()
     {
         _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
-        // No player seeded for "subject-xyz"
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(subject: "subject-xyz"));
 
@@ -182,7 +174,6 @@ internal sealed class TeamsEndpointShould
     public async Task FallsBackToUnknownWhenNoClaimsPresent()
     {
         _host.Storage.Teams.Seed(new Team(1, "M1", "T1", null, null));
-        // No player seeded; token has null subject
 
         using var client = _host.CreateClient(TestJwt.WithAccessRole(subject: null));
 
@@ -204,7 +195,6 @@ internal sealed class TeamsEndpointShould
         var response = await _client.PutAsJsonAsync(TeamsUrl, new ClaimTeamDto(1, true, null));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        // Only the one seeded player — no second player created
         _host.Storage.Players.All.Count.ShouldBe(1);
         _host.Storage.Players.All.Single().DisplayName.ShouldBe("Existing");
         _host.Storage.Teams.GetById(1)!.ClaimedByAuthSubject.ShouldBe("test-user");

--- a/src/Worms.Hub.Gateway.Tests/Worms.Hub.Gateway.Tests.csproj
+++ b/src/Worms.Hub.Gateway.Tests/Worms.Hub.Gateway.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Worms.Hub.Gateway\Worms.Hub.Gateway.csproj"/>
     <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj"/>
+    <ProjectReference Include="..\Worms.Hub.Storage.Fake\Worms.Hub.Storage.Fake.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Worms.Hub.Storage.Fake/FakeGamesRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakeGamesRepository.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using JetBrains.Annotations;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Storage.Fake;
+
+public sealed class FakeGamesRepository : IRepository<Game>
+{
+    private readonly List<Game> _store = [];
+    private int _nextId = 1;
+
+    [PublicAPI]
+    public void Seed(params Game[] games)
+    {
+        ArgumentNullException.ThrowIfNull(games);
+        foreach (var game in games)
+        {
+            _store.Add(game);
+            if (int.TryParse(game.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numericId)
+                && numericId >= _nextId)
+            {
+                _nextId = numericId + 1;
+            }
+        }
+    }
+
+    public IReadOnlyCollection<Game> GetAll() => [.. _store];
+
+    public Game Create(Game item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var newId = _nextId.ToString(CultureInfo.InvariantCulture);
+        _nextId++;
+        var stored = item with { Id = newId };
+        _store.Add(stored);
+        return stored;
+    }
+
+    public void Update(Game item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var index = _store.FindIndex(g => g.Id == item.Id);
+        if (index >= 0)
+        {
+            _store[index] = item;
+        }
+    }
+}

--- a/src/Worms.Hub.Storage.Fake/FakeHubStorage.cs
+++ b/src/Worms.Hub.Storage.Fake/FakeHubStorage.cs
@@ -1,0 +1,20 @@
+using JetBrains.Annotations;
+
+namespace Worms.Hub.Storage.Fake;
+
+[PublicAPI]
+public sealed class FakeHubStorage
+{
+    public FakeGamesRepository Games { get; } = new();
+    public FakeReplaysRepository Replays { get; } = new();
+    public FakeLeaguesRepository Leagues { get; } = new();
+    public FakeRatingsRepository Ratings { get; } = new();
+    public FakePlayersRepository Players { get; }
+    public FakeTeamsRepository Teams { get; }
+
+    public FakeHubStorage()
+    {
+        Players = new FakePlayersRepository();
+        Teams = new FakeTeamsRepository(Players);
+    }
+}

--- a/src/Worms.Hub.Storage.Fake/FakeLeaguesRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakeLeaguesRepository.cs
@@ -1,0 +1,31 @@
+using JetBrains.Annotations;
+using Worms.Hub.Storage.Database;
+
+namespace Worms.Hub.Storage.Fake;
+
+public sealed class FakeLeaguesRepository : ILeaguesRepository
+{
+    private readonly List<LeagueDb> _store = [];
+    private readonly Dictionary<(string Machine, string TeamName), IReadOnlyList<string>> _teamLeagues = [];
+
+    [PublicAPI]
+    public void Seed(params LeagueDb[] leagues)
+    {
+        _store.AddRange(leagues);
+    }
+
+    [PublicAPI]
+    public void Seed(string machine, string teamName, params string[] leagueIds)
+    {
+        _teamLeagues[(machine, teamName)] = leagueIds;
+    }
+
+    public IReadOnlyList<LeagueDb> GetAll() => [.. _store];
+
+    public LeagueDb? GetById(string id) => _store.FirstOrDefault(l => l.Id == id);
+
+    public IReadOnlyList<string> GetLeaguesTeamPlaysIn(string machine, string teamName) =>
+        _teamLeagues.TryGetValue((machine, teamName), out var leagues)
+            ? leagues
+            : [];
+}

--- a/src/Worms.Hub.Storage.Fake/FakePlayersRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakePlayersRepository.cs
@@ -1,0 +1,42 @@
+using JetBrains.Annotations;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Storage.Fake;
+
+public sealed class FakePlayersRepository : IPlayersRepository
+{
+    // Use a list to allow players whose AuthSubject may be null (edge case: token with no sub claim).
+    private readonly List<Player> _store = [];
+
+    [PublicAPI]
+    public void Seed(params Player[] players)
+    {
+        ArgumentNullException.ThrowIfNull(players);
+        _store.AddRange(players);
+    }
+
+    /// <summary>Test-only snapshot of all seeded/created players.</summary>
+    [PublicAPI]
+    public IReadOnlyCollection<Player> All => [.. _store];
+
+    public Player? GetByAuthSubject(string authSubject) =>
+        _store.FirstOrDefault(p => p.AuthSubject == authSubject);
+
+    public Player Create(Player player)
+    {
+        ArgumentNullException.ThrowIfNull(player);
+        // Replace any existing player with the same subject, or append
+        var index = _store.FindIndex(p => p.AuthSubject == player.AuthSubject);
+        if (index >= 0)
+        {
+            _store[index] = player;
+        }
+        else
+        {
+            _store.Add(player);
+        }
+
+        return player;
+    }
+}

--- a/src/Worms.Hub.Storage.Fake/FakePlayersRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakePlayersRepository.cs
@@ -16,7 +16,6 @@ public sealed class FakePlayersRepository : IPlayersRepository
         _store.AddRange(players);
     }
 
-    /// <summary>Test-only snapshot of all seeded/created players.</summary>
     [PublicAPI]
     public IReadOnlyCollection<Player> All => [.. _store];
 
@@ -26,7 +25,6 @@ public sealed class FakePlayersRepository : IPlayersRepository
     public Player Create(Player player)
     {
         ArgumentNullException.ThrowIfNull(player);
-        // Replace any existing player with the same subject, or append
         var index = _store.FindIndex(p => p.AuthSubject == player.AuthSubject);
         if (index >= 0)
         {

--- a/src/Worms.Hub.Storage.Fake/FakeRatingsRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakeRatingsRepository.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Storage.Fake;
+
+public sealed class FakeRatingsRepository : IRatingsRepository
+{
+    private readonly Dictionary<string, List<PlayerRating>> _store = [];
+
+    [PublicAPI]
+    public void Seed(string leagueId, params PlayerRating[] ratings)
+    {
+        _store[leagueId] = [.. ratings];
+    }
+
+    public IReadOnlyList<PlayerRating> GetByLeagueId(string leagueId) =>
+        _store.TryGetValue(leagueId, out var ratings)
+            ? [.. ratings.OrderByDescending(r => r.Rating)] // Mirror real repo's "ORDER BY rating DESC"
+            : [];
+
+    public void ReplaceForLeague(string leagueId, IReadOnlyList<PlayerRating> ratings)
+    {
+        ArgumentNullException.ThrowIfNull(ratings);
+        _store[leagueId] = [.. ratings];
+    }
+}

--- a/src/Worms.Hub.Storage.Fake/FakeReplaysRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakeReplaysRepository.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using JetBrains.Annotations;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Storage.Fake;
+
+public sealed class FakeReplaysRepository : IReplaysRepository
+{
+    private readonly List<Replay> _store = [];
+    private int _nextId = 1;
+
+    [PublicAPI]
+    public void Seed(params Replay[] replays)
+    {
+        ArgumentNullException.ThrowIfNull(replays);
+        foreach (var replay in replays)
+        {
+            _store.Add(replay);
+            if (int.TryParse(replay.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numericId)
+                && numericId >= _nextId)
+            {
+                _nextId = numericId + 1;
+            }
+        }
+    }
+
+    public IReadOnlyCollection<Replay> GetAll() => [.. _store];
+
+    public Replay Create(Replay item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var newId = _nextId.ToString(CultureInfo.InvariantCulture);
+        _nextId++;
+        var stored = item with { Id = newId };
+        _store.Add(stored);
+        return stored;
+    }
+
+    public void Update(Replay item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var index = _store.FindIndex(r => r.Id == item.Id);
+        if (index >= 0)
+        {
+            _store[index] = item;
+        }
+    }
+
+    public IReadOnlyList<Replay> GetByLeagueId(string leagueId) =>
+        // Mirror real repo's "ORDER BY date DESC NULLS LAST": dated replays newest-first, undated last.
+        [.. _store
+            .Where(r => r.LeagueId == leagueId)
+            .OrderByDescending(r => r.Date.HasValue)
+            .ThenByDescending(r => r.Date)];
+}

--- a/src/Worms.Hub.Storage.Fake/FakeTeamsRepository.cs
+++ b/src/Worms.Hub.Storage.Fake/FakeTeamsRepository.cs
@@ -1,0 +1,114 @@
+using JetBrains.Annotations;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Storage.Fake;
+
+public sealed class FakeTeamsRepository : ITeamsRepository
+{
+    private sealed class TeamEntry
+    {
+        public int Id { get; init; }
+        public string Machine { get; init; } = string.Empty;
+        public string TeamName { get; init; } = string.Empty;
+        public string? ClaimedByAuthSubject { get; set; }
+
+        /// <summary>
+        /// Explicitly seeded display name. When set, used verbatim at read time.
+        /// Cleared when <see cref="ClaimedByAuthSubject"/> is updated via
+        /// <see cref="FakeTeamsRepository.SetPlayerClaim"/>, so the name re-resolves from the
+        /// players store after a claim operation.
+        /// </summary>
+        public string? SeededClaimedByPlayerName { get; set; }
+    }
+
+    private readonly FakePlayersRepository _players;
+    private readonly List<TeamEntry> _store = [];
+    private int _nextId = 1;
+
+    public FakeTeamsRepository(FakePlayersRepository players)
+    {
+        ArgumentNullException.ThrowIfNull(players);
+        _players = players;
+    }
+
+    [PublicAPI]
+    public void Seed(params Team[] teams)
+    {
+        ArgumentNullException.ThrowIfNull(teams);
+        foreach (var team in teams)
+        {
+            _store.Add(new TeamEntry
+            {
+                Id = team.Id,
+                Machine = team.Machine,
+                TeamName = team.TeamName,
+                ClaimedByAuthSubject = team.ClaimedByAuthSubject,
+                SeededClaimedByPlayerName = team.ClaimedByPlayerName
+            });
+            if (team.Id >= _nextId)
+            {
+                _nextId = team.Id + 1;
+            }
+        }
+    }
+
+    public IReadOnlyCollection<Team> GetAll() => [.. _store.Select(Project)];
+
+    public Team? GetById(int id) =>
+        _store.FirstOrDefault(t => t.Id == id) is { } entry ? Project(entry) : null;
+
+    public void Upsert(string machine, string teamName)
+    {
+        if (_store.Any(t => t.Machine == machine && t.TeamName == teamName))
+        {
+            return; // ON CONFLICT DO NOTHING
+        }
+
+        _store.Add(new TeamEntry
+        {
+            Id = _nextId++,
+            Machine = machine,
+            TeamName = teamName,
+            ClaimedByAuthSubject = null,
+            SeededClaimedByPlayerName = null
+        });
+    }
+
+    public void SetPlayerClaim(int teamId, string? authSubject)
+    {
+        var entry = _store.FirstOrDefault(t => t.Id == teamId);
+        if (entry is null)
+        {
+            return;
+        }
+
+        entry.ClaimedByAuthSubject = authSubject;
+        // Clear the seeded name so subsequent reads resolve from the players store
+        entry.SeededClaimedByPlayerName = null;
+    }
+
+    private Team Project(TeamEntry entry)
+    {
+        string? claimedByPlayerName;
+        if (entry.SeededClaimedByPlayerName is not null)
+        {
+            claimedByPlayerName = entry.SeededClaimedByPlayerName;
+        }
+        else if (entry.ClaimedByAuthSubject is not null)
+        {
+            claimedByPlayerName = _players.GetByAuthSubject(entry.ClaimedByAuthSubject)?.DisplayName;
+        }
+        else
+        {
+            claimedByPlayerName = null;
+        }
+
+        return new Team(
+            entry.Id,
+            entry.Machine,
+            entry.TeamName,
+            claimedByPlayerName,
+            entry.ClaimedByAuthSubject);
+    }
+}

--- a/src/Worms.Hub.Storage.Fake/ServiceRegistration.cs
+++ b/src/Worms.Hub.Storage.Fake/ServiceRegistration.cs
@@ -1,0 +1,37 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Worms.Hub.Storage.Database;
+using Worms.Hub.Storage.Domain;
+
+namespace Worms.Hub.Storage.Fake;
+
+[PublicAPI]
+public static class ServiceRegistration
+{
+    public static IServiceCollection AddFakeHubStorageServices(this IServiceCollection services)
+    {
+        var fakes = new FakeHubStorage();
+
+        services.RemoveAll<IRepository<Game>>();
+        services.AddSingleton<IRepository<Game>>(_ => fakes.Games);
+
+        services.RemoveAll<IReplaysRepository>();
+        services.AddSingleton<IReplaysRepository>(_ => fakes.Replays);
+
+        services.RemoveAll<ILeaguesRepository>();
+        services.AddSingleton<ILeaguesRepository>(_ => fakes.Leagues);
+
+        services.RemoveAll<IRatingsRepository>();
+        services.AddSingleton<IRatingsRepository>(_ => fakes.Ratings);
+
+        services.RemoveAll<ITeamsRepository>();
+        services.AddSingleton<ITeamsRepository>(_ => fakes.Teams);
+
+        services.RemoveAll<IPlayersRepository>();
+        services.AddSingleton<IPlayersRepository>(_ => fakes.Players);
+
+        services.AddSingleton(fakes);
+        return services;
+    }
+}

--- a/src/Worms.Hub.Storage.Fake/Worms.Hub.Storage.Fake.csproj
+++ b/src/Worms.Hub.Storage.Fake/Worms.Hub.Storage.Fake.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Worms.Hub.Storage\Worms.Hub.Storage.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What

Introduces a new `Worms.Hub.Storage.Fake` project providing in-memory implementations of the Gateway's Storage repository seams, and rewires the Gateway endpoint tests to use them instead of NSubstitute mocks.

Closes #1483.

## Why

The Gateway endpoint tests previously configured six NSubstitute repository mocks per test. Swapping these for in-memory fakes lets tests seed real data structures and assert on the resulting state, producing tests that read more like the behaviour they verify and that exercise repository semantics (ordering, lookup) faithfully.

## Changes

- **`Worms.Hub.Storage.Fake`** — new library with in-memory fakes for Games, Replays, Leagues, Ratings, Players and Teams repositories, a `FakeHubStorage` holder, and an `AddFakeHubStorageServices()` registration extension. Fakes mirror the real repositories' ordering (`Ratings` by rating desc, `Replays` by date desc nulls last) and name-resolution behaviour.
- **`GatewayTestHost`** — registers the fakes via `AddFakeHubStorageServices()` and exposes a typed `Storage` holder, replacing the six mock repository properties. The non-repository collaborators (Announcer, ReplayProcessorQueue, RatingsCalculator) remain NSubstitute mocks.
- **Gateway endpoint/auth tests** — seed data via `_host.Storage.<Repo>.Seed(...)` and assert on fake state instead of mock `.Received()` calls.

## Testing

- 53 Gateway tests pass, 0 failures
- Solution builds clean under `--warnaserror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)