### PR TITLE
Route the Gateway temp-replay folder through IFileSystem in tests

### DIFF
--- a/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
+++ b/src/Worms.Hub.Gateway.Tests/GatewayTestHost.cs
@@ -16,9 +16,6 @@ namespace Worms.Hub.Gateway.Tests;
 
 internal sealed class GatewayTestHost : WebApplicationFactory<Program>
 {
-    private readonly string _tempReplayFolder =
-        Path.Combine(Path.GetTempPath(), "worms-gateway-tests", Guid.NewGuid().ToString("N"));
-
     internal IAnnouncer Announcer { get; } = Substitute.For<IAnnouncer>();
 
     internal IMessageQueue<ReplayToProcessMessage> ReplayProcessorQueue { get; } =
@@ -39,6 +36,9 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
     internal string GameFolder { get; } =
         Path.Combine(Path.GetTempPath(), "worms-gateway-tests-game", Guid.NewGuid().ToString("N"));
 
+    internal string TempReplayFolder { get; } =
+        Path.Combine(Path.GetTempPath(), "worms-gateway-tests-replays", Guid.NewGuid().ToString("N"));
+
     public GatewayTestHost()
     {
         // Boot only the gateway (not the worker) so no hosted services are started
@@ -46,7 +46,8 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("WORMS_HUB_DISTRIBUTED", "true");
         Environment.SetEnvironmentVariable("WORMS_HUB_GATEWAY", "true");
         Environment.SetEnvironmentVariable("WORMS_HUB_WORKER", null);
-        Environment.SetEnvironmentVariable("WORMS_STORAGE__TEMPREPLAYFOLDER", _tempReplayFolder);
+        FileSystem.AddDirectory(TempReplayFolder);
+        Environment.SetEnvironmentVariable("WORMS_STORAGE__TEMPREPLAYFOLDER", TempReplayFolder);
         FileSystem.AddDirectory(SchemesFolder);
         Environment.SetEnvironmentVariable("WORMS_STORAGE__SCHEMESFOLDER", SchemesFolder);
         FileSystem.AddDirectory(CliFolder);
@@ -123,21 +124,8 @@ internal sealed class GatewayTestHost : WebApplicationFactory<Program>
             Environment.SetEnvironmentVariable("WORMS_STORAGE__SCHEMESFOLDER", null);
             Environment.SetEnvironmentVariable("WORMS_STORAGE__CLIFOLDER", null);
             Environment.SetEnvironmentVariable("WORMS_STORAGE__GAMEFOLDER", null);
-            TryDeleteFolder(_tempReplayFolder);
         }
 
         base.Dispose(disposing);
-    }
-
-    private static void TryDeleteFolder(string path)
-    {
-        try
-        {
-            if (Directory.Exists(path))
-            {
-                Directory.Delete(path, recursive: true);
-            }
-        }
-        catch (Exception e) when (e is IOException or UnauthorizedAccessException) { /* best-effort cleanup */ }
     }
 }

--- a/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
+++ b/src/Worms.Hub.Gateway.Tests/ReplaysEndpointShould.cs
@@ -64,6 +64,10 @@ internal sealed class ReplaysEndpointShould
 
         await _host.ReplayProcessorQueue.Received(1).EnqueueMessage(
             Arg.Is<ReplayToProcessMessage>(m => m.ReplayFileName == stored.Filename));
+
+        var savedBytes = await _host.FileSystem.File.ReadAllBytesAsync(
+            Path.Combine(_host.TempReplayFolder, stored.Filename));
+        savedBytes.ShouldBe(ValidReplayBytes);
     }
 
     [Test]

--- a/src/Worms.Hub.Gateway/Worker/Processor.cs
+++ b/src/Worms.Hub.Gateway/Worker/Processor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
 using Worms.Armageddon.Files.Replays.Text;
 using Worms.Hub.Gateway.Announcers;
 using Worms.Hub.Gateway.Ratings;
@@ -15,6 +16,7 @@ internal sealed class Processor(
     IReplaysRepository replayRepository,
     ITeamsRepository teamsRepository,
     ReplayFiles replayFiles,
+    IFileSystem fileSystem,
     IAnnouncer announcer,
     IReplayTextReader replayTextReader,
     IRatingsCalculator ratingsCalculator,
@@ -40,7 +42,7 @@ internal sealed class Processor(
 
         // Check replay is in the folder
         var replayPath = replayFiles.GetReplayPath(message.ReplayFileName);
-        if (!File.Exists(replayPath))
+        if (!fileSystem.File.Exists(replayPath))
         {
             logger.LogError("Replay not found on disk: {ReplayPath}", replayPath);
             return;
@@ -48,7 +50,7 @@ internal sealed class Processor(
 
         // Check replay has a log file generated
         var logPath = replayFiles.GetLogPath(message.ReplayFileName);
-        if (!File.Exists(logPath))
+        if (!fileSystem.File.Exists(logPath))
         {
             logger.LogError("Log file not found: {LogPath}", logPath);
             return;
@@ -62,7 +64,7 @@ internal sealed class Processor(
             return;
         }
 
-        var replayLog = await File.ReadAllTextAsync(logPath);
+        var replayLog = await fileSystem.File.ReadAllTextAsync(logPath);
 
         // Parse the replay log
         var replayModel = replayTextReader.GetModel(replayLog);

--- a/src/Worms.Hub.Storage/Files/ReplayFiles.cs
+++ b/src/Worms.Hub.Storage/Files/ReplayFiles.cs
@@ -1,8 +1,9 @@
+using System.IO.Abstractions;
 using Microsoft.Extensions.Configuration;
 
 namespace Worms.Hub.Storage.Files;
 
-public class ReplayFiles(IConfiguration configuration)
+public class ReplayFiles(IConfiguration configuration, IFileSystem fileSystem)
 {
     public string GetReplayPath(string replayFileName)
     {
@@ -18,7 +19,7 @@ public class ReplayFiles(IConfiguration configuration)
             : replayFileName;
 
         var logPath = Path.Combine(GetReplayFolderPath(), $"{fileName}.log");
-        return File.Exists(logPath) ? logPath : null;
+        return fileSystem.File.Exists(logPath) ? logPath : null;
     }
 
     public async Task<string> SaveFileContents(Stream fileContentsStream)
@@ -28,14 +29,14 @@ public class ReplayFiles(IConfiguration configuration)
         var generatedFileName = Path.GetRandomFileName();
         var tempReplayFolderPath = GetReplayFolderPath();
 
-        if (!Path.Exists(tempReplayFolderPath))
+        if (!fileSystem.Directory.Exists(tempReplayFolderPath))
         {
-            _ = Directory.CreateDirectory(tempReplayFolderPath);
+            _ = fileSystem.Directory.CreateDirectory(tempReplayFolderPath);
         }
 
         var saveFilePath = Path.Combine(tempReplayFolderPath, generatedFileName);
 
-        var fileStream = File.Create(saveFilePath);
+        var fileStream = fileSystem.File.Create(saveFilePath);
         await using var stream = fileStream;
         await fileContentsStream.CopyToAsync(fileStream);
         await fileStream.DisposeAsync();


### PR DESCRIPTION
## Summary
- Switch `ReplayFiles` and `Worker/Processor` off direct `System.IO` statics (`File.Exists`/`Path.Exists`/`Directory.CreateDirectory`/`File.Create`/`ReadAllTextAsync`) onto the injected `IFileSystem`, matching the `CliFiles`/`SchemeFiles`/`GameFiles` seam from #1374.
- Register the temp replay folder with `GatewayTestHost`'s `MockFileSystem` instead of a real `Path.GetTempPath()` directory, and drop the now-unused `TryDeleteFolder`/`Dispose` real-disk cleanup so the host no longer touches real disk at all.
- Assert uploaded replay bytes land in `MockFileSystem` in `ReplaysEndpointShould`.

Pure seam migration — no behaviour change.

Closes #1496

## Test plan
- [x] `dotnet build` on `Worms.Hub.Storage`, `Worms.Hub.Gateway`, `Worms.Hub.Gateway.Tests` — clean, 0 warnings
- [x] `dotnet test src/Worms.Hub.Gateway.Tests --filter "Category!=Integration"` — 78/78 passed
- [x] `dotnet build Worms.sln` + `dotnet jb inspectcode` — 0 InspectCode results
- [x] `/code-review high --fix` — no findings
- [x] Spec review against issue acceptance criteria — pass