### PR TITLE
Group related packages in Renovate config to prevent version-mismatch failures

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,37 @@
         "@types/react",
         "@types/react-dom"
       ]
+    },
+    {
+      "groupName": "MUI",
+      "matchPackageNames": [
+        "@mui/material",
+        "@mui/icons-material"
+      ]
+    },
+    {
+      "groupName": "Emotion",
+      "matchPackageNames": [
+        "@emotion/react",
+        "@emotion/styled"
+      ]
+    },
+    {
+      "groupName": "ESLint",
+      "matchPackageNames": [
+        "eslint",
+        "@eslint/js",
+        "eslint-plugin-react-hooks",
+        "eslint-plugin-react-refresh",
+        "typescript-eslint"
+      ]
+    },
+    {
+      "groupName": "Testing Library",
+      "matchPackageNames": [
+        "@testing-library/jest-dom",
+        "@testing-library/react"
+      ]
     }
   ],
   "dependencyDashboard": true

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,13 @@
       ]
     },
     {
+      "extends": [
+        "monorepo:opentelemetry-dotnet",
+        "monorepo:opentelemetry-dotnet-contrib"
+      ],
+      "groupName": "OpenTelemetry"
+    },
+    {
       "groupName": "Worms Hub - Docker Images",
       "matchPackageNames": [
         "theeadie/worms-hub-gateway",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,7 +29,8 @@
         "System.IO.Abstractions",
         "System.IO.Abstractions.TestingHelpers",
         "TestableIO.System.IO.Abstractions",
-        "TestableIO.System.IO.Abstractions.TestingHelpers"
+        "TestableIO.System.IO.Abstractions.TestingHelpers",
+        "TestableIO.System.IO.Abstractions.Wrappers"
       ]
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,15 @@
         "theeadie/worms-hub-gateway",
         "theeadie/worms-hub-wa-runner"
       ]
+    },
+    {
+      "groupName": "React",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
     }
   ],
   "dependencyDashboard": true


### PR DESCRIPTION
## Summary
- npm install was failing when `react` and `react-dom` were bumped to mismatched versions by separate Renovate PRs (see [failing run](https://github.com/TheEadie/WormsLeague/actions/runs/29852138041/job/88707414588?pr=1539)) — group them and their `@types` packages together.
- Extend the same lockstep grouping to other npm packages with matching-version requirements or overlapping bump cadence: MUI (`@mui/material`/`@mui/icons-material`, must match versions), Emotion, ESLint + its plugins, and Testing Library.
- Fix the existing `System.IO.Abstractions` NuGet group, which was missing `TestableIO.System.IO.Abstractions.Wrappers` (used by `Worms.Armageddon.Files`) and so could drift out of sync with the rest of the group.
- Add a NuGet group for OpenTelemetry — its packages span two upstream repos (core `opentelemetry-dotnet` and `opentelemetry-dotnet-contrib`), so updates were landing as separate PRs even though they should bump together.

## Test plan
- [x] Validated `.github/renovate.json` is well-formed JSON
- [ ] Confirm Renovate picks up the new groups on its next run (dependency dashboard / next PRs)